### PR TITLE
feat(tools): add optional browser-harness adapter (#20)

### DIFF
--- a/src 2/tools/BrowserHarnessTool/BrowserHarnessTool.test.ts
+++ b/src 2/tools/BrowserHarnessTool/BrowserHarnessTool.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import { BrowserHarnessTool } from './BrowserHarnessTool.js'
+import {
+  BrowserHarnessError,
+  DEFAULT_BROWSER_HARNESS_COMMAND,
+  getBrowserHarnessSettings,
+  resolveBrowserHarnessCommand,
+  runBrowserHarnessScript,
+} from './adapter.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  resetSettingsCache()
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeSettingsDir(settings: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'browser-harness-test-'))
+  TEMP_DIRS.push(dir)
+  writeFileSync(join(dir, 'settings.json'), JSON.stringify(settings))
+  return dir
+}
+
+describe('browser-harness adapter', () => {
+  test('throws a clear error when integration is disabled', () => {
+    process.env.CLAUDE_CONFIG_DIR = makeSettingsDir({})
+
+    expect(() => getBrowserHarnessSettings()).toThrow(
+      'Browser Harness integration is not enabled. Set `browserHarness.enabled` to `true` in your settings after installing https://github.com/browser-use/browser-harness.',
+    )
+  })
+
+  test('throws when the browser-harness executable cannot be located', () => {
+    const whichImpl = mock((_: string) => null)
+
+    expect(() =>
+      resolveBrowserHarnessCommand(
+        { enabled: true },
+        { whichSync: whichImpl },
+      ),
+    ).toThrow(BrowserHarnessError)
+    expect(whichImpl).toHaveBeenCalledWith(DEFAULT_BROWSER_HARNESS_COMMAND)
+  })
+
+  test('uses configured command when overridden in settings', () => {
+    const whichImpl = mock((cmd: string) =>
+      cmd === '/opt/bin/my-harness' ? '/opt/bin/my-harness' : null,
+    )
+
+    const resolved = resolveBrowserHarnessCommand(
+      { enabled: true, command: '/opt/bin/my-harness' },
+      { whichSync: whichImpl },
+    )
+
+    expect(resolved).toBe('/opt/bin/my-harness')
+    expect(whichImpl).toHaveBeenCalledWith('/opt/bin/my-harness')
+  })
+
+  test('spawns browser-harness with the script on stdin on the happy path', async () => {
+    process.env.CLAUDE_CONFIG_DIR = makeSettingsDir({
+      browserHarness: {
+        enabled: true,
+        env: { BU_NAME: 'test-session' },
+        timeoutMs: 30_000,
+      },
+    })
+
+    const execImpl = mock(
+      async (
+        file: string,
+        args: string[],
+        options: {
+          useCwd?: boolean
+          timeout?: number
+          stdin?: string
+          input?: string
+          env?: NodeJS.ProcessEnv
+        },
+      ) => {
+        expect(file).toBe('/usr/local/bin/browser-harness')
+        expect(args).toEqual([])
+        expect(options.useCwd).toBe(false)
+        expect(options.timeout).toBe(30_000)
+        expect(options.stdin).toBe('pipe')
+        expect(options.input).toBe('print(page_info())\n')
+        expect(options.env?.BU_NAME).toBe('test-session')
+        return {
+          stdout: '{"url": "https://example.com"}',
+          stderr: '',
+          code: 0,
+        }
+      },
+    )
+
+    const result = await runBrowserHarnessScript(
+      { script: 'print(page_info())\n' },
+      {
+        whichSync: () => '/usr/local/bin/browser-harness',
+        execFileNoThrow: execImpl,
+      },
+    )
+
+    expect(execImpl).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe('{"url": "https://example.com"}')
+    expect(result.command).toBe('/usr/local/bin/browser-harness')
+  })
+
+  test('reports failure details when the harness exits non-zero', async () => {
+    process.env.CLAUDE_CONFIG_DIR = makeSettingsDir({
+      browserHarness: { enabled: true },
+    })
+
+    const execImpl = mock(async () => ({
+      stdout: '',
+      stderr: 'Traceback: harness daemon not attached',
+      code: 1,
+    }))
+
+    const result = await runBrowserHarnessScript(
+      { script: 'goto("https://example.com")\n' },
+      {
+        whichSync: () => '/usr/local/bin/browser-harness',
+        execFileNoThrow: execImpl,
+      },
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('harness daemon not attached')
+    expect(result.error).toContain('exited with code 1')
+  })
+
+  test('rejects an empty script before invoking the CLI', async () => {
+    process.env.CLAUDE_CONFIG_DIR = makeSettingsDir({
+      browserHarness: { enabled: true },
+    })
+
+    const execImpl = mock(async () => ({
+      stdout: '',
+      stderr: '',
+      code: 0,
+    }))
+
+    await expect(
+      runBrowserHarnessScript(
+        { script: '   ' },
+        {
+          whichSync: () => '/usr/local/bin/browser-harness',
+          execFileNoThrow: execImpl,
+        },
+      ),
+    ).rejects.toThrow('`script` must be a non-empty Python payload')
+    expect(execImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('BrowserHarnessTool', () => {
+  test('returns a failure result with setup guidance when disabled', async () => {
+    process.env.CLAUDE_CONFIG_DIR = makeSettingsDir({})
+
+    const result = await BrowserHarnessTool.call(
+      { script: 'print(page_info())' },
+      // BuildTool.call accepts an optional context; tests pass undefined via cast.
+      // @ts-expect-error — test-only invocation without tool context
+      undefined,
+    )
+
+    expect(result.data.success).toBe(false)
+    expect(result.data.error).toContain(
+      'Browser Harness integration is not enabled',
+    )
+    expect(result.data.message).toContain(
+      'Browser Harness integration is not enabled',
+    )
+  })
+
+  test('rejects an empty script via validateInput', async () => {
+    const validation = await BrowserHarnessTool.validateInput!(
+      { script: '   ' },
+      // @ts-expect-error — test-only invocation without tool context
+      undefined,
+    )
+
+    expect(validation.result).toBe(false)
+    if (validation.result === false) {
+      expect(validation.message).toContain('non-empty')
+    }
+  })
+})

--- a/src 2/tools/BrowserHarnessTool/BrowserHarnessTool.ts
+++ b/src 2/tools/BrowserHarnessTool/BrowserHarnessTool.ts
@@ -1,0 +1,195 @@
+import { z } from 'zod/v4'
+import type { ValidationResult } from '../../Tool.js'
+import { buildTool, type ToolDef } from '../../Tool.js'
+import { lazySchema } from '../../utils/lazySchema.js'
+import {
+  BrowserHarnessError,
+  runBrowserHarnessScript,
+} from './adapter.js'
+import {
+  BROWSER_HARNESS_TOOL_NAME,
+  BROWSER_HARNESS_TOOL_PROMPT,
+  DESCRIPTION,
+} from './prompt.js'
+
+const MAX_SCRIPT_CHARS = 64 * 1024
+
+const inputSchema = lazySchema(() =>
+  z.strictObject({
+    script: z
+      .string()
+      .describe(
+        'Python script piped to `browser-harness` on stdin. Helpers like `new_tab`, `goto`, and `page_info` are pre-imported.',
+      ),
+    timeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Optional per-call timeout override in milliseconds. Defaults to 5 minutes.',
+      ),
+  }),
+)
+type InputSchema = ReturnType<typeof inputSchema>
+
+const outputSchema = lazySchema(() =>
+  z.object({
+    success: z.boolean(),
+    exitCode: z.number(),
+    stdout: z.string(),
+    stderr: z.string(),
+    command: z.string().optional(),
+    durationMs: z.number().optional(),
+    message: z.string(),
+    error: z.string().optional(),
+  }),
+)
+type OutputSchema = ReturnType<typeof outputSchema>
+export type Output = z.infer<OutputSchema>
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) {
+    return text
+  }
+  return `${text.slice(0, max)}\n…(truncated ${text.length - max} chars)`
+}
+
+function formatSuccessMessage(stdout: string, stderr: string): string {
+  const parts: string[] = []
+  const trimmedOut = stdout.trim()
+  const trimmedErr = stderr.trim()
+  if (trimmedOut.length > 0) {
+    parts.push(truncate(trimmedOut, 4000))
+  }
+  if (trimmedErr.length > 0) {
+    parts.push(`stderr:\n${truncate(trimmedErr, 2000)}`)
+  }
+  if (parts.length === 0) {
+    return 'browser-harness script completed with no output.'
+  }
+  return parts.join('\n\n')
+}
+
+function formatFailureMessage(
+  exitCode: number,
+  stderr: string,
+  fallback: string,
+): string {
+  const trimmed = stderr.trim()
+  const suffix = trimmed.length > 0 ? `\n${truncate(trimmed, 4000)}` : ''
+  return `browser-harness failed (exit ${exitCode}): ${fallback}${suffix}`
+}
+
+function validateInputOrError(input: {
+  script: string
+  timeoutMs?: number
+}): ValidationResult {
+  if (typeof input.script !== 'string' || input.script.trim() === '') {
+    return {
+      result: false,
+      message: '`script` must be a non-empty Python payload.',
+      errorCode: 1,
+    }
+  }
+  if (input.script.length > MAX_SCRIPT_CHARS) {
+    return {
+      result: false,
+      message: `\`script\` exceeds the ${MAX_SCRIPT_CHARS}-character cap.`,
+      errorCode: 1,
+    }
+  }
+  return { result: true }
+}
+
+export const BrowserHarnessTool = buildTool({
+  name: BROWSER_HARNESS_TOOL_NAME,
+  searchHint: 'run a browser-harness python script against the real browser',
+  maxResultSizeChars: 20_000,
+  async description() {
+    return DESCRIPTION
+  },
+  async prompt() {
+    return BROWSER_HARNESS_TOOL_PROMPT
+  },
+  get inputSchema(): InputSchema {
+    return inputSchema()
+  },
+  get outputSchema(): OutputSchema {
+    return outputSchema()
+  },
+  isConcurrencySafe() {
+    return false
+  },
+  isReadOnly() {
+    return false
+  },
+  toAutoClassifierInput(input) {
+    return input.script
+  },
+  async validateInput(input) {
+    return validateInputOrError(input)
+  },
+  renderToolUseMessage() {
+    return 'Running browser-harness script'
+  },
+  mapToolResultToToolResultBlockParam(output, toolUseID) {
+    return {
+      tool_use_id: toolUseID,
+      type: 'tool_result',
+      content: output.message,
+      ...(output.success ? {} : { is_error: true }),
+    }
+  },
+  async call({ script, timeoutMs }) {
+    try {
+      const result = await runBrowserHarnessScript({ script, timeoutMs })
+      if (result.success) {
+        return {
+          data: {
+            success: true,
+            exitCode: result.exitCode,
+            stdout: result.stdout,
+            stderr: result.stderr,
+            command: result.command,
+            durationMs: result.durationMs,
+            message: formatSuccessMessage(result.stdout, result.stderr),
+          },
+        }
+      }
+      return {
+        data: {
+          success: false,
+          exitCode: result.exitCode,
+          stdout: result.stdout,
+          stderr: result.stderr,
+          command: result.command,
+          durationMs: result.durationMs,
+          error: result.error,
+          message: formatFailureMessage(
+            result.exitCode,
+            result.stderr,
+            result.error || 'see stderr',
+          ),
+        },
+      }
+    } catch (error) {
+      const message =
+        error instanceof BrowserHarnessError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : 'browser-harness invocation failed.'
+      return {
+        data: {
+          success: false,
+          exitCode: -1,
+          stdout: '',
+          stderr: '',
+          error: message,
+          message,
+        },
+      }
+    }
+  },
+} satisfies ToolDef<InputSchema, Output>)

--- a/src 2/tools/BrowserHarnessTool/adapter.ts
+++ b/src 2/tools/BrowserHarnessTool/adapter.ts
@@ -1,0 +1,149 @@
+import { execFileNoThrow } from '../../utils/execFileNoThrow.js'
+import { getSettings_DEPRECATED } from '../../utils/settings/settings.js'
+import { whichSync } from '../../utils/which.js'
+
+export const DEFAULT_BROWSER_HARNESS_COMMAND = 'browser-harness'
+export const DEFAULT_BROWSER_HARNESS_TIMEOUT_MS = 5 * 60 * 1000
+
+export type BrowserHarnessSettings = {
+  enabled?: boolean
+  command?: string
+  env?: Record<string, string>
+  timeoutMs?: number
+}
+
+type SettingsShape = {
+  browserHarness?: BrowserHarnessSettings
+}
+
+export type BrowserHarnessExecResult = {
+  stdout: string
+  stderr: string
+  code: number
+  error?: string
+}
+
+export type BrowserHarnessDependencies = {
+  getSettings?: () => SettingsShape
+  whichSync?: (cmd: string) => string | null
+  execFileNoThrow?: (
+    file: string,
+    args: string[],
+    options: {
+      useCwd?: boolean
+      timeout?: number
+      stdin?: 'pipe' | 'ignore' | 'inherit'
+      input?: string
+      env?: NodeJS.ProcessEnv
+      preserveOutputOnError?: boolean
+    },
+  ) => Promise<BrowserHarnessExecResult>
+}
+
+export type BrowserHarnessRunInput = {
+  script: string
+  timeoutMs?: number
+}
+
+export type BrowserHarnessRunResult = {
+  success: boolean
+  exitCode: number
+  stdout: string
+  stderr: string
+  command: string
+  durationMs: number
+  error?: string
+}
+
+export class BrowserHarnessError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BrowserHarnessError'
+  }
+}
+
+function readSettings(deps: BrowserHarnessDependencies): SettingsShape {
+  const getter = deps.getSettings ?? getSettings_DEPRECATED
+  return (getter() || {}) as SettingsShape
+}
+
+export function getBrowserHarnessSettings(
+  deps: BrowserHarnessDependencies = {},
+): BrowserHarnessSettings {
+  const settings = readSettings(deps).browserHarness
+  if (!settings?.enabled) {
+    throw new BrowserHarnessError(
+      'Browser Harness integration is not enabled. Set `browserHarness.enabled` to `true` in your settings after installing https://github.com/browser-use/browser-harness.',
+    )
+  }
+  return settings
+}
+
+export function resolveBrowserHarnessCommand(
+  settings: BrowserHarnessSettings,
+  deps: BrowserHarnessDependencies = {},
+): string {
+  const command = settings.command?.trim() || DEFAULT_BROWSER_HARNESS_COMMAND
+  const whichImpl = deps.whichSync ?? whichSync
+  const resolved = whichImpl(command)
+  if (!resolved) {
+    throw new BrowserHarnessError(
+      `Could not find the \`${command}\` executable on PATH. Install Browser Harness with \`uv tool install -e .\` inside a clone of https://github.com/browser-use/browser-harness, or set \`browserHarness.command\` to the absolute path of your installed binary.`,
+    )
+  }
+  return resolved
+}
+
+function buildEnv(
+  extra: Record<string, string> | undefined,
+): NodeJS.ProcessEnv | undefined {
+  if (!extra || Object.keys(extra).length === 0) {
+    return undefined
+  }
+  return { ...process.env, ...extra }
+}
+
+export async function runBrowserHarnessScript(
+  input: BrowserHarnessRunInput,
+  deps: BrowserHarnessDependencies = {},
+): Promise<BrowserHarnessRunResult> {
+  const script = input.script
+  if (typeof script !== 'string' || script.trim() === '') {
+    throw new BrowserHarnessError(
+      '`script` must be a non-empty Python payload for browser-harness.',
+    )
+  }
+
+  const settings = getBrowserHarnessSettings(deps)
+  const resolvedCommand = resolveBrowserHarnessCommand(settings, deps)
+  const timeout =
+    input.timeoutMs ?? settings.timeoutMs ?? DEFAULT_BROWSER_HARNESS_TIMEOUT_MS
+  const execImpl = deps.execFileNoThrow ?? execFileNoThrow
+
+  const startedAt = Date.now()
+  const result = await execImpl(resolvedCommand, [], {
+    useCwd: false,
+    timeout,
+    stdin: 'pipe',
+    input: script,
+    env: buildEnv(settings.env),
+    preserveOutputOnError: true,
+  })
+  const durationMs = Date.now() - startedAt
+
+  const success = result.code === 0 && !result.error
+  return {
+    success,
+    exitCode: result.code,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    command: resolvedCommand,
+    durationMs,
+    error: success
+      ? undefined
+      : result.error ||
+        `browser-harness exited with code ${result.code}. stderr: ${
+          result.stderr?.trim() || '(empty)'
+        }`,
+  }
+}

--- a/src 2/tools/BrowserHarnessTool/prompt.ts
+++ b/src 2/tools/BrowserHarnessTool/prompt.ts
@@ -1,0 +1,17 @@
+export const BROWSER_HARNESS_TOOL_NAME = 'BrowserHarness'
+
+export const DESCRIPTION =
+  'Execute a browser-harness script against the user\'s real browser (opt-in)'
+
+export const BROWSER_HARNESS_TOOL_PROMPT = `Run a Python script through the locally-installed \`browser-harness\` CLI.
+
+Browser Harness (https://github.com/browser-use/browser-harness) attaches to the user's running Chrome over CDP. This tool is a thin, explicit opt-in bridge: it spawns \`browser-harness\`, pipes \`script\` to its stdin, and returns the captured stdout/stderr.
+
+Preconditions — all must hold or the tool will error out without touching the browser:
+- \`browserHarness.enabled\` is \`true\` in settings.
+- The \`browser-harness\` command (or the configured \`browserHarness.command\`) is on \`$PATH\`. Install via \`git clone https://github.com/browser-use/browser-harness && cd browser-harness && uv tool install -e .\`.
+- The user has completed the one-time Chrome remote-debugging setup described in the browser-harness install guide.
+
+\`script\` is the full Python payload that would normally be piped into \`browser-harness <<'PY' ... PY\`. Helpers like \`new_tab\`, \`goto\`, \`page_info\`, and \`wait_for_load\` are pre-imported by the harness.
+
+Use this tool only when a real browser session is required (logged-in sites, uploads, messy UI flows) — prefer normal HTTP tools otherwise. The tool never activates the browser implicitly; the opt-in settings flag is the single control.`


### PR DESCRIPTION
Closes #20

## Summary
- Add `BrowserHarnessTool` under `src 2/tools/BrowserHarnessTool/` as a **standalone, opt-in** adapter over the [browser-use/browser-harness](https://github.com/browser-use/browser-harness) CLI.
- Gated behind `browserHarness.enabled` in settings; fails loudly with setup guidance when disabled or when the `browser-harness` binary is not on `PATH`.
- **Leaf-only change**: no edits to `tools.ts`, permission plumbing, or other trunk-guarded files. Wiring the tool into the dispatch registry is a follow-up that will require a `trunk-change-approved` review.

## Scope (from issue #20)
- [x] explicit install/setup flow documented in the tool prompt
- [x] explicit settings opt-in (`browserHarness.enabled`)
- [x] one narrow entrypoint (`BrowserHarness` tool + `runBrowserHarnessScript` adapter)
- [x] zero behavior change for users who do not opt in (no registry change yet)

## Files added
- `src 2/tools/BrowserHarnessTool/prompt.ts` — tool name, description, model prompt with preconditions + install command.
- `src 2/tools/BrowserHarnessTool/adapter.ts` — settings read, binary discovery, spawn logic, error class. Dependency-injected for tests.
- `src 2/tools/BrowserHarnessTool/BrowserHarnessTool.ts` — `buildTool(...)` wrapper: zod input (`script`, optional `timeoutMs`), `validateInput` rejecting empty payloads, success/failure message formatting, `isConcurrencySafe: false` (browser is shared state).
- `src 2/tools/BrowserHarnessTool/BrowserHarnessTool.test.ts` — 8 tests covering disabled state, missing binary, configured override, happy-path stdin pipe + env, non-zero exit, empty-script rejection, and tool-level failure mapping.

## Trust model
- Real browser control is inert until the user both:
  1. installs `browser-harness` (`uv tool install -e .`), and
  2. sets `browserHarness.enabled: true` in their settings.
- When those conditions are not met the adapter throws `BrowserHarnessError` with a one-shot remediation message before anything is spawned.
- `script` is passed verbatim on stdin, matching the documented `browser-harness <<'PY' ... PY` contract — this tool is a transparent bridge, not a re-implementation.

## Verification

**Automated (green):**
- `bun test tools/BrowserHarnessTool/BrowserHarnessTool.test.ts` → **8 pass, 0 fail**
- `./node_modules/.bin/eslint tools/BrowserHarnessTool/` → clean
- `bun run typecheck` → clean (pipeline script runs `tsc --noEmit` against `types/employee.ts`; scoped tsc on the new files has only the pre-existing `bun:test` module warning shared with other `*.test.ts` files in the repo)
- `bun run lint` → clean

**Manual fail-closed smoke tests (green):**
- With no `browserHarness` key in settings → adapter refuses with: *"Browser Harness integration is not enabled. Set \`browserHarness.enabled\` to \`true\` ..."*. No subprocess spawned.
- With `browserHarness.enabled: true` but a bogus `command` path → adapter refuses with: *"Could not find the \`/nope/missing\` executable on PATH. Install Browser Harness with \`uv tool install -e .\` ..."*. No subprocess spawned.

**Real-browser end-to-end demo — deferred to follow-up.** Attempted against a fresh `browser-harness` install locally; the upstream harness could not reliably drive Chrome on the test machine (both `browser-harness <<'PY' print(page_info()) PY` and `new_tab(...)` calls hang with the daemon reporting alive but tabs staying on `about:blank`, matching the \`attach failed: enable Runtime\` retry path in \`browser-harness --setup\`). Since this reproduces **without our adapter in the loop**, it is an upstream-setup issue, not a correctness issue in this PR. The acceptance-criterion screencast will land in the follow-up PR that also wires the tool into `tools.ts` — by then the harness install will need to be working anyway for registry testing.

## Follow-ups (explicitly out of scope per issue #20)
- Register the tool in `src 2/tools.ts` behind a feature flag (requires `trunk-change-approved` label).
- Real-browser screencast demonstrating the end-to-end task (blocked on upstream browser-harness install working locally — not a PR correctness issue).
- Richer permission/trust UX and KAIROS-aware browser tasks per the issue's explicit non-goals.

## Test plan
- [ ] Reviewer confirms no trunk-guarded files were touched (see \`CODEOWNERS\` + trunk-guard workflow).
- [ ] Reviewer confirms the adapter refuses to run when \`browserHarness.enabled\` is not \`true\`.
- [ ] Reviewer confirms the adapter refuses to run when the binary is not resolvable via \`which\`.
- [ ] \`bun test tools/BrowserHarnessTool/BrowserHarnessTool.test.ts\` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)