### PR TITLE
feat(kairos): add send user file tool

### DIFF
--- a/src 2/tools/SendUserFileTool/SendUserFileTool.test.ts
+++ b/src 2/tools/SendUserFileTool/SendUserFileTool.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import { SendUserFileTool } from './SendUserFileTool.js'
+import {
+  MAX_SEND_USER_FILE_BYTES,
+  getUniqueOutputPath,
+  sendUserFile,
+} from './delivery.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  resetSettingsCache()
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function makeSettingsDir(settings: unknown): string {
+  const dir = makeTempDir('send-user-file-settings-')
+  writeFileSync(join(dir, 'settings.json'), JSON.stringify(settings))
+  return dir
+}
+
+describe('SendUserFile delivery', () => {
+  test('writes a text file and reveals + opens it', async () => {
+    const outputDir = makeTempDir('send-user-file-output-')
+    process.env.CLAUDE_CONFIG_DIR = makeSettingsDir({
+      sendUserFile: {
+        outputDir,
+      },
+    })
+
+    const execImpl = mock(async () => ({
+      stdout: '',
+      stderr: '',
+      code: 0,
+    }))
+    const openImpl = mock(async () => true)
+
+    const result = await sendUserFile(
+      {
+        filename: 'greeting.md',
+        content: '# Hello Gagan\n\nIt works!',
+      },
+      {
+        platform: 'macos',
+        execFileNoThrow: execImpl,
+        openPath: openImpl,
+      },
+    )
+
+    expect(result.displayPath).toBe(result.path)
+    expect(result.path).toBe(join(outputDir, 'greeting.md'))
+    expect(readFileSync(result.path, 'utf8')).toBe('# Hello Gagan\n\nIt works!')
+    expect(execImpl).toHaveBeenCalledWith(
+      'open',
+      ['-R', join(outputDir, 'greeting.md')],
+      { useCwd: false },
+    )
+    expect(openImpl).toHaveBeenCalledWith(join(outputDir, 'greeting.md'))
+  })
+
+  test('adds numeric suffixes instead of overwriting', async () => {
+    const outputDir = makeTempDir('send-user-file-overwrite-')
+    writeFileSync(join(outputDir, 'greeting.md'), 'first')
+    writeFileSync(join(outputDir, 'greeting-2.md'), 'second')
+
+    const candidate = await getUniqueOutputPath(outputDir, 'greeting.md')
+
+    expect(candidate).toBe(join(outputDir, 'greeting-3.md'))
+  })
+
+  test('rejects traversal filenames with a clear error', async () => {
+    process.env.CLAUDE_CONFIG_DIR = makeSettingsDir({})
+
+    const result = await SendUserFileTool.call({
+      filename: '../../etc/hosts',
+      content: 'bad',
+      openAfter: false,
+    })
+
+    expect(result.data).toEqual({
+      success: false,
+      filename: '../../etc/hosts',
+      mimeType: 'text/plain',
+      isBase64: false,
+      openAfter: false,
+      message: 'Filename must be a bare name like `report.md`, not a path.',
+      error: 'Filename must be a bare name like `report.md`, not a path.',
+    })
+  })
+
+  test('writes binary files from base64 content', async () => {
+    const outputDir = makeTempDir('send-user-file-binary-')
+    process.env.CLAUDE_CONFIG_DIR = makeSettingsDir({
+      sendUserFile: {
+        outputDir,
+      },
+    })
+
+    const pngBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII='
+
+    const result = await sendUserFile(
+      {
+        filename: 'test.png',
+        content: pngBase64,
+        isBase64: true,
+        openAfter: false,
+      },
+      {
+        execFileNoThrow: async () => ({
+          stdout: '',
+          stderr: '',
+          code: 0,
+        }),
+      },
+    )
+
+    expect(result.bytesWritten).toBe(Buffer.from(pngBase64, 'base64').length)
+    expect(readFileSync(result.path).toString('base64')).toBe(pngBase64)
+  })
+
+  test('rejects files larger than 10 MB', async () => {
+    process.env.CLAUDE_CONFIG_DIR = makeSettingsDir({})
+
+    const oversized = 'a'.repeat(MAX_SEND_USER_FILE_BYTES + 1)
+    const result = await SendUserFileTool.call({
+      filename: 'huge.txt',
+      content: oversized,
+      openAfter: false,
+    })
+
+    expect(result.data.success).toBe(false)
+    expect(result.data.error).toContain('10 MB limit')
+  })
+})

--- a/src 2/tools/SendUserFileTool/SendUserFileTool.ts
+++ b/src 2/tools/SendUserFileTool/SendUserFileTool.ts
@@ -1,0 +1,192 @@
+import { z } from 'zod/v4'
+import type { ValidationResult } from '../../Tool.js'
+import { buildTool, type ToolDef } from '../../Tool.js'
+import { lazySchema } from '../../utils/lazySchema.js'
+import {
+  type SendUserFileInput,
+  decodeSendUserFileContent,
+  sendUserFile,
+  validateSendUserFilename,
+} from './delivery.js'
+import {
+  DESCRIPTION,
+  SEND_USER_FILE_TOOL_NAME,
+  SEND_USER_FILE_TOOL_PROMPT,
+} from './prompt.js'
+
+const DEFAULT_MIME_TYPE = 'text/plain'
+
+const inputSchema = lazySchema(() =>
+  z.strictObject({
+    filename: z
+      .string()
+      .describe('Bare filename like `report.md` or `image.png`, not a path'),
+    content: z
+      .string()
+      .describe('Full file contents as text, or base64 when `isBase64` is true'),
+    mimeType: z
+      .string()
+      .optional()
+      .describe('Optional MIME type metadata. Defaults to text/plain.'),
+    isBase64: z
+      .boolean()
+      .optional()
+      .describe('Set true when `content` is base64-encoded binary data.'),
+    openAfter: z
+      .boolean()
+      .optional()
+      .describe('Defaults to true. Opens the written file in the default app.'),
+  }),
+)
+type InputSchema = ReturnType<typeof inputSchema>
+
+const outputSchema = lazySchema(() =>
+  z.object({
+    success: z.boolean(),
+    filename: z.string(),
+    path: z.string().optional(),
+    displayPath: z.string().optional(),
+    mimeType: z.string(),
+    isBase64: z.boolean(),
+    openAfter: z.boolean(),
+    opened: z.boolean().optional(),
+    revealed: z.boolean().optional(),
+    bytesWritten: z.number().optional(),
+    message: z.string(),
+    sentAt: z.string().optional(),
+    error: z.string().optional(),
+  }),
+)
+type OutputSchema = ReturnType<typeof outputSchema>
+export type Output = z.infer<OutputSchema>
+
+function formatUseMessage(input: { filename?: string }): string {
+  return input.filename
+    ? `Sending file "${input.filename}"`
+    : 'Sending file to the user'
+}
+
+function formatSuccessMessage({
+  displayPath,
+  openAfter,
+  opened,
+  revealed,
+}: {
+  displayPath: string
+  openAfter: boolean
+  opened: boolean
+  revealed: boolean
+}): string {
+  const warnings: string[] = []
+  if (!revealed) {
+    warnings.push('could not reveal it automatically')
+  }
+  if (openAfter && !opened) {
+    warnings.push('could not open it automatically')
+  }
+  if (warnings.length === 0) {
+    return `📁 Sent file: ${displayPath}`
+  }
+  return `📁 Sent file: ${displayPath} (${warnings.join('; ')})`
+}
+
+function validateInputOrError(input: SendUserFileInput): ValidationResult {
+  try {
+    validateSendUserFilename(input.filename)
+    decodeSendUserFileContent(input.content, input.isBase64 ?? false)
+    return { result: true }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Invalid file delivery request.'
+    return { result: false, message, errorCode: 1 }
+  }
+}
+
+export const SendUserFileTool = buildTool({
+  name: SEND_USER_FILE_TOOL_NAME,
+  searchHint: 'deliver a file to the user on their local machine',
+  maxResultSizeChars: 20_000,
+  async description() {
+    return DESCRIPTION
+  },
+  async prompt() {
+    return SEND_USER_FILE_TOOL_PROMPT
+  },
+  get inputSchema(): InputSchema {
+    return inputSchema()
+  },
+  get outputSchema(): OutputSchema {
+    return outputSchema()
+  },
+  isConcurrencySafe() {
+    return true
+  },
+  toAutoClassifierInput(input) {
+    return `${input.filename}\n${input.content}`
+  },
+  async validateInput(input) {
+    return validateInputOrError(input)
+  },
+  renderToolUseMessage(input) {
+    return formatUseMessage(input)
+  },
+  mapToolResultToToolResultBlockParam(output, toolUseID) {
+    return {
+      tool_use_id: toolUseID,
+      type: 'tool_result',
+      content: output.message,
+    }
+  },
+  async call({
+    filename,
+    content,
+    mimeType = DEFAULT_MIME_TYPE,
+    isBase64 = false,
+    openAfter = true,
+  }) {
+    try {
+      const delivery = await sendUserFile({
+        filename,
+        content,
+        mimeType,
+        isBase64,
+        openAfter,
+      })
+      return {
+        data: {
+          success: true,
+          filename,
+          path: delivery.path,
+          displayPath: delivery.displayPath,
+          mimeType: delivery.mimeType,
+          isBase64,
+          openAfter,
+          opened: delivery.opened,
+          revealed: delivery.revealed,
+          bytesWritten: delivery.bytesWritten,
+          message: formatSuccessMessage({
+            displayPath: delivery.displayPath,
+            openAfter,
+            opened: delivery.opened,
+            revealed: delivery.revealed,
+          }),
+          sentAt: new Date().toISOString(),
+        },
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'File delivery failed.'
+      return {
+        data: {
+          success: false,
+          filename,
+          mimeType,
+          isBase64,
+          openAfter,
+          message,
+          error: message,
+        },
+      }
+    }
+  },
+} satisfies ToolDef<InputSchema, Output>)

--- a/src 2/tools/SendUserFileTool/delivery.ts
+++ b/src 2/tools/SendUserFileTool/delivery.ts
@@ -1,0 +1,229 @@
+import { mkdir, writeFile } from 'fs/promises'
+import { basename, dirname, extname, isAbsolute, join, sep } from 'path'
+import { homedir } from 'os'
+import { openPath } from '../../utils/browser.js'
+import { execFileNoThrow } from '../../utils/execFileNoThrow.js'
+import { pathExists } from '../../utils/file.js'
+import { expandPath } from '../../utils/path.js'
+import { getPlatform, type Platform } from '../../utils/platform.js'
+import { getSettings_DEPRECATED } from '../../utils/settings/settings.js'
+
+const DEFAULT_MIME_TYPE = 'text/plain'
+export const MAX_SEND_USER_FILE_BYTES = 10 * 1024 * 1024
+
+export type SendUserFileInput = {
+  filename: string
+  content: string
+  mimeType?: string
+  isBase64?: boolean
+  openAfter?: boolean
+}
+
+export type SendUserFileSettings = {
+  outputDir?: string
+}
+
+type SettingsShape = {
+  sendUserFile?: SendUserFileSettings
+}
+
+type ExecResult = {
+  stdout: string
+  stderr: string
+  code: number
+  error?: string
+}
+
+export type DeliveryDependencies = {
+  homeDir?: string
+  platform?: Platform
+  pathExists?: typeof pathExists
+  mkdir?: (path: string) => Promise<void>
+  writeFile?: (path: string, data: string | Uint8Array) => Promise<void>
+  execFileNoThrow?: (
+    file: string,
+    args: string[],
+    options?: { useCwd?: boolean },
+  ) => Promise<ExecResult>
+  openPath?: typeof openPath
+}
+
+export type SendUserFileDelivery = {
+  path: string
+  displayPath: string
+  outputDir: string
+  bytesWritten: number
+  mimeType: string
+  revealed: boolean
+  opened: boolean
+}
+
+export class SendUserFileError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SendUserFileError'
+  }
+}
+
+function getSettings(): SettingsShape {
+  return (getSettings_DEPRECATED() || {}) as SettingsShape
+}
+
+export function validateSendUserFilename(filename: string): void {
+  const trimmed = filename.trim()
+  if (!trimmed) {
+    throw new SendUserFileError('Filename is required.')
+  }
+  if (trimmed !== basename(trimmed)) {
+    throw new SendUserFileError(
+      'Filename must be a bare name like `report.md`, not a path.',
+    )
+  }
+  if (
+    trimmed.includes('/') ||
+    trimmed.includes('\\') ||
+    trimmed.includes('..') ||
+    isAbsolute(trimmed) ||
+    trimmed === '.' ||
+    trimmed === '..'
+  ) {
+    throw new SendUserFileError(
+      'Filename must be a bare name like `report.md`, not a path.',
+    )
+  }
+}
+
+export function decodeSendUserFileContent(
+  content: string,
+  isBase64: boolean,
+): Uint8Array {
+  const bytes = isBase64
+    ? Uint8Array.from(Buffer.from(content, 'base64'))
+    : Uint8Array.from(Buffer.from(content, 'utf8'))
+
+  if (bytes.byteLength > MAX_SEND_USER_FILE_BYTES) {
+    throw new SendUserFileError(
+      `File content exceeds the 10 MB limit (${bytes.byteLength} bytes).`,
+    )
+  }
+
+  return bytes
+}
+
+export async function getSendUserFileOutputDir(
+  {
+    homeDir = homedir(),
+    pathExists: pathExistsImpl = pathExists,
+  }: Pick<DeliveryDependencies, 'homeDir' | 'pathExists'> = {},
+): Promise<string> {
+  const configuredDir = getSettings().sendUserFile?.outputDir?.trim()
+  if (configuredDir) {
+    return expandPath(configuredDir)
+  }
+
+  const downloadsDir = join(homeDir, 'Downloads')
+  if (await pathExistsImpl(downloadsDir)) {
+    return downloadsDir
+  }
+
+  return homeDir
+}
+
+export async function getUniqueOutputPath(
+  outputDir: string,
+  filename: string,
+  pathExistsImpl: typeof pathExists = pathExists,
+): Promise<string> {
+  const extension = extname(filename)
+  const baseName =
+    extension.length > 0 ? filename.slice(0, -extension.length) : filename
+
+  let attempt = 1
+  while (true) {
+    const candidate =
+      attempt === 1
+        ? filename
+        : `${baseName}-${attempt}${extension || ''}`
+    const candidatePath = join(outputDir, candidate)
+    if (!(await pathExistsImpl(candidatePath))) {
+      return candidatePath
+    }
+    attempt += 1
+  }
+}
+
+function toDisplayPath(filePath: string, homeDir: string): string {
+  return filePath.startsWith(homeDir + sep)
+    ? `~${filePath.slice(homeDir.length)}`
+    : filePath
+}
+
+export async function revealWrittenFile(
+  filePath: string,
+  {
+    platform = getPlatform(),
+    execFileNoThrow: execImpl = execFileNoThrow,
+  }: Pick<DeliveryDependencies, 'platform' | 'execFileNoThrow'> = {},
+): Promise<boolean> {
+  if (platform === 'unknown') {
+    return false
+  }
+
+  const command =
+    platform === 'macos'
+      ? { file: 'open', args: ['-R', filePath] }
+      : platform === 'windows'
+        ? { file: 'explorer', args: [`/select,${filePath}`] }
+        : { file: 'xdg-open', args: [dirname(filePath)] }
+
+  const result = await execImpl(command.file, command.args, { useCwd: false })
+  return result.code === 0
+}
+
+export async function openWrittenFile(
+  filePath: string,
+  {
+    openPath: openPathImpl = openPath,
+  }: Pick<DeliveryDependencies, 'openPath'> = {},
+): Promise<boolean> {
+  return openPathImpl(filePath)
+}
+
+export async function sendUserFile(
+  input: SendUserFileInput,
+  deps: DeliveryDependencies = {},
+): Promise<SendUserFileDelivery> {
+  validateSendUserFilename(input.filename)
+
+  const bytes = decodeSendUserFileContent(input.content, input.isBase64 ?? false)
+  const homeDir = deps.homeDir ?? homedir()
+  const outputDir = await getSendUserFileOutputDir({
+    homeDir,
+    pathExists: deps.pathExists,
+  })
+  const writePath = await getUniqueOutputPath(
+    outputDir,
+    input.filename.trim(),
+    deps.pathExists,
+  )
+
+  const mkdirImpl = deps.mkdir ?? (path => mkdir(path, { recursive: true }))
+  const writeFileImpl = deps.writeFile ?? ((path, data) => writeFile(path, data))
+
+  await mkdirImpl(outputDir)
+  await writeFileImpl(writePath, bytes)
+
+  const revealed = await revealWrittenFile(writePath, deps)
+  const openAfter = input.openAfter ?? true
+  const opened = openAfter ? await openWrittenFile(writePath, deps) : false
+
+  return {
+    path: writePath,
+    displayPath: toDisplayPath(writePath, homeDir),
+    outputDir,
+    bytesWritten: bytes.byteLength,
+    mimeType: input.mimeType || DEFAULT_MIME_TYPE,
+    revealed,
+    opened,
+  }
+}

--- a/src 2/tools/SendUserFileTool/prompt.ts
+++ b/src 2/tools/SendUserFileTool/prompt.ts
@@ -1,0 +1,12 @@
+export const SEND_USER_FILE_TOOL_NAME = 'SendUserFile'
+
+export const DESCRIPTION =
+  'Deliver a file to the user by writing it to a visible folder on their machine'
+
+export const SEND_USER_FILE_TOOL_PROMPT = `Write a file the user should receive locally.
+
+\`filename\` must be a bare filename like \`report.md\` or \`image.png\`, not a path.
+\`content\` is the full file contents. For binary files, pass base64 and set \`isBase64: true\`.
+\`mimeType\` is optional metadata; \`openAfter\` defaults to true and opens the file after writing it.
+
+The tool writes to a user-visible directory, never silently overwrites an existing file, and rejects path traversal attempts.`


### PR DESCRIPTION
Closes #5

## What changed
- add `SendUserFileTool` with filename validation, 10 MB cap, overwrite suffixing, binary base64 support, and user-facing result text
- add OS-aware delivery helpers for reveal + open behavior and output-dir resolution
- add focused tests for happy path, overwrite protection, traversal rejection, binary writes, and oversize rejection

## Verification
- `bun test tools/SendUserFileTool/SendUserFileTool.test.ts`
- `./node_modules/.bin/eslint tools/SendUserFileTool/SendUserFileTool.ts tools/SendUserFileTool/delivery.ts tools/SendUserFileTool/prompt.ts tools/SendUserFileTool/SendUserFileTool.test.ts`
- `bun run typecheck`
- `bun run lint`
- manual proof: Finder reveal/open, overwrite suffixing, Preview opened 1x1 PNG, traversal rejected with clear error