### PR TITLE
Protect trunk files from accidental edits (CODEOWNERS + CI guard)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# Trunk files: every PR that touches these must be reviewed by the owner.
+# Pair with branch protection on `main` requiring CODEOWNERS review.
+
+/src\ 2/QueryEngine.ts  @gagan114662
+/src\ 2/Task.ts         @gagan114662
+/src\ 2/Tool.ts         @gagan114662
+/src\ 2/query.ts        @gagan114662
+/src\ 2/context.ts      @gagan114662
+/src\ 2/tools.ts        @gagan114662
+/src\ 2/commands.ts     @gagan114662
+/src\ 2/entrypoints/    @gagan114662
+/src\ 2/query/          @gagan114662
+/src\ 2/context/        @gagan114662
+/src\ 2/state/          @gagan114662
+/src\ 2/hooks/          @gagan114662
+/src\ 2/migrations/     @gagan114662
+/src\ 2/schemas/        @gagan114662
+/src\ 2/types/          @gagan114662
+
+/.github/CODEOWNERS              @gagan114662
+/.github/workflows/trunk-guard.yml @gagan114662

--- a/.github/workflows/trunk-guard.yml
+++ b/.github/workflows/trunk-guard.yml
@@ -1,0 +1,62 @@
+name: trunk-guard
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  block-trunk-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect trunk file changes
+        id: detect
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          git diff --name-only "$BASE" "$HEAD" > /tmp/changed.txt
+          echo "Changed files:"
+          cat /tmp/changed.txt
+
+          PATTERNS='^src 2/QueryEngine\.ts$
+          ^src 2/Task\.ts$
+          ^src 2/Tool\.ts$
+          ^src 2/query\.ts$
+          ^src 2/context\.ts$
+          ^src 2/tools\.ts$
+          ^src 2/commands\.ts$
+          ^src 2/entrypoints/
+          ^src 2/query/
+          ^src 2/context/
+          ^src 2/state/
+          ^src 2/hooks/
+          ^src 2/migrations/
+          ^src 2/schemas/
+          ^src 2/types/'
+
+          HITS=$(grep -Ef <(echo "$PATTERNS") /tmp/changed.txt || true)
+          if [ -n "$HITS" ]; then
+            echo "trunk_hits<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$HITS" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for override label
+        id: label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            core.setOutput('approved', labels.includes('trunk-change-approved'));
+
+      - name: Fail if trunk touched without approval
+        if: steps.detect.outputs.trunk_hits != '' && steps.label.outputs.approved != 'true'
+        run: |
+          echo "::error::This PR modifies trunk files. Apply label 'trunk-change-approved' to allow."
+          echo "Trunk files changed:"
+          echo "${{ steps.detect.outputs.trunk_hits }}"
+          exit 1


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` declaring ownership of architectural/trunk files in `src 2/` (QueryEngine, Task, Tool, query, context, tools, commands, entrypoints, state, hooks, migrations, schemas, types).
- Add `.github/workflows/trunk-guard.yml` — a PR CI check that fails any PR touching trunk paths unless the `trunk-change-approved` label is deliberately applied.
- Pairs with local `chmod a-w` on trunk files and branch protection on `main` (PRs required, force-push/deletion blocked, admin enforcement on) to make accidental trunk edits impossible for both Claude and the author.

## Test plan
- [ ] This PR itself runs `trunk-guard` and passes (no trunk paths modified).
- [ ] After merge, open a test PR that touches `src 2/QueryEngine.ts` and confirm `block-trunk-changes` fails.
- [ ] Add the `trunk-change-approved` label and confirm the check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)