### PR TITLE
feat(kairos): add daemon skeleton

### DIFF
--- a/src 2/daemon/kairos/paths.ts
+++ b/src 2/daemon/kairos/paths.ts
@@ -1,0 +1,14 @@
+import { join } from 'path'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+
+export function getKairosStateDir(): string {
+  return join(getClaudeConfigHomeDir(), 'kairos')
+}
+
+export function getKairosStatusPath(): string {
+  return join(getKairosStateDir(), 'status.json')
+}
+
+export function getKairosStdoutLogPath(): string {
+  return join(getKairosStateDir(), 'daemon.out.log')
+}

--- a/src 2/daemon/kairos/worker.test.ts
+++ b/src 2/daemon/kairos/worker.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { spawn } from 'child_process'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { getKairosStateDir, getKairosStatusPath, getKairosStdoutLogPath } from './paths.js'
+import { runKairosWorker } from './worker.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempConfigDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-daemon-test-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+async function waitForPath(path: string, timeoutMs = 3_000): Promise<void> {
+  const started = Date.now()
+  while (Date.now() - started < timeoutMs) {
+    try {
+      readFileSync(path)
+      return
+    } catch {
+      await Bun.sleep(50)
+    }
+  }
+  throw new Error(`Timed out waiting for ${path}`)
+}
+
+describe('Kairos daemon worker', () => {
+  test('writes state files and shuts down cleanly when aborted', async () => {
+    const configDir = makeTempConfigDir()
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    const controller = new AbortController()
+    const stdoutChunks: string[] = []
+
+    const running = runKairosWorker({
+      signal: controller.signal,
+      stdout: {
+        write(chunk: string) {
+          stdoutChunks.push(chunk)
+          return true
+        },
+      },
+      pid: 12345,
+      now: (() => {
+        let tick = 0
+        return () => new Date(Date.UTC(2026, 3, 21, 12, 0, tick++))
+      })(),
+    })
+
+    await waitForPath(getKairosStatusPath())
+    controller.abort()
+
+    const exitCode = await running
+    expect(exitCode).toBe(0)
+    expect(getKairosStateDir()).toBe(join(configDir, 'kairos'))
+
+    const status = JSON.parse(readFileSync(getKairosStatusPath(), 'utf8'))
+    expect(status).toMatchObject({
+      kind: 'kairos',
+      state: 'stopped',
+      pid: 12345,
+    })
+
+    const log = readFileSync(getKairosStdoutLogPath(), 'utf8')
+    expect(log).toContain('startup complete; entering idle loop')
+    expect(log).toContain('shutdown requested; exiting cleanly')
+    expect(stdoutChunks.join('')).toContain('startup complete; entering idle loop')
+  })
+
+  test('daemon main exits with code 0 on SIGTERM', async () => {
+    const configDir = makeTempConfigDir()
+    const daemonRoot = join(process.cwd(), 'daemon')
+    const child = spawn(
+      process.execPath,
+      [
+        '--eval',
+        'import { daemonMain } from "./daemon/main.ts"; await daemonMain(["kairos"]);',
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          CLAUDE_CONFIG_DIR: configDir,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
+
+    let stdout = ''
+    child.stdout.on('data', chunk => {
+      stdout += String(chunk)
+    })
+
+    await waitForPath(join(configDir, 'kairos', 'status.json'))
+    child.kill('SIGTERM')
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      child.once('error', reject)
+      child.once('exit', code => resolve(code))
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('startup complete; entering idle loop')
+
+    const log = readFileSync(join(configDir, 'kairos', 'daemon.out.log'), 'utf8')
+    expect(log).toContain('shutdown requested; exiting cleanly')
+  })
+})

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -1,0 +1,107 @@
+import { appendFile, mkdir, writeFile } from 'fs/promises'
+import type { Writable } from 'stream'
+import { getKairosStateDir, getKairosStatusPath, getKairosStdoutLogPath } from './paths.js'
+
+type KairosStatus = {
+  kind: 'kairos'
+  state: 'starting' | 'idle' | 'stopped'
+  pid: number
+  startedAt: string
+  updatedAt: string
+  stoppedAt?: string
+}
+
+export type RunKairosWorkerOptions = {
+  signal?: AbortSignal
+  stdout?: Pick<Writable, 'write'>
+  now?: () => Date
+  pid?: number
+}
+
+function formatLogLine(message: string, now: Date, pid: number): string {
+  return `[${now.toISOString()}] [kairos] pid=${pid} ${message}\n`
+}
+
+async function writeStatus(status: KairosStatus): Promise<void> {
+  await writeFile(getKairosStatusPath(), `${JSON.stringify(status, null, 2)}\n`)
+}
+
+async function logLine(
+  message: string,
+  {
+    stdout = process.stdout,
+    now = new Date(),
+    pid = process.pid,
+  }: {
+    stdout?: Pick<Writable, 'write'>
+    now?: Date
+    pid?: number
+  },
+): Promise<void> {
+  const line = formatLogLine(message, now, pid)
+  stdout.write(line)
+  await appendFile(getKairosStdoutLogPath(), line)
+}
+
+function waitForAbort(signal?: AbortSignal): Promise<void> {
+  if (!signal) {
+    return new Promise(() => {})
+  }
+  if (signal.aborted) {
+    return Promise.resolve()
+  }
+  return new Promise(resolve => {
+    signal.addEventListener('abort', () => resolve(), { once: true })
+  })
+}
+
+export async function runKairosWorker(
+  options: RunKairosWorkerOptions = {},
+): Promise<number> {
+  const now = options.now ?? (() => new Date())
+  const pid = options.pid ?? process.pid
+  const startedAt = now().toISOString()
+
+  await mkdir(getKairosStateDir(), { recursive: true })
+
+  await writeStatus({
+    kind: 'kairos',
+    state: 'starting',
+    pid,
+    startedAt,
+    updatedAt: startedAt,
+  })
+  await logLine('startup complete; entering idle loop', {
+    stdout: options.stdout,
+    now: now(),
+    pid,
+  })
+
+  const idleAt = now().toISOString()
+  await writeStatus({
+    kind: 'kairos',
+    state: 'idle',
+    pid,
+    startedAt,
+    updatedAt: idleAt,
+  })
+
+  await waitForAbort(options.signal)
+
+  const stoppedAt = now().toISOString()
+  await logLine('shutdown requested; exiting cleanly', {
+    stdout: options.stdout,
+    now: now(),
+    pid,
+  })
+  await writeStatus({
+    kind: 'kairos',
+    state: 'stopped',
+    pid,
+    startedAt,
+    updatedAt: stoppedAt,
+    stoppedAt,
+  })
+
+  return 0
+}

--- a/src 2/daemon/main.ts
+++ b/src 2/daemon/main.ts
@@ -1,0 +1,44 @@
+import { runKairosWorker } from './kairos/worker.js'
+
+type SignalHandler = () => void
+
+export type DaemonMainOptions = {
+  registerSignalHandlers?: (
+    handler: SignalHandler,
+  ) => (() => void) | Promise<() => void>
+}
+
+async function defaultRegisterSignalHandlers(
+  handler: SignalHandler,
+): Promise<() => void> {
+  process.once('SIGINT', handler)
+  process.once('SIGTERM', handler)
+  return () => {
+    process.off('SIGINT', handler)
+    process.off('SIGTERM', handler)
+  }
+}
+
+export async function daemonMain(
+  args: string[],
+  options: DaemonMainOptions = {},
+): Promise<void> {
+  const subcommand = args[0]
+  if (subcommand !== 'kairos') {
+    throw new Error(
+      `Unknown daemon subcommand: ${subcommand ?? '(none)'}. Expected \`kairos\`.`,
+    )
+  }
+
+  const controller = new AbortController()
+  const register =
+    options.registerSignalHandlers ?? defaultRegisterSignalHandlers
+  const unregister = await register(() => controller.abort())
+
+  try {
+    const exitCode = await runKairosWorker({ signal: controller.signal })
+    process.exitCode = exitCode
+  } finally {
+    unregister()
+  }
+}

--- a/src 2/daemon/workerRegistry.ts
+++ b/src 2/daemon/workerRegistry.ts
@@ -1,0 +1,13 @@
+import { runKairosWorker } from './kairos/worker.js'
+
+export async function runDaemonWorker(kind: string | undefined): Promise<void> {
+  if (kind === 'kairos') {
+    const exitCode = await runKairosWorker()
+    process.exitCode = exitCode
+    return
+  }
+
+  throw new Error(
+    `Unknown daemon worker: ${kind ?? '(none)'}. Expected \`kairos\`.`,
+  )
+}

--- a/src 2/package.json
+++ b/src 2/package.json
@@ -9,8 +9,9 @@
   },
   "scripts": {
     "dev": "bun ./entrypoints/cli.tsx",
+    "test": "bun test",
     "typecheck": "tsc --noEmit --allowJs false --skipLibCheck ./types/employee.ts",
-    "lint": "eslint ./types/employee.ts ./utils/employeeConfig.ts ./tools/AgentTool/builtInAgents.ts ./tools/AgentTool/built-in/engineeringLeadAgent.ts ./commands/employee/index.ts ./commands/employee/employee.tsx ./scripts/employeeSmoke.ts ./entrypoints/cli.tsx --cache --no-error-on-unmatched-pattern",
+    "lint": "eslint ./types/employee.ts ./utils/employeeConfig.ts ./tools/AgentTool/builtInAgents.ts ./tools/AgentTool/built-in/engineeringLeadAgent.ts ./commands/employee/index.ts ./commands/employee/employee.tsx ./scripts/employeeSmoke.ts ./entrypoints/cli.tsx ./daemon/**/*.ts --no-error-on-unmatched-pattern",
     "build": "bun build ./entrypoints/cli.tsx --outfile ./dist/cli.js --target bun --format esm --define MACRO='{\"VERSION\":\"0.0.0-rebuilt\",\"BUILD_TIME\":\"2026-03-31T00:00:00.000Z\",\"FEEDBACK_CHANNEL\":\"#claude-code\",\"ISSUES_EXPLAINER\":\"open an issue\",\"PACKAGE_URL\":\"@anthropic-ai/claude-code\",\"NATIVE_PACKAGE_URL\":\"@anthropic-ai/claude-code-native\",\"VERSION_CHANGELOG\":\"\"}' --external @ant/computer-use-mcp --external @ant/computer-use-mcp/types --external @ant/computer-use-mcp/sentinelApps --external @ant/claude-for-chrome-mcp --external @ant/computer-use-swift --external @ant/computer-use-input --external @anthropic-ai/mcpb --external @anthropic-ai/sandbox-runtime --external audio-capture-napi --external color-diff-napi --external image-processor-napi --external url-handler-napi",
     "build:employee-smoke": "bun build ./scripts/employeeSmoke.ts --outfile ./dist/employee-smoke.js --target bun --format esm --define MACRO='{\"VERSION\":\"0.0.0-rebuilt\",\"BUILD_TIME\":\"2026-03-31T00:00:00.000Z\",\"FEEDBACK_CHANNEL\":\"#claude-code\",\"ISSUES_EXPLAINER\":\"open an issue\",\"PACKAGE_URL\":\"@anthropic-ai/claude-code\",\"NATIVE_PACKAGE_URL\":\"@anthropic-ai/claude-code-native\",\"VERSION_CHANGELOG\":\"\"}' --external ./protectedNamespace.js --external @aws-sdk/client-sts",
     "smoke:cli": "bun ./entrypoints/cli.tsx --version",


### PR DESCRIPTION
Closes #12

## What changed
- add the initial `src 2/daemon/**` skeleton for Kairos
- add a `daemonMain(["kairos"])` dispatcher with SIGINT/SIGTERM handling
- add a Kairos worker that creates the global state dir, writes `status.json`, appends `daemon.out.log`, idles, and exits cleanly
- add a worker registry entry for the existing `--daemon-worker` fast path
- add daemon lifecycle tests
- add a `test` script and include daemon files in lint
- remove eslint cache writes from the lint script so lint runs reliably in this environment

## Verification
Automated:
- `HOME=/Users/gaganarora/conductor/workspaces/again-v1/winnipeg/.context/fake-home-pr TMPDIR=/Users/gaganarora/conductor/workspaces/again-v1/winnipeg/.context/test-tmp-pr bun test`
- `TMPDIR=/Users/gaganarora/conductor/workspaces/again-v1/winnipeg/.context/test-tmp-pr bun run typecheck`
- `TMPDIR=/Users/gaganarora/conductor/workspaces/again-v1/winnipeg/.context/test-tmp-pr bun run lint`

Manual / visual proof:
- ran the direct Phase 1 daemon entrypoint with `CLAUDE_CONFIG_DIR=/tmp/kairos-phase1-proof bun --eval ... daemonMain(["kairos"])`
- confirmed `status.json` was written
- confirmed `daemon.out.log` had a startup line
- sent `SIGTERM`
- confirmed clean shutdown log line and final `state: "stopped"`

## Note
Phase 1 intentionally verifies the daemon through the direct daemon entrypoint. `install-kairos` and the final user-facing `claude daemon kairos` install path are later-phase work and are not part of this PR.