### PR TITLE
Phase 2: add Kairos project workers and registry

### DIFF
--- a/src 2/daemon/kairos/projectRegistry.ts
+++ b/src 2/daemon/kairos/projectRegistry.ts
@@ -1,0 +1,105 @@
+import type { FSWatcher } from 'chokidar'
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { z } from 'zod/v4'
+import { safeParseJSON } from '../../utils/json.js'
+import { lazySchema } from '../../utils/lazySchema.js'
+import { jsonStringify } from '../../utils/slowOperations.js'
+import { getKairosStateDir } from './paths.js'
+
+const PROJECTS_FILE = 'projects.json'
+const WATCH_STABILITY_MS = 300
+
+const registrySchema = lazySchema(() =>
+  z.object({
+    projects: z.array(z.string()),
+  }),
+)
+
+type RegistryFile = z.infer<ReturnType<typeof registrySchema>>
+
+export type ProjectsChange = {
+  added: string[]
+  removed: string[]
+  projects: string[]
+}
+
+export type ProjectRegistry = {
+  path: string
+  read(): Promise<string[]>
+  write(projects: string[]): Promise<void>
+  watch(onChange: (change: ProjectsChange) => void): Promise<() => Promise<void>>
+}
+
+function normalizeProjects(projects: string[]): string[] {
+  return [...new Set(projects.map(project => project.normalize('NFC')).sort())]
+}
+
+async function readProjectsFile(path: string): Promise<string[]> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf8')
+  } catch {
+    return []
+  }
+  const parsed = safeParseJSON(raw, false)
+  const result = registrySchema().safeParse(parsed)
+  if (!result.success) return []
+  return normalizeProjects(result.data.projects)
+}
+
+export async function createProjectRegistry(): Promise<ProjectRegistry> {
+  const dir = getKairosStateDir()
+  const path = join(dir, PROJECTS_FILE)
+
+  await mkdir(dir, { recursive: true })
+
+  return {
+    path,
+    read() {
+      return readProjectsFile(path)
+    },
+    async write(projects: string[]) {
+      const body: RegistryFile = { projects: normalizeProjects(projects) }
+      await writeFile(path, `${jsonStringify(body, null, 2)}\n`, 'utf8')
+    },
+    async watch(onChange) {
+      const { default: chokidar } = await import('chokidar')
+      let previous = await readProjectsFile(path)
+
+      const emitDiff = async () => {
+        const next = await readProjectsFile(path)
+        const previousSet = new Set(previous)
+        const nextSet = new Set(next)
+        const added = next.filter(project => !previousSet.has(project))
+        const removed = previous.filter(project => !nextSet.has(project))
+        previous = next
+        if (added.length === 0 && removed.length === 0) return
+        onChange({ added, removed, projects: next })
+      }
+
+      const watcher: FSWatcher = chokidar.watch(path, {
+        persistent: false,
+        ignoreInitial: true,
+        awaitWriteFinish: {
+          stabilityThreshold: WATCH_STABILITY_MS,
+        },
+      })
+
+      watcher.on('add', () => void emitDiff())
+      watcher.on('change', () => void emitDiff())
+      watcher.on('unlink', () =>
+        void (async () => {
+          const removed = previous
+          previous = []
+          if (removed.length === 0) return
+          onChange({ added: [], removed, projects: [] })
+        })(),
+      )
+
+      return async () => {
+        await watcher.close()
+      }
+    },
+  }
+}

--- a/src 2/daemon/kairos/projectWorker.test.ts
+++ b/src 2/daemon/kairos/projectWorker.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { CronScheduler } from '../../utils/cronScheduler.js'
+import type { CronTask } from '../../utils/cronTasks.js'
+import { createProjectRegistry } from './projectRegistry.js'
+import { createProjectWorker } from './projectWorker.js'
+import { createStateWriter } from './stateWriter.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempConfigDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function makeTask(id: string): CronTask {
+  return {
+    id,
+    cron: '* * * * *',
+    prompt: `task ${id}`,
+    createdAt: Date.now(),
+  }
+}
+
+describe('Kairos project worker', () => {
+  test('project registry reads, writes, and diffs projects.json', async () => {
+    const configDir = makeTempConfigDir('kairos-registry-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    const registry = await createProjectRegistry()
+    expect(await registry.read()).toEqual([])
+
+    await registry.write(['/repo/b', '/repo/a', '/repo/a'])
+    expect(await registry.read()).toEqual(['/repo/a', '/repo/b'])
+
+    const changes: Array<{ added: string[]; removed: string[] }> = []
+    const stop = await registry.watch(change => {
+      changes.push({ added: change.added, removed: change.removed })
+    })
+
+    await Bun.sleep(50)
+    await registry.write(['/repo/b', '/repo/c'])
+    await Bun.sleep(400)
+    await stop()
+
+    expect(changes).toEqual([
+      {
+        added: ['/repo/c'],
+        removed: ['/repo/a'],
+      },
+    ])
+  })
+
+  test('coalesces overlapping fires into one catch-up pass', async () => {
+    const configDir = makeTempConfigDir('kairos-worker-')
+    const projectDir = makeTempConfigDir('kairos-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    let fireTask: ((task: CronTask) => void) | undefined
+    const scheduler: CronScheduler = {
+      start() {},
+      stop() {},
+      getNextFireTime() {
+        return null
+      },
+    }
+
+    const stateWriter = await createStateWriter()
+    const worker = createProjectWorker(projectDir, {
+      stateWriter,
+      createScheduler(options) {
+        fireTask = options.onFireTask
+        return scheduler
+      },
+    })
+
+    mkdirSync(join(projectDir, '.claude'), { recursive: true })
+    writeFileSync(
+      join(projectDir, '.claude', 'scheduled_tasks.json'),
+      JSON.stringify(
+        {
+          tasks: [makeTask('first'), makeTask('second')],
+        },
+        null,
+        2,
+      ),
+    )
+
+    worker.start()
+    fireTask?.(makeTask('first'))
+    fireTask?.(makeTask('second'))
+
+    await Bun.sleep(150)
+
+    const log = readFileSync(
+      join(projectDir, '.claude', 'kairos', 'log.jsonl'),
+      'utf8',
+    )
+    expect(log).toContain('"kind":"overlap_coalesced"')
+    expect(log).toContain('"kind":"catchup_started"')
+
+    const catchupCount = log
+      .split('\n')
+      .filter(line => line.includes('"kind":"catchup_started"')).length
+    expect(catchupCount).toBe(1)
+
+    const firedCount = log
+      .split('\n')
+      .filter(line => line.includes('"kind":"fired"')).length
+    expect(firedCount).toBe(2)
+
+    const scheduledTasks = readFileSync(
+      join(projectDir, '.claude', 'scheduled_tasks.json'),
+      'utf8',
+    )
+    expect(scheduledTasks).toContain('"tasks": []')
+  })
+})

--- a/src 2/daemon/kairos/projectWorker.ts
+++ b/src 2/daemon/kairos/projectWorker.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from 'crypto'
+import { createCronScheduler, type CronScheduler } from '../../utils/cronScheduler.js'
+import { readCronTasks, writeCronTasks } from '../../utils/cronTasks.js'
+import type { CronTask } from '../../utils/cronTasks.js'
+import type { ProjectStatus } from './stateWriter.js'
+
+export type ProjectWorkerDeps = {
+  stateWriter: {
+    writeProjectStatus(status: ProjectStatus): Promise<void>
+    appendProjectLog(
+      projectDir: string,
+      event: Record<string, unknown>,
+    ): Promise<void>
+  }
+  createScheduler?: (options: ConstructorParameters<typeof createCronScheduler>[0]) => CronScheduler
+  now?: () => Date
+}
+
+export type ProjectWorker = {
+  start(): void
+  stop(): Promise<void>
+  onFireTask(task: CronTask): void
+  onMissed(tasks: CronTask[]): void
+  getSnapshot(): {
+    running: boolean
+    dirty: boolean
+    pendingCount: number
+    nextFireAt: number | null
+  }
+}
+
+export function createProjectWorker(
+  projectDir: string,
+  deps: ProjectWorkerDeps,
+): ProjectWorker {
+  const now = deps.now ?? (() => new Date())
+  const lockIdentity = randomUUID()
+  const createSchedulerImpl = deps.createScheduler ?? createCronScheduler
+
+  let running = false
+  let dirty = false
+  let pendingCount = 0
+  let stopped = false
+  let currentRun: Promise<void> | null = null
+  const completedOneShots = new Set<string>()
+  let cleanupTimer: ReturnType<typeof setTimeout> | null = null
+  let cleanupRun: Promise<void> | null = null
+
+  const flushCompletedOneShots = async (): Promise<void> => {
+    if (completedOneShots.size === 0) return
+    const ids = new Set(completedOneShots)
+    completedOneShots.clear()
+    const tasks = await readCronTasks(projectDir)
+    const remaining = tasks.filter(task => !ids.has(task.id))
+    await writeCronTasks(remaining, projectDir)
+  }
+
+  const scheduleOneShotCleanup = (): void => {
+    if (cleanupTimer || stopped) return
+    cleanupTimer = setTimeout(() => {
+      cleanupTimer = null
+      cleanupRun = flushCompletedOneShots().finally(() => {
+        cleanupRun = null
+        if (completedOneShots.size > 0) {
+          scheduleOneShotCleanup()
+        }
+      })
+    }, 50)
+    cleanupTimer.unref?.()
+  }
+
+  const writeStatus = async (lastEvent: string): Promise<void> => {
+    await deps.stateWriter.writeProjectStatus({
+      projectDir,
+      running,
+      dirty,
+      pendingCount,
+      lastEvent,
+      updatedAt: now().toISOString(),
+      nextFireAt: scheduler.getNextFireTime(),
+      ...(lastEvent === 'finished' ? { lastRunAt: now().toISOString() } : {}),
+    })
+  }
+
+  const runCycle = async (source: 'event' | 'catchup'): Promise<void> => {
+    if (source === 'catchup') {
+      await deps.stateWriter.appendProjectLog(projectDir, {
+        kind: 'catchup_started',
+        t: now().toISOString(),
+      })
+    }
+    await writeStatus(source === 'catchup' ? 'catchup_started' : 'fired')
+    await deps.stateWriter.appendProjectLog(projectDir, {
+      kind: 'finished',
+      source,
+      t: now().toISOString(),
+    })
+    await writeStatus('finished')
+  }
+
+  const drain = async (): Promise<void> => {
+    if (running || stopped) return
+    running = true
+    currentRun = (async () => {
+      try {
+        await runCycle('event')
+        while (dirty && !stopped) {
+          dirty = false
+          pendingCount = 1
+          await runCycle('catchup')
+        }
+      } finally {
+        running = false
+        pendingCount = dirty ? 1 : 0
+        await writeStatus('finished')
+      }
+    })()
+    await currentRun
+    currentRun = null
+  }
+
+  const scheduler = createSchedulerImpl({
+    dir: projectDir,
+    lockIdentity,
+    isLoading: () => false,
+    onFire: () => {},
+    onFireTask(task) {
+      void worker.onFireTask(task)
+    },
+    onMissed(tasks) {
+      void worker.onMissed(tasks)
+    },
+  })
+
+  const worker: ProjectWorker = {
+    start() {
+      void deps.stateWriter.appendProjectLog(projectDir, {
+        kind: 'worker_started',
+        t: now().toISOString(),
+        nextFireAt: scheduler.getNextFireTime(),
+      })
+      void writeStatus('worker_started')
+      scheduler.start()
+    },
+    async stop() {
+      stopped = true
+      if (cleanupTimer) {
+        clearTimeout(cleanupTimer)
+        cleanupTimer = null
+      }
+      scheduler.stop()
+      await currentRun
+      await cleanupRun
+      await flushCompletedOneShots()
+      await deps.stateWriter.appendProjectLog(projectDir, {
+        kind: 'worker_stopped',
+        t: now().toISOString(),
+      })
+      await writeStatus('worker_stopped')
+    },
+    onFireTask(task) {
+      if (!task.recurring) {
+        completedOneShots.add(task.id)
+        scheduleOneShotCleanup()
+      }
+      void deps.stateWriter.appendProjectLog(projectDir, {
+        kind: 'fired',
+        t: now().toISOString(),
+        taskId: task.id,
+        cron: task.cron,
+      })
+      if (running) {
+        dirty = true
+        pendingCount = 1
+        void deps.stateWriter.appendProjectLog(projectDir, {
+          kind: 'overlap_coalesced',
+          t: now().toISOString(),
+          taskId: task.id,
+        })
+        void writeStatus('overlap_coalesced')
+        return
+      }
+      pendingCount = 1
+      void drain()
+    },
+    onMissed(tasks) {
+      void deps.stateWriter.appendProjectLog(projectDir, {
+        kind: 'missed',
+        t: now().toISOString(),
+        count: tasks.length,
+      })
+      void writeStatus('missed')
+    },
+    getSnapshot() {
+      return {
+        running,
+        dirty,
+        pendingCount,
+        nextFireAt: scheduler.getNextFireTime(),
+      }
+    },
+  }
+
+  return worker
+}

--- a/src 2/daemon/kairos/stateWriter.ts
+++ b/src 2/daemon/kairos/stateWriter.ts
@@ -1,0 +1,106 @@
+import { appendFile, mkdir, rename, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
+import { jsonStringify } from '../../utils/slowOperations.js'
+import { getKairosStateDir } from './paths.js'
+
+export type ProjectStatus = {
+  projectDir: string
+  running: boolean
+  dirty: boolean
+  pendingCount: number
+  lastEvent?: string
+  lastRunAt?: string
+  nextFireAt?: number | null
+  updatedAt: string
+}
+
+export type ProjectLogEvent =
+  | { kind: 'worker_started'; t: string; nextFireAt?: number | null }
+  | { kind: 'worker_stopped'; t: string }
+  | { kind: 'fired'; t: string; taskId: string; cron: string }
+  | { kind: 'missed'; t: string; count: number }
+  | { kind: 'overlap_coalesced'; t: string; taskId: string }
+  | { kind: 'catchup_started'; t: string }
+  | { kind: 'finished'; t: string; source: 'event' | 'catchup' }
+  | { kind: 'project_registered'; t: string; projectDir: string }
+  | { kind: 'project_unregistered'; t: string; projectDir: string }
+
+export type GlobalStatus = {
+  kind: 'kairos'
+  state: 'starting' | 'idle' | 'stopped'
+  pid: number
+  startedAt: string
+  updatedAt: string
+  projects: number
+  lastEventAt?: string
+  stoppedAt?: string
+}
+
+const writeQueues = new Map<string, Promise<void>>()
+
+async function enqueuePathWrite(
+  path: string,
+  writeOp: () => Promise<void>,
+): Promise<void> {
+  const previous = writeQueues.get(path) ?? Promise.resolve()
+  const next = previous.then(writeOp)
+  writeQueues.set(
+    path,
+    next.finally(() => {
+      if (writeQueues.get(path) === next) {
+        writeQueues.delete(path)
+      }
+    }),
+  )
+  await next
+}
+
+async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  await enqueuePathWrite(path, async () => {
+    const tempPath = `${path}.tmp`
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(tempPath, `${jsonStringify(value, null, 2)}\n`, 'utf8')
+    await rename(tempPath, path)
+  })
+}
+
+async function appendJsonLine(path: string, value: unknown): Promise<void> {
+  await enqueuePathWrite(path, async () => {
+    await mkdir(dirname(path), { recursive: true })
+    await appendFile(path, `${jsonStringify(value)}\n`, 'utf8')
+  })
+}
+
+function getProjectKairosDir(projectDir: string): string {
+  return join(projectDir, '.claude', 'kairos')
+}
+
+export async function createStateWriter() {
+  await mkdir(getKairosStateDir(), { recursive: true })
+
+  return {
+    async writeGlobalStatus(status: GlobalStatus): Promise<void> {
+      await writeJsonAtomic(join(getKairosStateDir(), 'status.json'), status)
+    },
+    async appendGlobalEvent(event: ProjectLogEvent): Promise<void> {
+      await appendJsonLine(join(getKairosStateDir(), 'events.jsonl'), event)
+    },
+    async ensureProjectDir(projectDir: string): Promise<void> {
+      await mkdir(getProjectKairosDir(projectDir), { recursive: true })
+    },
+    async writeProjectStatus(status: ProjectStatus): Promise<void> {
+      const dir = getProjectKairosDir(status.projectDir)
+      await mkdir(dir, { recursive: true })
+      await writeJsonAtomic(join(dir, 'status.json'), status)
+    },
+    async appendProjectLog(
+      projectDir: string,
+      event: ProjectLogEvent,
+    ): Promise<void> {
+      const dir = getProjectKairosDir(projectDir)
+      await mkdir(dir, { recursive: true })
+      await appendJsonLine(join(dir, 'log.jsonl'), event)
+    },
+    getProjectKairosDir,
+  }
+}

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -1,6 +1,9 @@
 import { appendFile, mkdir, writeFile } from 'fs/promises'
 import type { Writable } from 'stream'
+import { createProjectRegistry } from './projectRegistry.js'
+import { createProjectWorker } from './projectWorker.js'
 import { getKairosStateDir, getKairosStatusPath, getKairosStdoutLogPath } from './paths.js'
+import { createStateWriter } from './stateWriter.js'
 
 type KairosStatus = {
   kind: 'kairos'
@@ -63,6 +66,55 @@ export async function runKairosWorker(
   const startedAt = now().toISOString()
 
   await mkdir(getKairosStateDir(), { recursive: true })
+  const stateWriter = await createStateWriter()
+  const projectRegistry = await createProjectRegistry()
+  const activeWorkers = new Map<
+    string,
+    ReturnType<typeof createProjectWorker>
+  >()
+
+  const syncGlobalStatus = async (state: 'starting' | 'idle' | 'stopped') => {
+    await stateWriter.writeGlobalStatus({
+      kind: 'kairos',
+      state,
+      pid,
+      startedAt,
+      updatedAt: now().toISOString(),
+      ...(state === 'stopped' ? { stoppedAt: now().toISOString() } : {}),
+      projects: activeWorkers.size,
+      ...(activeWorkers.size > 0 ? { lastEventAt: now().toISOString() } : {}),
+    })
+  }
+
+  const addProject = async (projectDir: string) => {
+    if (activeWorkers.has(projectDir)) return
+    await stateWriter.ensureProjectDir(projectDir)
+    const worker = createProjectWorker(projectDir, {
+      stateWriter,
+      now,
+    })
+    activeWorkers.set(projectDir, worker)
+    await stateWriter.appendGlobalEvent({
+      kind: 'project_registered',
+      t: now().toISOString(),
+      projectDir,
+    })
+    worker.start()
+    await syncGlobalStatus('idle')
+  }
+
+  const removeProject = async (projectDir: string) => {
+    const worker = activeWorkers.get(projectDir)
+    if (!worker) return
+    activeWorkers.delete(projectDir)
+    await worker.stop()
+    await stateWriter.appendGlobalEvent({
+      kind: 'project_unregistered',
+      t: now().toISOString(),
+      projectDir,
+    })
+    await syncGlobalStatus('idle')
+  }
 
   await writeStatus({
     kind: 'kairos',
@@ -71,10 +123,24 @@ export async function runKairosWorker(
     startedAt,
     updatedAt: startedAt,
   })
+  await syncGlobalStatus('starting')
   await logLine('startup complete; entering idle loop', {
     stdout: options.stdout,
     now: now(),
     pid,
+  })
+
+  for (const projectDir of await projectRegistry.read()) {
+    await addProject(projectDir)
+  }
+
+  const stopWatchingProjects = await projectRegistry.watch(change => {
+    for (const projectDir of change.added) {
+      void addProject(projectDir)
+    }
+    for (const projectDir of change.removed) {
+      void removeProject(projectDir)
+    }
   })
 
   const idleAt = now().toISOString()
@@ -85,8 +151,14 @@ export async function runKairosWorker(
     startedAt,
     updatedAt: idleAt,
   })
+  await syncGlobalStatus('idle')
 
   await waitForAbort(options.signal)
+
+  await stopWatchingProjects()
+  for (const projectDir of [...activeWorkers.keys()]) {
+    await removeProject(projectDir)
+  }
 
   const stoppedAt = now().toISOString()
   await logLine('shutdown requested; exiting cleanly', {
@@ -102,6 +174,7 @@ export async function runKairosWorker(
     updatedAt: stoppedAt,
     stoppedAt,
   })
+  await syncGlobalStatus('stopped')
 
   return 0
 }


### PR DESCRIPTION
## Summary
- add a Kairos project registry watcher backed by `~/.claude/kairos/projects.json`
- add per-project state/log writers and project workers with single-flight coalescing
- extend the Kairos daemon worker to add/remove project schedulers live

Closes #13

## Verification
- `TMPDIR='/Users/gaganarora/conductor/workspaces/again-v1/winnipeg/.context/test-tmp' bun test 'daemon/kairos/projectWorker.test.ts'`
- `TMPDIR='/Users/gaganarora/conductor/workspaces/again-v1/winnipeg/.context/test-tmp' bun run typecheck`
- `TMPDIR='/Users/gaganarora/conductor/workspaces/again-v1/winnipeg/.context/test-tmp' bun run lint`
- `HOME='/Users/gaganarora/conductor/workspaces/again-v1/winnipeg/.context/fake-home' TMPDIR='/Users/gaganarora/conductor/workspaces/again-v1/winnipeg/.context/test-tmp' bun test`
- live proof: start `daemonMain(["kairos"])`, add/remove a project in `projects.json`, verify overlap logs `fired -> overlap_coalesced -> catchup_started`, confirm one-shot tasks are removed from `scheduled_tasks.json`, and confirm `worker_stopped` on project removal
