### PR TITLE
chore: retrigger trunk-guard on label changes

### DIFF
--- a/.github/workflows/trunk-guard.yml
+++ b/.github/workflows/trunk-guard.yml
@@ -3,6 +3,7 @@ name: trunk-guard
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   block-trunk-changes:


### PR DESCRIPTION
Adds `labeled`/`unlabeled` to the trunk-guard `pull_request` triggers so label-based approvals re-run the check. (Missed from PR #1 squash.)