### PR TITLE
feat(kairos): reminder scheduling core (#8)

### DIFF
--- a/src 2/services/reminders/reminderScheduler.test.ts
+++ b/src 2/services/reminders/reminderScheduler.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { scheduleReminder } from './reminderScheduler.js'
+import { ReminderValidationError } from './reminderValidation.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-reminder-test-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function readScheduledTasks(projectDir: string): {
+  tasks: Array<{
+    id: string
+    cron: string
+    prompt: string
+    createdAt: number
+    recurring?: boolean
+  }>
+} {
+  const raw = readFileSync(
+    join(projectDir, '.claude', 'scheduled_tasks.json'),
+    'utf-8',
+  )
+  return JSON.parse(raw)
+}
+
+describe('scheduleReminder', () => {
+  test('writes a durable one-shot task for a future reminder', async () => {
+    const projectDir = makeProjectDir()
+    const now = new Date('2026-05-15T14:00:00.000Z')
+    const at = new Date('2026-05-15T14:02:00.000Z')
+
+    const result = await scheduleReminder(
+      { projectDir, text: 'Drink water.', at },
+      { now, generateId: () => 'abcd1234' },
+    )
+
+    expect(result.status).toBe('scheduled')
+    expect(result.id).toBe('abcd1234')
+    expect(result.text).toBe('Drink water.')
+    expect(result.at.getTime()).toBe(at.getTime())
+    expect(result.filePath).toBe(
+      join(projectDir, '.claude', 'scheduled_tasks.json'),
+    )
+
+    const file = readScheduledTasks(projectDir)
+    expect(file.tasks).toHaveLength(1)
+    const [task] = file.tasks
+    expect(task).toMatchObject({
+      id: 'abcd1234',
+      prompt: 'Drink water.',
+      createdAt: now.getTime(),
+    })
+    expect(task!.recurring).toBeUndefined()
+    // Cron string corresponds to the target minute in local time; just
+    // confirm the shape is the durable one-shot cron format.
+    expect(task!.cron.split(/\s+/)).toHaveLength(5)
+    expect(task!.cron).toBe(result.cron)
+  })
+
+  test('rejects a reminder whose target time is in the past', async () => {
+    const projectDir = makeProjectDir()
+    const now = new Date('2026-05-15T14:00:00.000Z')
+    const at = new Date('2026-05-15T13:00:00.000Z')
+
+    await expect(
+      scheduleReminder({ projectDir, text: 'Drink water.', at }, { now }),
+    ).rejects.toMatchObject({
+      name: 'ReminderValidationError',
+      code: 'past_time',
+    })
+
+    // No file should have been written.
+    expect(() => readScheduledTasks(projectDir)).toThrow()
+  })
+
+  test('rejects a reminder for the current minute as past', async () => {
+    const projectDir = makeProjectDir()
+    const now = new Date('2026-05-15T14:00:30.000Z')
+    const at = new Date('2026-05-15T14:00:00.000Z')
+
+    await expect(
+      scheduleReminder({ projectDir, text: 'Drink water.', at }, { now }),
+    ).rejects.toBeInstanceOf(ReminderValidationError)
+  })
+
+  test('rejects empty reminder text', async () => {
+    const projectDir = makeProjectDir()
+    const now = new Date('2026-05-15T14:00:00.000Z')
+
+    await expect(
+      scheduleReminder(
+        {
+          projectDir,
+          text: '   ',
+          at: new Date('2026-05-15T14:02:00.000Z'),
+        },
+        { now },
+      ),
+    ).rejects.toMatchObject({
+      code: 'empty_text',
+    })
+  })
+
+  test('rejects unparseable target times', async () => {
+    const projectDir = makeProjectDir()
+    const now = new Date('2026-05-15T14:00:00.000Z')
+
+    await expect(
+      scheduleReminder(
+        { projectDir, text: 'Drink water.', at: 'not-a-date' },
+        { now },
+      ),
+    ).rejects.toMatchObject({
+      code: 'invalid_time',
+    })
+  })
+
+  test('does not create a duplicate when the same reminder is requested twice', async () => {
+    const projectDir = makeProjectDir()
+    const now = new Date('2026-05-15T14:00:00.000Z')
+    const at = new Date('2026-05-15T14:02:00.000Z')
+
+    let idCounter = 0
+    const generateId = () => `id${++idCounter}`
+
+    const first = await scheduleReminder(
+      { projectDir, text: 'Drink water.', at },
+      { now, generateId },
+    )
+    expect(first.status).toBe('scheduled')
+    expect(first.id).toBe('id1')
+
+    const second = await scheduleReminder(
+      { projectDir, text: 'Drink water.', at },
+      { now, generateId },
+    )
+
+    expect(second.status).toBe('duplicate')
+    expect(second.id).toBe('id1')
+    // generateId was never consumed by the duplicate path.
+    expect(idCounter).toBe(1)
+
+    const file = readScheduledTasks(projectDir)
+    expect(file.tasks).toHaveLength(1)
+    expect(file.tasks[0]!.id).toBe('id1')
+  })
+
+  test('different reminder text at the same minute is not a duplicate', async () => {
+    const projectDir = makeProjectDir()
+    const now = new Date('2026-05-15T14:00:00.000Z')
+    const at = new Date('2026-05-15T14:02:00.000Z')
+
+    let idCounter = 0
+    const generateId = () => `id${++idCounter}`
+
+    await scheduleReminder(
+      { projectDir, text: 'Drink water.', at },
+      { now, generateId },
+    )
+    const second = await scheduleReminder(
+      { projectDir, text: 'Stretch.', at },
+      { now, generateId },
+    )
+
+    expect(second.status).toBe('scheduled')
+    expect(second.id).toBe('id2')
+
+    const file = readScheduledTasks(projectDir)
+    expect(file.tasks.map(t => t.prompt).sort()).toEqual([
+      'Drink water.',
+      'Stretch.',
+    ])
+  })
+
+  test('rejects reminders more than a year out (cannot be expressed as 5-field cron)', async () => {
+    const projectDir = makeProjectDir()
+    const now = new Date('2026-05-15T14:00:00.000Z')
+    // Two years out — a 5-field cron cannot distinguish from one year out.
+    const at = new Date('2028-05-15T14:02:00.000Z')
+
+    await expect(
+      scheduleReminder({ projectDir, text: 'Annual.', at }, { now }),
+    ).rejects.toMatchObject({
+      code: 'unreachable_time',
+    })
+  })
+
+  test('rounds sub-minute precision up to the next whole minute', async () => {
+    const projectDir = makeProjectDir()
+    const now = new Date('2026-05-15T14:00:00.000Z')
+    // 14:02:45 → rounds to 14:03:00
+    const at = new Date('2026-05-15T14:02:45.000Z')
+
+    const result = await scheduleReminder(
+      { projectDir, text: 'Ping.', at },
+      { now, generateId: () => 'rounded1' },
+    )
+
+    expect(result.at.getUTCMinutes()).toBe(3)
+    expect(result.at.getUTCSeconds()).toBe(0)
+    expect(result.at.getUTCMilliseconds()).toBe(0)
+  })
+})

--- a/src 2/services/reminders/reminderScheduler.ts
+++ b/src 2/services/reminders/reminderScheduler.ts
@@ -1,0 +1,110 @@
+// Core reminder-scheduling layer for KAIROS.
+//
+// Turns a validated reminder request into exactly one durable one-shot
+// entry in <projectDir>/.claude/scheduled_tasks.json. The daemon already
+// knows how to fire durable cron tasks, so this service only needs to
+// write the task file — it does not maintain a parallel scheduler.
+//
+// Deduplication: a second request for the same project + same fire minute
+// + same text is reported as a duplicate and does NOT append a second
+// pending entry. "Same fire minute" is compared via the generated cron
+// string, which is minute-resolution by construction.
+
+import { randomUUID } from 'node:crypto'
+import {
+  type CronTask,
+  getCronFilePath,
+  readCronTasks,
+  writeCronTasks,
+} from '../../utils/cronTasks.js'
+import {
+  type ReminderRequest,
+  type ValidatedReminder,
+  validateReminder,
+} from './reminderValidation.js'
+
+export type ScheduleReminderResult = {
+  /**
+   * `scheduled` — a new durable one-shot task was written.
+   * `duplicate` — an equivalent pending task already existed; no-op write.
+   */
+  status: 'scheduled' | 'duplicate'
+  id: string
+  cron: string
+  at: Date
+  text: string
+  projectDir: string
+  filePath: string
+}
+
+export type ScheduleReminderDeps = {
+  now?: Date
+  /** Injected for tests; defaults to randomUUID().slice(0,8) for parity with addCronTask. */
+  generateId?: () => string
+}
+
+function defaultGenerateId(): string {
+  return randomUUID().slice(0, 8)
+}
+
+function findDuplicate(
+  tasks: CronTask[],
+  normalized: ValidatedReminder,
+): CronTask | undefined {
+  return tasks.find(
+    t => !t.recurring && t.cron === normalized.cron && t.prompt === normalized.text,
+  )
+}
+
+/**
+ * Validate the request, check for an existing equivalent pending reminder,
+ * and — if none exists — append a new durable one-shot task to the
+ * project's scheduled_tasks.json. Returns the task id and enough context
+ * for the caller to render a confirmation message.
+ *
+ * Throws {@link import('./reminderValidation').ReminderValidationError} on
+ * bad input; all I/O errors surface from the underlying fs calls.
+ */
+export async function scheduleReminder(
+  req: ReminderRequest,
+  deps: ScheduleReminderDeps = {},
+): Promise<ScheduleReminderResult> {
+  const now = deps.now ?? new Date()
+  const generateId = deps.generateId ?? defaultGenerateId
+  const normalized = validateReminder(req, now)
+
+  const existing = await readCronTasks(normalized.projectDir)
+  const duplicate = findDuplicate(existing, normalized)
+  const filePath = getCronFilePath(normalized.projectDir)
+
+  if (duplicate) {
+    return {
+      status: 'duplicate',
+      id: duplicate.id,
+      cron: normalized.cron,
+      at: normalized.at,
+      text: normalized.text,
+      projectDir: normalized.projectDir,
+      filePath,
+    }
+  }
+
+  const id = generateId()
+  const task: CronTask = {
+    id,
+    cron: normalized.cron,
+    prompt: normalized.text,
+    createdAt: now.getTime(),
+  }
+  await writeCronTasks([...existing, task], normalized.projectDir)
+
+  return {
+    status: 'scheduled',
+    id,
+    cron: normalized.cron,
+    at: normalized.at,
+    text: normalized.text,
+    projectDir: normalized.projectDir,
+    filePath,
+  }
+}

--- a/src 2/services/reminders/reminderValidation.ts
+++ b/src 2/services/reminders/reminderValidation.ts
@@ -1,0 +1,155 @@
+// Pure validation + normalization for KAIROS reminder requests.
+//
+// A reminder request names a target wall-clock time and reminder text. The
+// daemon only knows how to fire durable one-shot cron tasks, so validation
+// has two jobs:
+//
+//   1. Reject inputs the daemon can't act on: empty text, missing project,
+//      unparseable time, time in the past, time so far out the 5-field cron
+//      can't uniquely identify it.
+//   2. Normalize the surviving request into { text, at, cron } so the
+//      scheduler can write it verbatim and the deduper can compare by
+//      cron string equality.
+//
+// The validator does NOT touch disk. reminderScheduler.ts owns all I/O.
+
+import { nextCronRunMs } from '../../utils/cronTasks.js'
+
+export type ReminderRequest = {
+  projectDir: string
+  text: string
+  at: Date | number | string
+}
+
+export type ValidatedReminder = {
+  projectDir: string
+  text: string
+  at: Date
+  cron: string
+}
+
+export type ReminderErrorCode =
+  | 'invalid_project'
+  | 'empty_text'
+  | 'invalid_time'
+  | 'past_time'
+  | 'unreachable_time'
+
+export class ReminderValidationError extends Error {
+  readonly code: ReminderErrorCode
+  constructor(code: ReminderErrorCode, message: string) {
+    super(message)
+    this.name = 'ReminderValidationError'
+    this.code = code
+  }
+}
+
+function toDate(at: Date | number | string): Date | null {
+  if (at instanceof Date) {
+    return Number.isFinite(at.getTime()) ? new Date(at.getTime()) : null
+  }
+  if (typeof at === 'number') {
+    if (!Number.isFinite(at)) return null
+    return new Date(at)
+  }
+  if (typeof at === 'string') {
+    const d = new Date(at)
+    return Number.isFinite(d.getTime()) ? d : null
+  }
+  return null
+}
+
+// Cron resolution is whole minutes. Round the target up so a reminder for
+// 14:30:45 fires at 14:31:00 rather than waiting a year for the :30 mark.
+function roundUpToMinute(d: Date): Date {
+  if (d.getSeconds() === 0 && d.getMilliseconds() === 0) {
+    return new Date(d.getTime())
+  }
+  const r = new Date(d.getTime())
+  r.setSeconds(0, 0)
+  r.setMinutes(r.getMinutes() + 1)
+  return r
+}
+
+/**
+ * Build the one-shot cron string that fires once at exactly `at`.
+ *
+ * Pins minute + hour + dayOfMonth + month; leaves dayOfWeek as wildcard so
+ * standard "either" semantics reduce to the single dom/month match.
+ */
+export function toOneShotCron(at: Date): string {
+  return [
+    at.getMinutes(),
+    at.getHours(),
+    at.getDate(),
+    at.getMonth() + 1,
+    '*',
+  ].join(' ')
+}
+
+/**
+ * Validate and normalize a reminder request. Throws {@link ReminderValidationError}
+ * with a specific code for each rejection reason so the caller can show the
+ * user a precise message.
+ *
+ * `now` is injectable for tests.
+ */
+export function validateReminder(
+  req: ReminderRequest,
+  now: Date = new Date(),
+): ValidatedReminder {
+  if (typeof req.projectDir !== 'string' || req.projectDir.length === 0) {
+    throw new ReminderValidationError(
+      'invalid_project',
+      'Reminder requires a non-empty projectDir.',
+    )
+  }
+
+  const text = typeof req.text === 'string' ? req.text.trim() : ''
+  if (text.length === 0) {
+    throw new ReminderValidationError(
+      'empty_text',
+      'Reminder text must not be empty.',
+    )
+  }
+
+  const rawAt = toDate(req.at)
+  if (rawAt === null) {
+    throw new ReminderValidationError(
+      'invalid_time',
+      `Could not parse reminder time: ${String(req.at)}`,
+    )
+  }
+
+  const at = roundUpToMinute(rawAt)
+  if (at.getTime() <= now.getTime()) {
+    throw new ReminderValidationError(
+      'past_time',
+      `Reminder time ${at.toISOString()} is not in the future (now ${now.toISOString()}).`,
+    )
+  }
+
+  const cron = toOneShotCron(at)
+
+  // 5-field cron has no year, so we can only represent a target uniquely
+  // within roughly one trip around the calendar. Verify that the cron
+  // scheduler, asked "when does this fire next from now", lands on the
+  // exact minute we asked for. This catches both >1-year targets (would
+  // fire a year early) and Feb-29-in-a-non-leap-year style mismatches.
+  const computed = nextCronRunMs(cron, now.getTime())
+  if (computed === null || computed !== at.getTime()) {
+    throw new ReminderValidationError(
+      'unreachable_time',
+      `Reminder time ${at.toISOString()} can't be expressed as a one-shot cron from now (nearest fire: ${
+        computed === null ? 'never' : new Date(computed).toISOString()
+      }). Pick a target within the next year.`,
+    )
+  }
+
+  return {
+    projectDir: req.projectDir,
+    text,
+    at,
+    cron,
+  }
+}


### PR DESCRIPTION
## Summary

Core reminder-scheduling layer for KAIROS — turns a validated reminder request into exactly one durable one-shot entry in `<projectDir>/.claude/scheduled_tasks.json`. The daemon already knows how to fire durable cron tasks, so there is no parallel scheduler.

Files:

- `src 2/services/reminders/reminderValidation.ts` — pure validation: rejects empty text/project, unparseable times, past times, and targets the 5-field cron cannot uniquely identify (>1 year out).
- `src 2/services/reminders/reminderScheduler.ts` — writes the durable one-shot task and dedupes equivalent pending reminders by `(projectDir, cron, text)`.
- `src 2/services/reminders/reminderScheduler.test.ts` — bun tests covering happy path, past-time, invalid text/time, duplicate suppression, distinct-text-same-minute, >1-year horizon, sub-minute rounding.

Closes #8.

## Design notes

- Deduplication is minute-resolution by construction: the generated cron is `M H DoM Mon *` pinned to the target, so string equality of the cron is equivalent to "same project, same time" for the comparison `same project + same time + same text`.
- Sub-minute precision rounds up (`14:02:45` → `14:03:00`) so the scheduler's strictly-after-next-minute semantics don't silently push a reminder a year out.
- `validateReminder` also verifies `nextCronRunMs(cron, now)` lands on the rounded target to catch cases where the pinned-date cron would fire earlier than intended (e.g. Feb-29-in-a-non-leap-year, targets >1y out).
- Scheduler uses `readCronTasks(dir)` + `writeCronTasks(tasks, dir)` with the explicit project root so it never touches bootstrap state — callable from the daemon, tests, or future leaves.

## Verification

- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun test services/reminders/reminderScheduler.test.ts` — 9 pass, 0 fail, 29 expect() calls
- Acceptance-criteria coverage:
  - [x] Creating a reminder via `scheduleReminder` writes a durable one-shot entry (`'writes a durable one-shot task for a future reminder'`)
  - [x] Duplicate requests do not create duplicate pending tasks (`'does not create a duplicate when the same reminder is requested twice'`)
  - [x] Invalid/past times are rejected clearly (`'rejects a reminder whose target time is in the past'`, `'rejects a reminder for the current minute as past'`, `'rejects unparseable target times'`, `'rejects empty reminder text'`, `'rejects reminders more than a year out'`)

## Trunk guard

Only touches `src 2/services/reminders/**` — no trunk-listed paths. `trunk-guard` should pass without the override label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)