### PR TITLE
feat(kairos): add PushNotificationTool

### DIFF
--- a/src 2/tools/PushNotificationTool/PushNotificationTool.test.ts
+++ b/src 2/tools/PushNotificationTool/PushNotificationTool.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import { getPushNotificationSettings, sendPushNotification } from './transport.js'
+
+const ORIGINAL_FETCH = globalThis.fetch
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  delete process.env.CLAUDE_CONFIG_DIR
+  resetSettingsCache()
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeSettingsDir(settings: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'push-notification-test-'))
+  TEMP_DIRS.push(dir)
+  writeFileSync(join(dir, 'settings.json'), JSON.stringify(settings))
+  return dir
+}
+
+describe('PushNotification transport', () => {
+  test('sends ntfy notification on happy path', async () => {
+    const dir = makeSettingsDir({
+      pushNotification: {
+        provider: 'ntfy',
+        ntfyTopic: 'kairos-gagan-test',
+      },
+    })
+    process.env.CLAUDE_CONFIG_DIR = dir
+
+    const fetcher = mock(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        expect(String(url)).toBe('https://ntfy.sh/')
+        expect(init?.method).toBe('POST')
+        expect(init?.headers).toEqual({
+          'Content-Type': 'application/json',
+        })
+        expect(JSON.parse(String(init?.body))).toEqual({
+          topic: 'kairos-gagan-test',
+          title: 'hello',
+          message: 'this is a test from the new tool',
+          priority: 4,
+          tags: ['🚨'],
+        })
+        return new Response('', { status: 200 })
+      },
+    )
+
+    const result = await sendPushNotification(
+      {
+        title: 'hello',
+        body: 'this is a test from the new tool',
+        priority: 'high',
+        tag: '🚨',
+      },
+      fetcher,
+    )
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      provider: 'ntfy',
+      target: 'kairos-gagan-test',
+    })
+  })
+
+  test('throws a clear error when settings are missing', () => {
+    const dir = makeSettingsDir({})
+    process.env.CLAUDE_CONFIG_DIR = dir
+
+    expect(() => getPushNotificationSettings()).toThrow(
+      'Push notifications are not configured. Set `pushNotification.provider` to `"ntfy"` or `"pushover"` in your settings.',
+    )
+  })
+
+  test('surfaces upstream http failures', async () => {
+    const dir = makeSettingsDir({
+      pushNotification: {
+        provider: 'ntfy',
+        ntfyTopic: 'kairos-gagan-test',
+      },
+    })
+    process.env.CLAUDE_CONFIG_DIR = dir
+
+    const fetcher = mock(
+      async () =>
+        new Response('boom', {
+          status: 503,
+          statusText: 'Service Unavailable',
+        }),
+    )
+
+    expect(
+      sendPushNotification(
+        {
+          title: 'hello',
+          body: 'this is a test from the new tool',
+          priority: 'normal',
+        },
+        fetcher,
+      ),
+    ).rejects.toThrow(
+      'ntfy delivery failed (503 Service Unavailable): boom',
+    )
+  })
+})

--- a/src 2/tools/PushNotificationTool/PushNotificationTool.ts
+++ b/src 2/tools/PushNotificationTool/PushNotificationTool.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod/v4'
+import { buildTool, type ToolDef } from '../../Tool.js'
+import { lazySchema } from '../../utils/lazySchema.js'
+import {
+  type PushNotificationPriority,
+  sendPushNotification,
+} from './transport.js'
+import {
+  DESCRIPTION,
+  PUSH_NOTIFICATION_TOOL_NAME,
+  PUSH_NOTIFICATION_TOOL_PROMPT,
+} from './prompt.js'
+
+const inputSchema = lazySchema(() =>
+  z.strictObject({
+    title: z.string().describe('Short notification title shown to the user'),
+    body: z.string().describe('Notification body text'),
+    priority: z
+      .enum(['low', 'normal', 'high'])
+      .optional()
+      .describe('Optional delivery priority. Defaults to normal.'),
+    tag: z
+      .string()
+      .optional()
+      .describe('Optional emoji or short tag shown with the notification'),
+  }),
+)
+type InputSchema = ReturnType<typeof inputSchema>
+
+const outputSchema = lazySchema(() =>
+  z.object({
+    success: z.boolean(),
+    provider: z.enum(['ntfy', 'pushover']).optional(),
+    target: z.string().optional(),
+    title: z.string(),
+    body: z.string(),
+    priority: z.enum(['low', 'normal', 'high']),
+    tag: z.string().optional(),
+    deliveredAt: z.string().optional(),
+    error: z.string().optional(),
+  }),
+)
+type OutputSchema = ReturnType<typeof outputSchema>
+export type Output = z.infer<OutputSchema>
+
+function formatUseMessage(input: {
+  title?: string
+  priority?: PushNotificationPriority
+}): string {
+  const title = input.title ? ` "${input.title}"` : ''
+  const priority =
+    input.priority && input.priority !== 'normal'
+      ? ` (${input.priority} priority)`
+      : ''
+  return `Sending push notification${title}${priority}`
+}
+
+export const PushNotificationTool = buildTool({
+  name: PUSH_NOTIFICATION_TOOL_NAME,
+  searchHint: 'send a real push notification to the user',
+  maxResultSizeChars: 20_000,
+  async description() {
+    return DESCRIPTION
+  },
+  async prompt() {
+    return PUSH_NOTIFICATION_TOOL_PROMPT
+  },
+  get inputSchema(): InputSchema {
+    return inputSchema()
+  },
+  get outputSchema(): OutputSchema {
+    return outputSchema()
+  },
+  isConcurrencySafe() {
+    return true
+  },
+  toAutoClassifierInput(input) {
+    return `${input.title}\n${input.body}`
+  },
+  renderToolUseMessage(input) {
+    return formatUseMessage(input)
+  },
+  mapToolResultToToolResultBlockParam(output, toolUseID) {
+    if (!output.success) {
+      return {
+        tool_use_id: toolUseID,
+        type: 'tool_result',
+        content: output.error || 'Push notification failed.',
+      }
+    }
+    return {
+      tool_use_id: toolUseID,
+      type: 'tool_result',
+      content: `Push notification sent via ${output.provider} to ${output.target}.`,
+    }
+  },
+  async call({ title, body, priority = 'normal', tag }) {
+    try {
+      const delivery = await sendPushNotification({
+        title,
+        body,
+        priority,
+        tag,
+      })
+      return {
+        data: {
+          success: true,
+          provider: delivery.provider,
+          target: delivery.target,
+          title,
+          body,
+          priority,
+          tag,
+          deliveredAt: new Date().toISOString(),
+        },
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Push notification failed.'
+      return {
+        data: {
+          success: false,
+          title,
+          body,
+          priority,
+          tag,
+          error: message,
+        },
+      }
+    }
+  },
+} satisfies ToolDef<InputSchema, Output>)

--- a/src 2/tools/PushNotificationTool/prompt.ts
+++ b/src 2/tools/PushNotificationTool/prompt.ts
@@ -1,0 +1,8 @@
+export const PUSH_NOTIFICATION_TOOL_NAME = 'PushNotification'
+
+export const DESCRIPTION =
+  'Send a push notification to the user via ntfy or Pushover'
+
+export const PUSH_NOTIFICATION_TOOL_PROMPT = `Send a real push notification to the user when something should interrupt them outside the terminal.
+
+Use \`title\` for the short heading and \`body\` for the actual message. \`priority\` defaults to \`normal\`. \`tag\` is optional and can be an emoji or short label.`

--- a/src 2/tools/PushNotificationTool/transport.ts
+++ b/src 2/tools/PushNotificationTool/transport.ts
@@ -1,0 +1,193 @@
+import { getSettings_DEPRECATED } from '../../utils/settings/settings.js'
+
+export type PushNotificationProvider = 'ntfy' | 'pushover'
+export type PushNotificationPriority = 'low' | 'normal' | 'high'
+
+export type PushNotificationSettings = {
+  provider: PushNotificationProvider
+  ntfyTopic?: string
+  pushoverUserKey?: string
+  pushoverAppToken?: string
+}
+
+export type PushNotificationInput = {
+  title: string
+  body: string
+  priority: PushNotificationPriority
+  tag?: string
+}
+
+export type PushNotificationDelivery = {
+  provider: PushNotificationProvider
+  target: string
+}
+
+export type FetchLike = typeof fetch
+
+export class PushNotificationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PushNotificationError'
+  }
+}
+
+function getSettings(): { pushNotification?: PushNotificationSettings } {
+  return (getSettings_DEPRECATED() || {}) as {
+    pushNotification?: PushNotificationSettings
+  }
+}
+
+export function getPushNotificationSettings(): PushNotificationSettings {
+  const settings = getSettings().pushNotification
+  if (!settings?.provider) {
+    throw new PushNotificationError(
+      'Push notifications are not configured. Set `pushNotification.provider` to `"ntfy"` or `"pushover"` in your settings.',
+    )
+  }
+  if (settings.provider === 'ntfy' && !settings.ntfyTopic) {
+    throw new PushNotificationError(
+      'Push notifications are not configured for ntfy. Set `pushNotification.ntfyTopic` in your settings.',
+    )
+  }
+  if (
+    settings.provider === 'pushover' &&
+    (!settings.pushoverUserKey || !settings.pushoverAppToken)
+  ) {
+    throw new PushNotificationError(
+      'Push notifications are not configured for Pushover. Set `pushNotification.pushoverUserKey` and `pushNotification.pushoverAppToken` in your settings.',
+    )
+  }
+  return settings
+}
+
+function ntfyPriority(priority: PushNotificationPriority): string {
+  switch (priority) {
+    case 'low':
+      return '2'
+    case 'high':
+      return '4'
+    case 'normal':
+    default:
+      return '3'
+  }
+}
+
+function ntfyPriorityNumber(priority: PushNotificationPriority): number {
+  switch (priority) {
+    case 'low':
+      return 2
+    case 'high':
+      return 4
+    case 'normal':
+    default:
+      return 3
+  }
+}
+
+function pushoverPriority(priority: PushNotificationPriority): string {
+  switch (priority) {
+    case 'low':
+      return '-1'
+    case 'high':
+      return '1'
+    case 'normal':
+    default:
+      return '0'
+  }
+}
+
+async function sendNtfyNotification(
+  input: PushNotificationInput,
+  settings: PushNotificationSettings & { provider: 'ntfy'; ntfyTopic: string },
+  fetcher: FetchLike,
+): Promise<PushNotificationDelivery> {
+  const response = await fetcher('https://ntfy.sh/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      topic: settings.ntfyTopic,
+      title: input.title,
+      message: input.body,
+      priority: ntfyPriorityNumber(input.priority),
+      ...(input.tag ? { tags: [input.tag] } : {}),
+    }),
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new PushNotificationError(
+      `ntfy delivery failed (${response.status} ${response.statusText}): ${body || 'empty response body'}`,
+    )
+  }
+
+  return {
+    provider: 'ntfy',
+    target: settings.ntfyTopic,
+  }
+}
+
+async function sendPushoverNotification(
+  input: PushNotificationInput,
+  settings: PushNotificationSettings & {
+    provider: 'pushover'
+    pushoverUserKey: string
+    pushoverAppToken: string
+  },
+  fetcher: FetchLike,
+): Promise<PushNotificationDelivery> {
+  const params = new URLSearchParams({
+    token: settings.pushoverAppToken,
+    user: settings.pushoverUserKey,
+    title: input.tag ? `${input.tag} ${input.title}` : input.title,
+    message: input.body,
+    priority: pushoverPriority(input.priority),
+  })
+
+  const response = await fetcher('https://api.pushover.net/1/messages.json', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params,
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new PushNotificationError(
+      `Pushover delivery failed (${response.status} ${response.statusText}): ${body || 'empty response body'}`,
+    )
+  }
+
+  return {
+    provider: 'pushover',
+    target: settings.pushoverUserKey,
+  }
+}
+
+export async function sendPushNotification(
+  input: PushNotificationInput,
+  fetcher: FetchLike = fetch,
+): Promise<PushNotificationDelivery> {
+  const settings = getPushNotificationSettings()
+  if (settings.provider === 'ntfy') {
+    return sendNtfyNotification(
+      input,
+      settings as PushNotificationSettings & {
+        provider: 'ntfy'
+        ntfyTopic: string
+      },
+      fetcher,
+    )
+  }
+  return sendPushoverNotification(
+    input,
+    settings as PushNotificationSettings & {
+      provider: 'pushover'
+      pushoverUserKey: string
+      pushoverAppToken: string
+    },
+    fetcher,
+  )
+}


### PR DESCRIPTION
## Summary
Adds the leaf-scoped `PushNotificationTool` implementation under `src 2/tools/PushNotificationTool/`.

This fills the pre-existing `tools.ts` require path without touching trunk files.

Closes #4.

## What changed
- added `PushNotificationTool.ts`
- added `transport.ts`
- added `prompt.ts`
- added `PushNotificationTool.test.ts`
- supports `ntfy` and `pushover` config from merged settings
- uses ntfy JSON publish API so emoji tags work without invalid header encoding
- returns clear tool results on missing config / upstream failure

## Verification
- `bun test tools/PushNotificationTool/PushNotificationTool.test.ts`
- `bun run typecheck`
- `bun run lint`
- targeted eslint on the new tool files
- live ntfy send verified against topic `xAagK5QUYrKlEQMw`
- live high-priority + emoji tag send verified
- missing-config path verified: tool returns a readable `not configured` error instead of crashing

## Notes
- This PR is leaf-only and does not touch trunk-guarded files.
- Exposure still depends on a KAIROS-enabled build, but merging this is safe because the tool remains behind the existing feature gate in `tools.ts`.
