### PR TITLE
feat(kairos): Phase 3 child runner + cost tracker + cap-hit path

### DIFF
--- a/src 2/daemon/kairos/capHit.integration.test.ts
+++ b/src 2/daemon/kairos/capHit.integration.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { CronTask } from '../../utils/cronTasks.js'
+import type {
+  ChildLauncher,
+  ChildLauncherParams,
+  ChildStreamMessage,
+} from './childRunner.js'
+import { createCostTracker } from './costTracker.js'
+import { createStateWriter } from './stateWriter.js'
+import { makeCapHitHandler, makeRunFiredTask } from './worker.js'
+import {
+  getKairosGlobalEventsPath,
+  getKairosPausePath,
+  getProjectKairosCostsPath,
+  getProjectKairosEventsPath,
+  getKairosGlobalCostsPath,
+} from './paths.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function makeTask(id: string, prompt = 'do work'): CronTask {
+  return {
+    id,
+    cron: '* * * * *',
+    prompt,
+    createdAt: Date.now(),
+  }
+}
+
+function makeLauncher(messages: ChildStreamMessage[]): {
+  launcher: ChildLauncher
+  calls: ChildLauncherParams[]
+} {
+  const calls: ChildLauncherParams[] = []
+  const launcher: ChildLauncher = async function* (params) {
+    calls.push(params)
+    for (const msg of messages) yield msg
+  }
+  return { launcher, calls }
+}
+
+describe('cap-hit integration', () => {
+  test('fired task above cap writes daemon-originated notice, sets pause, no recursive child run', async () => {
+    const configDir = makeTempDir('kairos-cap-')
+    const projectDir = makeTempDir('kairos-cap-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+
+    const costTracker = createCostTracker({
+      caps: { globalUSD: 0.05 },
+      stateWriter,
+    })
+
+    const { launcher, calls } = makeLauncher([
+      { type: 'system', subtype: 'init', tools: ['Read'], session_id: 's1' },
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        duration_ms: 100,
+        total_cost_usd: 0.1, // exceeds 0.05 cap
+        session_id: 's1',
+      },
+    ])
+
+    const now = () => new Date('2026-04-22T12:00:00.000Z')
+    const handleCapHit = makeCapHitHandler(stateWriter, now)
+    const runFiredTask = makeRunFiredTask({
+      projectDir,
+      stateWriter,
+      costTracker,
+      launcher,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 1,
+      timeoutMs: 5000,
+      handleCapHit,
+      now,
+    })
+
+    const outcome = await runFiredTask(makeTask('t-over'), 'event')
+
+    expect(outcome.ok).toBe(true)
+    expect(outcome.paused).toBe(true)
+    expect(calls).toHaveLength(1) // no recursive notification run
+
+    // Pause flag set by the daemon itself.
+    expect(existsSync(getKairosPausePath())).toBe(true)
+    const pause = JSON.parse(readFileSync(getKairosPausePath(), 'utf8'))
+    expect(pause.paused).toBe(true)
+    expect(pause.reason).toBe('cap_hit')
+    expect(pause.scope).toBe('global')
+    expect(pause.source).toBe('daemon')
+
+    // Global events.jsonl contains the daemon-originated notice.
+    const globalEvents = readFileSync(getKairosGlobalEventsPath(), 'utf8')
+    expect(globalEvents).toContain('"kind":"cap_hit_notice"')
+    expect(globalEvents).toContain('"source":"daemon"')
+
+    // Per-project events.jsonl has the child-run surfaced result too.
+    const projectEvents = readFileSync(
+      getProjectKairosEventsPath(projectDir),
+      'utf8',
+    )
+    expect(projectEvents).toContain('"kind":"child_started"')
+    expect(projectEvents).toContain('"kind":"child_finished"')
+    expect(projectEvents).toContain('"kind":"cap_hit_notice"')
+
+    // Costs are recorded at both levels.
+    const globalCosts = JSON.parse(
+      readFileSync(getKairosGlobalCostsPath(), 'utf8'),
+    )
+    const projectCosts = JSON.parse(
+      readFileSync(getProjectKairosCostsPath(projectDir), 'utf8'),
+    )
+    expect(globalCosts.totalUSD).toBeCloseTo(0.1, 5)
+    expect(globalCosts.runs).toBe(1)
+    expect(projectCosts.totalUSD).toBeCloseTo(0.1, 5)
+    expect(projectCosts.runs).toBe(1)
+
+    // A subsequent fire while paused also does not launch another run
+    // because runFiredTask is only invoked by projectWorker when
+    // checkPaused returns false. Here we simulate that: if we force a
+    // call anyway, the launcher is the only place that mutates calls,
+    // and the daemon's notice path never calls the launcher.
+    expect(calls).toHaveLength(1)
+  })
+
+  test('runFiredTask with no launcher is a no-op (child runs disabled)', async () => {
+    const configDir = makeTempDir('kairos-cap-noop-')
+    const projectDir = makeTempDir('kairos-cap-noop-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+
+    const now = () => new Date('2026-04-22T12:00:00.000Z')
+    const runFiredTask = makeRunFiredTask({
+      projectDir,
+      stateWriter,
+      costTracker: null,
+      launcher: null,
+      defaultAllowedTools: [],
+      maxTurns: 1,
+      timeoutMs: 5000,
+      handleCapHit: makeCapHitHandler(stateWriter, now),
+      now,
+    })
+
+    const outcome = await runFiredTask(makeTask('t-noop'), 'event')
+    expect(outcome.ok).toBe(true)
+    expect(outcome.paused).toBe(false)
+    expect(outcome.result).toBeUndefined()
+  })
+})

--- a/src 2/daemon/kairos/childRunner.test.ts
+++ b/src 2/daemon/kairos/childRunner.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import type {
+  ChildEvent,
+  ChildLauncher,
+  ChildLauncherParams,
+  ChildStreamMessage,
+} from './childRunner.js'
+import { runChild } from './childRunner.js'
+
+type RecordedCall = {
+  params: ChildLauncherParams
+}
+
+function makeLauncher(
+  messages: ChildStreamMessage[],
+  opts: { delayMs?: number; throwError?: Error } = {},
+): { launcher: ChildLauncher; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = []
+  const launcher: ChildLauncher = async function* (params) {
+    calls.push({ params })
+    if (opts.throwError) throw opts.throwError
+    for (const msg of messages) {
+      if (opts.delayMs) {
+        await Bun.sleep(opts.delayMs)
+        if (params.signal.aborted) {
+          // Respect the caller's timeout — abort ends the stream.
+          return
+        }
+      }
+      yield msg
+    }
+  }
+  return { launcher, calls }
+}
+
+function makeNow(startMs: number, stepMs = 10): () => Date {
+  let current = startMs
+  return () => {
+    const date = new Date(current)
+    current += stepMs
+    return date
+  }
+}
+
+afterEach(() => {
+  // No shared state to clear.
+})
+
+describe('childRunner.runChild', () => {
+  test('happy path: records stream events and extracts cost', async () => {
+    const events: ChildEvent[] = []
+    const { launcher, calls } = makeLauncher([
+      {
+        type: 'system',
+        subtype: 'init',
+        tools: ['Read'],
+        session_id: 'sess-1',
+      },
+      { type: 'assistant', session_id: 'sess-1' },
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 2,
+        duration_ms: 1234,
+        total_cost_usd: 0.042,
+        session_id: 'sess-1',
+      },
+    ])
+
+    const result = await runChild(
+      {
+        taskId: 't-happy',
+        prompt: 'hello',
+        projectDir: '/tmp/proj',
+        allowedTools: ['Read'],
+        maxTurns: 3,
+        timeoutMs: 5000,
+        runId: 'run-happy',
+      },
+      {
+        launcher,
+        onEvent: e => {
+          events.push(e)
+        },
+        now: makeNow(1_700_000_000_000),
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.exitReason).toBe('completed')
+    expect(result.costUSD).toBe(0.042)
+    expect(result.numTurns).toBe(2)
+    expect(result.sessionId).toBe('sess-1')
+    expect(result.allowedTools).toEqual(['Read'])
+
+    expect(calls).toHaveLength(1)
+    const startEvents = events.filter(e => e.kind === 'child_started')
+    const messageEvents = events.filter(e => e.kind === 'child_message')
+    const finishedEvents = events.filter(e => e.kind === 'child_finished')
+    expect(startEvents).toHaveLength(1)
+    expect(messageEvents).toHaveLength(3)
+    expect(finishedEvents).toHaveLength(1)
+  })
+
+  test('tool allowlist boundary: launcher receives exactly the configured tools', async () => {
+    const { launcher, calls } = makeLauncher([
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        total_cost_usd: 0.01,
+      },
+    ])
+
+    await runChild(
+      {
+        taskId: 't-allow',
+        prompt: 'hi',
+        projectDir: '/tmp/proj',
+        // Caller presents a broader list; the runner must pass it through
+        // verbatim and freeze it on the result — extra mutations to the
+        // caller-owned array post-spawn must not leak in.
+        allowedTools: ['Read', 'Glob'],
+        runId: 'run-allow',
+      },
+      {
+        launcher,
+        onEvent: () => {},
+        now: makeNow(1_700_000_000_000),
+      },
+    )
+
+    expect(calls[0]?.params.allowedTools).toEqual(['Read', 'Glob'])
+
+    // Ensure the runner does not retain a reference to the caller's array.
+    const callerArray = ['Read']
+    await runChild(
+      {
+        taskId: 't-allow-2',
+        prompt: 'hi',
+        projectDir: '/tmp/proj',
+        allowedTools: callerArray,
+        runId: 'run-allow-2',
+      },
+      {
+        launcher,
+        onEvent: () => {},
+        now: makeNow(1_700_000_000_000),
+      },
+    )
+    callerArray.push('Bash')
+    expect(calls[1]?.params.allowedTools).toEqual(['Read'])
+  })
+
+  test('timeout: aborts stream and reports timeout reason', async () => {
+    const events: ChildEvent[] = []
+    const { launcher } = makeLauncher(
+      [
+        { type: 'system', subtype: 'init' },
+        {
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          num_turns: 1,
+          total_cost_usd: 0,
+        },
+      ],
+      { delayMs: 200 },
+    )
+
+    const result = await runChild(
+      {
+        taskId: 't-timeout',
+        prompt: 'slow',
+        projectDir: '/tmp/proj',
+        allowedTools: [],
+        timeoutMs: 50,
+        runId: 'run-timeout',
+      },
+      {
+        launcher,
+        onEvent: e => {
+          events.push(e)
+        },
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.exitReason).toBe('timeout')
+    expect(events.some(e => e.kind === 'child_timeout')).toBe(true)
+  })
+
+  test('error: launcher throws → exitReason=error and error event written', async () => {
+    const events: ChildEvent[] = []
+    const { launcher } = makeLauncher([], {
+      throwError: new Error('boom'),
+    })
+
+    const result = await runChild(
+      {
+        taskId: 't-err',
+        prompt: 'x',
+        projectDir: '/tmp/proj',
+        allowedTools: [],
+        runId: 'run-err',
+      },
+      {
+        launcher,
+        onEvent: e => {
+          events.push(e)
+        },
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.exitReason).toBe('error')
+    expect(result.errorMessage).toBe('boom')
+    expect(events.some(e => e.kind === 'child_error')).toBe(true)
+  })
+
+  test('stream ends without result message → error with missing-result message', async () => {
+    const events: ChildEvent[] = []
+    const { launcher } = makeLauncher([
+      { type: 'system', subtype: 'init' },
+    ])
+
+    const result = await runChild(
+      {
+        taskId: 't-no-result',
+        prompt: 'x',
+        projectDir: '/tmp/proj',
+        allowedTools: [],
+        runId: 'run-no-result',
+      },
+      {
+        launcher,
+        onEvent: e => {
+          events.push(e)
+        },
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.exitReason).toBe('error')
+    expect(result.errorMessage).toContain('without a result')
+    expect(events.some(e => e.kind === 'child_error')).toBe(true)
+  })
+
+  test('result with error_max_budget_usd → exitReason=max_budget', async () => {
+    const events: ChildEvent[] = []
+    const { launcher } = makeLauncher([
+      {
+        type: 'result',
+        subtype: 'error_max_budget_usd',
+        is_error: true,
+        num_turns: 5,
+        duration_ms: 9000,
+        total_cost_usd: 1.0,
+        errors: ['budget exceeded'],
+      },
+    ])
+
+    const result = await runChild(
+      {
+        taskId: 't-max',
+        prompt: 'x',
+        projectDir: '/tmp/proj',
+        allowedTools: [],
+        runId: 'run-max',
+      },
+      {
+        launcher,
+        onEvent: e => {
+          events.push(e)
+        },
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.exitReason).toBe('max_budget')
+    expect(result.costUSD).toBe(1.0)
+    expect(result.errorMessage).toBe('budget exceeded')
+  })
+})

--- a/src 2/daemon/kairos/childRunner.ts
+++ b/src 2/daemon/kairos/childRunner.ts
@@ -1,0 +1,384 @@
+import { randomUUID } from 'crypto'
+
+// A subset of @anthropic-ai/claude-agent-sdk's SDKMessage that we actually
+// read — kept loose on purpose so the launcher contract doesn't depend on
+// the SDK's full type surface.
+export type ChildStreamMessage =
+  | {
+      type: 'system'
+      subtype: 'init'
+      tools?: string[]
+      model?: string
+      session_id?: string
+      [key: string]: unknown
+    }
+  | {
+      type: 'assistant'
+      message?: unknown
+      session_id?: string
+      [key: string]: unknown
+    }
+  | {
+      type: 'result'
+      subtype:
+        | 'success'
+        | 'error_during_execution'
+        | 'error_max_turns'
+        | 'error_max_budget_usd'
+        | 'error_max_structured_output_retries'
+      is_error?: boolean
+      num_turns?: number
+      duration_ms?: number
+      total_cost_usd?: number
+      session_id?: string
+      errors?: string[]
+      [key: string]: unknown
+    }
+  | {
+      type: string
+      [key: string]: unknown
+    }
+
+export type ChildLauncherParams = {
+  prompt: string
+  projectDir: string
+  allowedTools: string[]
+  maxTurns: number
+  signal: AbortSignal
+}
+
+export type ChildLauncher = (
+  params: ChildLauncherParams,
+) => AsyncIterable<ChildStreamMessage>
+
+export type ChildRunOptions = {
+  taskId: string
+  prompt: string
+  projectDir: string
+  allowedTools: string[]
+  maxTurns?: number
+  timeoutMs?: number
+  runId?: string
+}
+
+export type ChildRunExitReason =
+  | 'completed'
+  | 'timeout'
+  | 'error'
+  | 'max_turns'
+  | 'max_budget'
+
+export type ChildRunResult = {
+  runId: string
+  ok: boolean
+  exitReason: ChildRunExitReason
+  sessionId?: string
+  costUSD: number
+  numTurns: number
+  durationMs: number
+  allowedTools: string[]
+  errorMessage?: string
+}
+
+export type ChildEvent =
+  | {
+      kind: 'child_started'
+      t: string
+      runId: string
+      taskId: string
+      allowedTools: string[]
+      maxTurns: number
+      timeoutMs: number
+    }
+  | {
+      kind: 'child_message'
+      t: string
+      runId: string
+      messageType: string
+      sessionId?: string
+    }
+  | {
+      kind: 'child_finished'
+      t: string
+      runId: string
+      exitReason: ChildRunExitReason
+      ok: boolean
+      costUSD: number
+      numTurns: number
+      durationMs: number
+      sessionId?: string
+    }
+  | {
+      kind: 'child_error'
+      t: string
+      runId: string
+      errorMessage: string
+    }
+  | {
+      kind: 'child_timeout'
+      t: string
+      runId: string
+      timeoutMs: number
+    }
+
+export type ChildRunDeps = {
+  launcher: ChildLauncher
+  onEvent: (event: ChildEvent) => Promise<void> | void
+  now?: () => Date
+}
+
+const DEFAULT_MAX_TURNS = 3
+const DEFAULT_TIMEOUT_MS = 2 * 60 * 1000
+
+function exitReasonFromResult(
+  msg: Extract<ChildStreamMessage, { type: 'result' }>,
+): ChildRunExitReason {
+  switch (msg.subtype) {
+    case 'success':
+      return 'completed'
+    case 'error_max_turns':
+      return 'max_turns'
+    case 'error_max_budget_usd':
+      return 'max_budget'
+    default:
+      return 'error'
+  }
+}
+
+export async function runChild(
+  options: ChildRunOptions,
+  deps: ChildRunDeps,
+): Promise<ChildRunResult> {
+  const now = deps.now ?? (() => new Date())
+  const runId = options.runId ?? randomUUID()
+  const maxTurns = options.maxTurns ?? DEFAULT_MAX_TURNS
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  // Freeze the allowlist at spawn time — the launcher is called with
+  // exactly these tools and no mutation afterwards changes them.
+  const allowedTools = [...options.allowedTools]
+
+  const controller = new AbortController()
+  const startedAtDate = now()
+  const startedAtMs = startedAtDate.getTime()
+
+  await deps.onEvent({
+    kind: 'child_started',
+    t: startedAtDate.toISOString(),
+    runId,
+    taskId: options.taskId,
+    allowedTools,
+    maxTurns,
+    timeoutMs,
+  })
+
+  let timedOut = false
+  const timer = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, timeoutMs)
+  if (typeof (timer as unknown as { unref?: () => void }).unref === 'function') {
+    ;(timer as unknown as { unref: () => void }).unref()
+  }
+
+  let sessionId: string | undefined
+  let resultMessage:
+    | Extract<ChildStreamMessage, { type: 'result' }>
+    | undefined
+  let streamError: Error | null = null
+
+  try {
+    const stream = deps.launcher({
+      prompt: options.prompt,
+      projectDir: options.projectDir,
+      allowedTools,
+      maxTurns,
+      signal: controller.signal,
+    })
+
+    for await (const message of stream) {
+      if (!sessionId && typeof message.session_id === 'string') {
+        sessionId = message.session_id
+      }
+
+      await deps.onEvent({
+        kind: 'child_message',
+        t: now().toISOString(),
+        runId,
+        messageType: String(message.type),
+        sessionId,
+      })
+
+      if (message.type === 'result') {
+        resultMessage = message as Extract<
+          ChildStreamMessage,
+          { type: 'result' }
+        >
+      }
+    }
+  } catch (err) {
+    streamError = err instanceof Error ? err : new Error(String(err))
+  } finally {
+    clearTimeout(timer)
+  }
+
+  const finishedAtMs = now().getTime()
+  const durationMs = finishedAtMs - startedAtMs
+
+  if (timedOut) {
+    await deps.onEvent({
+      kind: 'child_timeout',
+      t: now().toISOString(),
+      runId,
+      timeoutMs,
+    })
+
+    const result: ChildRunResult = {
+      runId,
+      ok: false,
+      exitReason: 'timeout',
+      sessionId,
+      costUSD: resultMessage?.total_cost_usd ?? 0,
+      numTurns: resultMessage?.num_turns ?? 0,
+      durationMs,
+      allowedTools,
+      errorMessage: `child run exceeded ${timeoutMs}ms`,
+    }
+    await deps.onEvent({
+      kind: 'child_finished',
+      t: now().toISOString(),
+      runId,
+      exitReason: result.exitReason,
+      ok: result.ok,
+      costUSD: result.costUSD,
+      numTurns: result.numTurns,
+      durationMs: result.durationMs,
+      sessionId,
+    })
+    return result
+  }
+
+  if (streamError) {
+    await deps.onEvent({
+      kind: 'child_error',
+      t: now().toISOString(),
+      runId,
+      errorMessage: streamError.message,
+    })
+    const result: ChildRunResult = {
+      runId,
+      ok: false,
+      exitReason: 'error',
+      sessionId,
+      costUSD: resultMessage?.total_cost_usd ?? 0,
+      numTurns: resultMessage?.num_turns ?? 0,
+      durationMs,
+      allowedTools,
+      errorMessage: streamError.message,
+    }
+    await deps.onEvent({
+      kind: 'child_finished',
+      t: now().toISOString(),
+      runId,
+      exitReason: result.exitReason,
+      ok: result.ok,
+      costUSD: result.costUSD,
+      numTurns: result.numTurns,
+      durationMs: result.durationMs,
+      sessionId,
+    })
+    return result
+  }
+
+  if (!resultMessage) {
+    const result: ChildRunResult = {
+      runId,
+      ok: false,
+      exitReason: 'error',
+      sessionId,
+      costUSD: 0,
+      numTurns: 0,
+      durationMs,
+      allowedTools,
+      errorMessage: 'child stream ended without a result message',
+    }
+    await deps.onEvent({
+      kind: 'child_error',
+      t: now().toISOString(),
+      runId,
+      errorMessage: result.errorMessage ?? 'missing result',
+    })
+    await deps.onEvent({
+      kind: 'child_finished',
+      t: now().toISOString(),
+      runId,
+      exitReason: result.exitReason,
+      ok: result.ok,
+      costUSD: result.costUSD,
+      numTurns: result.numTurns,
+      durationMs: result.durationMs,
+      sessionId,
+    })
+    return result
+  }
+
+  const exitReason = exitReasonFromResult(resultMessage)
+  const ok = exitReason === 'completed' && resultMessage.is_error !== true
+
+  const result: ChildRunResult = {
+    runId,
+    ok,
+    exitReason,
+    sessionId,
+    costUSD: resultMessage.total_cost_usd ?? 0,
+    numTurns: resultMessage.num_turns ?? 0,
+    durationMs: resultMessage.duration_ms ?? durationMs,
+    allowedTools,
+    errorMessage: resultMessage.errors?.[0],
+  }
+
+  await deps.onEvent({
+    kind: 'child_finished',
+    t: now().toISOString(),
+    runId,
+    exitReason: result.exitReason,
+    ok: result.ok,
+    costUSD: result.costUSD,
+    numTurns: result.numTurns,
+    durationMs: result.durationMs,
+    sessionId,
+  })
+
+  return result
+}
+
+/**
+ * Default launcher backed by @anthropic-ai/claude-agent-sdk's `query()`. Kept
+ * as a lazy import so tests that inject their own launcher don't pay the
+ * cost of loading the SDK runtime.
+ */
+export function createSdkChildLauncher(): ChildLauncher {
+  return async function* launcher(params) {
+    const sdk = await import('@anthropic-ai/claude-agent-sdk')
+    const query = sdk.query({
+      prompt: params.prompt,
+      options: {
+        allowedTools: params.allowedTools,
+        maxTurns: params.maxTurns,
+        cwd: params.projectDir,
+        abortController: (() => {
+          // Bridge our AbortSignal to the SDK's AbortController option.
+          const ctrl = new AbortController()
+          if (params.signal.aborted) ctrl.abort()
+          else
+            params.signal.addEventListener('abort', () => ctrl.abort(), {
+              once: true,
+            })
+          return ctrl
+        })(),
+      } as Record<string, unknown>,
+    }) as unknown as AsyncIterable<ChildStreamMessage>
+    for await (const msg of query) {
+      yield msg
+    }
+  }
+}

--- a/src 2/daemon/kairos/costTracker.test.ts
+++ b/src 2/daemon/kairos/costTracker.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'bun:test'
+import { createCostTracker } from './costTracker.js'
+import type { CostsFile } from './stateWriter.js'
+
+function inMemoryStateWriter() {
+  const globalCosts = { current: null as CostsFile | null }
+  const projectCosts = new Map<string, CostsFile>()
+
+  return {
+    async readGlobalCosts() {
+      return globalCosts.current
+    },
+    async writeGlobalCosts(c: CostsFile) {
+      globalCosts.current = c
+    },
+    async readProjectCosts(dir: string) {
+      return projectCosts.get(dir) ?? null
+    },
+    async writeProjectCosts(dir: string, c: CostsFile) {
+      projectCosts.set(dir, c)
+    },
+    inspect() {
+      return { global: globalCosts.current, projects: projectCosts }
+    },
+  }
+}
+
+describe('costTracker', () => {
+  test('records per-project and global totals on every run', async () => {
+    const stateWriter = inMemoryStateWriter()
+    const tracker = createCostTracker({
+      caps: {},
+      stateWriter,
+    })
+
+    await tracker.record({
+      projectDir: '/p/a',
+      taskId: 't1',
+      runId: 'r1',
+      costUSD: 0.1,
+      numTurns: 2,
+      durationMs: 1000,
+    })
+    await tracker.record({
+      projectDir: '/p/a',
+      taskId: 't2',
+      runId: 'r2',
+      costUSD: 0.2,
+      numTurns: 3,
+      durationMs: 2000,
+    })
+    await tracker.record({
+      projectDir: '/p/b',
+      taskId: 't3',
+      runId: 'r3',
+      costUSD: 0.5,
+      numTurns: 1,
+      durationMs: 500,
+    })
+
+    const snap = stateWriter.inspect()
+    expect(snap.global?.totalUSD).toBeCloseTo(0.8, 5)
+    expect(snap.global?.runs).toBe(3)
+    expect(snap.projects.get('/p/a')?.totalUSD).toBeCloseTo(0.3, 5)
+    expect(snap.projects.get('/p/a')?.runs).toBe(2)
+    expect(snap.projects.get('/p/b')?.totalUSD).toBeCloseTo(0.5, 5)
+    expect(snap.projects.get('/p/b')?.runs).toBe(1)
+  })
+
+  test('per-project cap triggers cap-hit scoped to project', async () => {
+    const stateWriter = inMemoryStateWriter()
+    const tracker = createCostTracker({
+      caps: { perProjectUSD: 0.5 },
+      stateWriter,
+    })
+
+    const r1 = await tracker.record({
+      projectDir: '/p/a',
+      taskId: 't1',
+      runId: 'r1',
+      costUSD: 0.2,
+      numTurns: 1,
+      durationMs: 100,
+    })
+    expect(r1.capHit).toBeNull()
+
+    const r2 = await tracker.record({
+      projectDir: '/p/a',
+      taskId: 't2',
+      runId: 'r2',
+      costUSD: 0.4,
+      numTurns: 1,
+      durationMs: 100,
+    })
+    expect(r2.capHit).not.toBeNull()
+    expect(r2.capHit?.scope).toBe('project')
+    expect(r2.capHit?.cap).toBe(0.5)
+    expect(r2.capHit?.current).toBeCloseTo(0.6, 5)
+  })
+
+  test('global cap takes precedence over per-project cap when both trip', async () => {
+    const stateWriter = inMemoryStateWriter()
+    const tracker = createCostTracker({
+      caps: { perProjectUSD: 0.1, globalUSD: 0.1 },
+      stateWriter,
+    })
+
+    const out = await tracker.record({
+      projectDir: '/p/a',
+      taskId: 't1',
+      runId: 'r1',
+      costUSD: 0.2,
+      numTurns: 1,
+      durationMs: 100,
+    })
+
+    expect(out.capHit?.scope).toBe('global')
+  })
+
+  test('cap-hit only fires when totals reach the cap — below cap returns null', async () => {
+    const stateWriter = inMemoryStateWriter()
+    const tracker = createCostTracker({
+      caps: { globalUSD: 1 },
+      stateWriter,
+    })
+
+    const out = await tracker.record({
+      projectDir: '/p/a',
+      taskId: 't1',
+      runId: 'r1',
+      costUSD: 0.3,
+      numTurns: 1,
+      durationMs: 100,
+    })
+    expect(out.capHit).toBeNull()
+    expect(out.globalTotal).toBeCloseTo(0.3, 5)
+  })
+})

--- a/src 2/daemon/kairos/costTracker.ts
+++ b/src 2/daemon/kairos/costTracker.ts
@@ -1,0 +1,149 @@
+import type { CostsFile } from './stateWriter.js'
+
+export type CostCaps = {
+  perProjectUSD?: number
+  globalUSD?: number
+}
+
+export type CostRecordInput = {
+  projectDir: string
+  taskId: string
+  runId: string
+  costUSD: number
+  numTurns: number
+  durationMs: number
+}
+
+export type CapHit = {
+  scope: 'project' | 'global'
+  cap: number
+  current: number
+}
+
+export type CostRecordResult = {
+  capHit: CapHit | null
+  projectTotal: number
+  globalTotal: number
+}
+
+export type CostTracker = {
+  record(input: CostRecordInput): Promise<CostRecordResult>
+  getCaps(): CostCaps
+}
+
+type CostTrackerDeps = {
+  caps: CostCaps
+  now?: () => Date
+  stateWriter: {
+    readGlobalCosts(): Promise<CostsFile | null>
+    writeGlobalCosts(costs: CostsFile): Promise<void>
+    readProjectCosts(projectDir: string): Promise<CostsFile | null>
+    writeProjectCosts(projectDir: string, costs: CostsFile): Promise<void>
+  }
+}
+
+function emptyCosts(updatedAt: string): CostsFile {
+  return {
+    totalUSD: 0,
+    totalTurns: 0,
+    runs: 0,
+    updatedAt,
+  }
+}
+
+function accumulate(
+  prior: CostsFile | null,
+  runUSD: number,
+  runTurns: number,
+  updatedAt: string,
+): CostsFile {
+  const base = prior ?? emptyCosts(updatedAt)
+  return {
+    totalUSD: base.totalUSD + runUSD,
+    totalTurns: base.totalTurns + runTurns,
+    runs: base.runs + 1,
+    lastRunUSD: runUSD,
+    lastRunAt: updatedAt,
+    updatedAt,
+  }
+}
+
+// Serialize record() calls so read/modify/write of the cost files is atomic
+// against itself. Cap checks must observe the updated totals produced by the
+// same call that wrote them, not a stale snapshot from a concurrent record().
+function serialize<T>(fn: () => Promise<T>, queueRef: { q: Promise<unknown> }): Promise<T> {
+  const next = queueRef.q.then(fn, fn)
+  queueRef.q = next.catch(() => {})
+  return next
+}
+
+export function createCostTracker(deps: CostTrackerDeps): CostTracker {
+  const now = deps.now ?? (() => new Date())
+  const queueRef = { q: Promise.resolve() as Promise<unknown> }
+
+  return {
+    getCaps() {
+      return { ...deps.caps }
+    },
+    record(input: CostRecordInput): Promise<CostRecordResult> {
+      return serialize(async () => {
+        const updatedAt = now().toISOString()
+
+        const [priorGlobal, priorProject] = await Promise.all([
+          deps.stateWriter.readGlobalCosts(),
+          deps.stateWriter.readProjectCosts(input.projectDir),
+        ])
+
+        const nextGlobal = accumulate(
+          priorGlobal,
+          input.costUSD,
+          input.numTurns,
+          updatedAt,
+        )
+        const nextProject = accumulate(
+          priorProject,
+          input.costUSD,
+          input.numTurns,
+          updatedAt,
+        )
+
+        await Promise.all([
+          deps.stateWriter.writeGlobalCosts(nextGlobal),
+          deps.stateWriter.writeProjectCosts(input.projectDir, nextProject),
+        ])
+
+        let capHit: CapHit | null = null
+
+        if (
+          deps.caps.perProjectUSD !== undefined &&
+          nextProject.totalUSD >= deps.caps.perProjectUSD
+        ) {
+          capHit = {
+            scope: 'project',
+            cap: deps.caps.perProjectUSD,
+            current: nextProject.totalUSD,
+          }
+        }
+
+        if (
+          deps.caps.globalUSD !== undefined &&
+          nextGlobal.totalUSD >= deps.caps.globalUSD
+        ) {
+          // Global cap takes precedence — if both are hit, global is the
+          // one that should pause the whole daemon.
+          capHit = {
+            scope: 'global',
+            cap: deps.caps.globalUSD,
+            current: nextGlobal.totalUSD,
+          }
+        }
+
+        return {
+          capHit,
+          projectTotal: nextProject.totalUSD,
+          globalTotal: nextGlobal.totalUSD,
+        }
+      }, queueRef)
+    },
+  }
+}

--- a/src 2/daemon/kairos/demo.ts
+++ b/src 2/daemon/kairos/demo.ts
@@ -1,0 +1,178 @@
+/**
+ * Phase 3 visual-proof demo.
+ *
+ * Runs the full fired-task → child-run → cost-record → cap-hit flow against a
+ * fake child launcher, using throwaway temp directories for the global kairos
+ * state and one project. Prints every state file the acceptance checklist
+ * asks to see, so you can screenshot the terminal output for the PR.
+ *
+ * Usage (from `src 2/`):
+ *   bun run ./daemon/kairos/demo.ts
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { CronTask } from '../../utils/cronTasks.js'
+import type { ChildLauncher, ChildStreamMessage } from './childRunner.js'
+import { createCostTracker } from './costTracker.js'
+import {
+  getKairosGlobalCostsPath,
+  getKairosGlobalEventsPath,
+  getKairosPausePath,
+  getProjectKairosCostsPath,
+  getProjectKairosEventsPath,
+} from './paths.js'
+import { createStateWriter } from './stateWriter.js'
+import { makeCapHitHandler, makeRunFiredTask } from './worker.js'
+
+function banner(title: string): void {
+  const bar = '='.repeat(Math.max(8, 72 - title.length - 2))
+  console.log(`\n== ${title} ${bar}`)
+}
+
+function printFile(label: string, path: string): void {
+  banner(label)
+  console.log(`path: ${path}`)
+  if (!existsSync(path)) {
+    console.log('(file not present)')
+    return
+  }
+  console.log(readFileSync(path, 'utf8').trimEnd())
+}
+
+function makeTask(id: string, prompt: string): CronTask {
+  return { id, cron: '* * * * *', prompt, createdAt: Date.now() }
+}
+
+function fakeLauncher(messages: ChildStreamMessage[]): {
+  launcher: ChildLauncher
+  callCount: () => number
+} {
+  let calls = 0
+  const launcher: ChildLauncher = async function* () {
+    calls += 1
+    for (const msg of messages) yield msg
+  }
+  return { launcher, callCount: () => calls }
+}
+
+async function main(): Promise<void> {
+  const configDir = mkdtempSync(join(tmpdir(), 'kairos-demo-config-'))
+  const projectDir = mkdtempSync(join(tmpdir(), 'kairos-demo-project-'))
+  process.env.CLAUDE_CONFIG_DIR = configDir
+
+  console.log(`kairos state dir:  ${configDir}/kairos`)
+  console.log(`project dir:       ${projectDir}`)
+
+  try {
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+
+    // Tiny global cap so even one successful run trips it.
+    const costTracker = createCostTracker({
+      caps: { globalUSD: 0.05 },
+      stateWriter,
+    })
+
+    const now = () => new Date('2026-04-22T12:00:00.000Z')
+    const handleCapHit = makeCapHitHandler(stateWriter, now)
+
+    // ---- Run 1: under cap, happy path -----------------------------------
+    const run1 = fakeLauncher([
+      { type: 'system', subtype: 'init', tools: ['Read'], session_id: 's1' },
+      { type: 'assistant', session_id: 's1' },
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        duration_ms: 420,
+        total_cost_usd: 0.02,
+        session_id: 's1',
+      },
+    ])
+
+    const runFiredTask1 = makeRunFiredTask({
+      projectDir,
+      stateWriter,
+      costTracker,
+      launcher: run1.launcher,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 1,
+      timeoutMs: 5_000,
+      handleCapHit,
+      now,
+    })
+
+    banner('run 1: under cap (0.02 USD vs 0.05 cap)')
+    const outcome1 = await runFiredTask1(
+      makeTask('demo-1', 'summarize README'),
+      'event',
+    )
+    console.log('outcome:', JSON.stringify(outcome1, null, 2))
+    console.log('launcher calls:', run1.callCount())
+
+    // ---- Run 2: trips the cap -------------------------------------------
+    const run2 = fakeLauncher([
+      { type: 'system', subtype: 'init', tools: ['Read'], session_id: 's2' },
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 2,
+        duration_ms: 800,
+        total_cost_usd: 0.1,
+        session_id: 's2',
+      },
+    ])
+
+    const runFiredTask2 = makeRunFiredTask({
+      projectDir,
+      stateWriter,
+      costTracker,
+      launcher: run2.launcher,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 1,
+      timeoutMs: 5_000,
+      handleCapHit,
+      now,
+    })
+
+    banner('run 2: trips cap (+0.10 USD → total 0.12 ≥ 0.05)')
+    const outcome2 = await runFiredTask2(
+      makeTask('demo-2', 'expensive task'),
+      'event',
+    )
+    console.log('outcome:', JSON.stringify(outcome2, null, 2))
+    console.log(
+      'launcher calls for run 2 (must be 1 — no recursive notification):',
+      run2.callCount(),
+    )
+
+    // ---- State files ----------------------------------------------------
+    printFile('per-project events.jsonl', getProjectKairosEventsPath(projectDir))
+    printFile('per-project costs.json', getProjectKairosCostsPath(projectDir))
+    printFile('global events.jsonl', getKairosGlobalEventsPath())
+    printFile('global costs.json', getKairosGlobalCostsPath())
+    printFile('pause.json (daemon-originated)', getKairosPausePath())
+
+    banner('done')
+    console.log('All state files written under:')
+    console.log(`  ${configDir}/kairos/`)
+    console.log(`  ${projectDir}/.claude/kairos/`)
+    console.log(
+      'Leave as-is to inspect further, or delete manually when finished.',
+    )
+  } catch (err) {
+    // Only clean up on failure — success leaves files around for screenshots.
+    rmSync(configDir, { recursive: true, force: true })
+    rmSync(projectDir, { recursive: true, force: true })
+    throw err
+  }
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src 2/daemon/kairos/paths.ts
+++ b/src 2/daemon/kairos/paths.ts
@@ -12,3 +12,27 @@ export function getKairosStatusPath(): string {
 export function getKairosStdoutLogPath(): string {
   return join(getKairosStateDir(), 'daemon.out.log')
 }
+
+export function getKairosGlobalEventsPath(): string {
+  return join(getKairosStateDir(), 'events.jsonl')
+}
+
+export function getKairosGlobalCostsPath(): string {
+  return join(getKairosStateDir(), 'costs.json')
+}
+
+export function getKairosPausePath(): string {
+  return join(getKairosStateDir(), 'pause.json')
+}
+
+export function getProjectKairosDir(projectDir: string): string {
+  return join(projectDir, '.claude', 'kairos')
+}
+
+export function getProjectKairosEventsPath(projectDir: string): string {
+  return join(getProjectKairosDir(projectDir), 'events.jsonl')
+}
+
+export function getProjectKairosCostsPath(projectDir: string): string {
+  return join(getProjectKairosDir(projectDir), 'costs.json')
+}

--- a/src 2/daemon/kairos/projectWorker.test.ts
+++ b/src 2/daemon/kairos/projectWorker.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import type { CronScheduler } from '../../utils/cronScheduler.js'
 import type { CronTask } from '../../utils/cronTasks.js'
+import type { ChildRunResult } from './childRunner.js'
 import { createProjectRegistry } from './projectRegistry.js'
 import { createProjectWorker } from './projectWorker.js'
 import { createStateWriter } from './stateWriter.js'
@@ -124,5 +125,107 @@ describe('Kairos project worker', () => {
       'utf8',
     )
     expect(scheduledTasks).toContain('"tasks": []')
+  })
+
+  test('invokes runFiredTask with fired task and stops draining on pause', async () => {
+    const configDir = makeTempConfigDir('kairos-worker-child-')
+    const projectDir = makeTempConfigDir('kairos-project-child-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    let fireTask: ((task: CronTask) => void) | undefined
+    const scheduler: CronScheduler = {
+      start() {},
+      stop() {},
+      getNextFireTime() {
+        return null
+      },
+    }
+
+    const stateWriter = await createStateWriter()
+    const fakeResult: ChildRunResult = {
+      runId: 'r1',
+      ok: true,
+      exitReason: 'completed',
+      costUSD: 0.01,
+      numTurns: 1,
+      durationMs: 10,
+      allowedTools: ['Read'],
+    }
+
+    const calls: Array<{ taskId: string; source: 'event' | 'catchup' }> = []
+    let firesBeforePause = 0
+    const runFiredTask = mock(
+      async (task: CronTask, source: 'event' | 'catchup') => {
+        calls.push({ taskId: task.id, source })
+        firesBeforePause += 1
+        const paused = firesBeforePause >= 1
+        return { ok: true, paused, result: fakeResult }
+      },
+    )
+
+    const worker = createProjectWorker(projectDir, {
+      stateWriter,
+      createScheduler(options) {
+        fireTask = options.onFireTask
+        return scheduler
+      },
+      runFiredTask,
+    })
+
+    worker.start()
+    fireTask?.(makeTask('t1'))
+    fireTask?.(makeTask('t2'))
+
+    await Bun.sleep(150)
+
+    expect(calls.length).toBe(1)
+    expect(calls[0]).toEqual({ taskId: 't1', source: 'event' })
+  })
+
+  test('skips work while paused and records skipped_paused in per-project log', async () => {
+    const configDir = makeTempConfigDir('kairos-worker-paused-')
+    const projectDir = makeTempConfigDir('kairos-project-paused-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    let fireTask: ((task: CronTask) => void) | undefined
+    const scheduler: CronScheduler = {
+      start() {},
+      stop() {},
+      getNextFireTime() {
+        return null
+      },
+    }
+
+    const stateWriter = await createStateWriter()
+    const runFiredTask = mock(
+      async (_task: CronTask, _source: 'event' | 'catchup') => ({
+        ok: true,
+        paused: false,
+      }),
+    )
+
+    const worker = createProjectWorker(projectDir, {
+      stateWriter,
+      createScheduler(options) {
+        fireTask = options.onFireTask
+        return scheduler
+      },
+      runFiredTask,
+      checkPaused: async () => true,
+    })
+
+    worker.start()
+    fireTask?.(makeTask('tp1'))
+
+    await Bun.sleep(100)
+
+    expect(runFiredTask).not.toHaveBeenCalled()
+
+    const log = readFileSync(
+      join(projectDir, '.claude', 'kairos', 'log.jsonl'),
+      'utf8',
+    )
+    expect(log).toContain('"kind":"skipped_paused"')
+    expect(log).toContain('"reason":"global_pause"')
   })
 })

--- a/src 2/daemon/kairos/projectWorker.ts
+++ b/src 2/daemon/kairos/projectWorker.ts
@@ -2,7 +2,14 @@ import { randomUUID } from 'crypto'
 import { createCronScheduler, type CronScheduler } from '../../utils/cronScheduler.js'
 import { readCronTasks, writeCronTasks } from '../../utils/cronTasks.js'
 import type { CronTask } from '../../utils/cronTasks.js'
+import type { ChildRunResult } from './childRunner.js'
 import type { ProjectStatus } from './stateWriter.js'
+
+export type RunFiredTaskResult = {
+  ok: boolean
+  paused: boolean
+  result?: ChildRunResult
+}
 
 export type ProjectWorkerDeps = {
   stateWriter: {
@@ -14,6 +21,19 @@ export type ProjectWorkerDeps = {
   }
   createScheduler?: (options: ConstructorParameters<typeof createCronScheduler>[0]) => CronScheduler
   now?: () => Date
+  /**
+   * Handles the actual child Claude run when a task fires. Injected by the
+   * daemon so the worker stays transport-agnostic. Returns whether the run
+   * completed cleanly and whether the global pause state flipped on during
+   * the run (cap hit) — the worker uses `paused` to stop scheduling more
+   * catch-ups for this drain.
+   */
+  runFiredTask?: (
+    task: CronTask,
+    source: 'event' | 'catchup',
+  ) => Promise<RunFiredTaskResult>
+  /** Returns true if the global pause flag is set. */
+  checkPaused?: () => Promise<boolean>
 }
 
 export type ProjectWorker = {
@@ -42,6 +62,7 @@ export function createProjectWorker(
   let pendingCount = 0
   let stopped = false
   let currentRun: Promise<void> | null = null
+  let pendingTask: CronTask | null = null
   const completedOneShots = new Set<string>()
   let cleanupTimer: ReturnType<typeof setTimeout> | null = null
   let cleanupRun: Promise<void> | null = null
@@ -82,7 +103,10 @@ export function createProjectWorker(
     })
   }
 
-  const runCycle = async (source: 'event' | 'catchup'): Promise<void> => {
+  const runCycle = async (
+    source: 'event' | 'catchup',
+    task: CronTask | null,
+  ): Promise<{ paused: boolean }> => {
     if (source === 'catchup') {
       await deps.stateWriter.appendProjectLog(projectDir, {
         kind: 'catchup_started',
@@ -90,12 +114,31 @@ export function createProjectWorker(
       })
     }
     await writeStatus(source === 'catchup' ? 'catchup_started' : 'fired')
+
+    if (deps.checkPaused && (await deps.checkPaused())) {
+      await deps.stateWriter.appendProjectLog(projectDir, {
+        kind: 'skipped_paused',
+        t: now().toISOString(),
+        taskId: task?.id ?? '(unknown)',
+        reason: 'global_pause',
+      })
+      await writeStatus('skipped_paused')
+      return { paused: true }
+    }
+
+    let paused = false
+    if (deps.runFiredTask && task) {
+      const outcome = await deps.runFiredTask(task, source)
+      paused = outcome.paused
+    }
+
     await deps.stateWriter.appendProjectLog(projectDir, {
       kind: 'finished',
       source,
       t: now().toISOString(),
     })
     await writeStatus('finished')
+    return { paused }
   }
 
   const drain = async (): Promise<void> => {
@@ -103,11 +146,25 @@ export function createProjectWorker(
     running = true
     currentRun = (async () => {
       try {
-        await runCycle('event')
+        const firstTask = pendingTask
+        pendingTask = null
+        const first = await runCycle('event', firstTask)
+        if (first.paused) {
+          dirty = false
+          pendingTask = null
+          return
+        }
         while (dirty && !stopped) {
           dirty = false
           pendingCount = 1
-          await runCycle('catchup')
+          const catchupTask = pendingTask
+          pendingTask = null
+          const outcome = await runCycle('catchup', catchupTask)
+          if (outcome.paused) {
+            dirty = false
+            pendingTask = null
+            break
+          }
         }
       } finally {
         running = false
@@ -172,6 +229,7 @@ export function createProjectWorker(
       if (running) {
         dirty = true
         pendingCount = 1
+        pendingTask = task
         void deps.stateWriter.appendProjectLog(projectDir, {
           kind: 'overlap_coalesced',
           t: now().toISOString(),
@@ -181,6 +239,7 @@ export function createProjectWorker(
         return
       }
       pendingCount = 1
+      pendingTask = task
       void drain()
     },
     onMissed(tasks) {

--- a/src 2/daemon/kairos/stateWriter.ts
+++ b/src 2/daemon/kairos/stateWriter.ts
@@ -1,7 +1,15 @@
-import { appendFile, mkdir, rename, writeFile } from 'fs/promises'
+import { appendFile, mkdir, readFile, rename, writeFile } from 'fs/promises'
 import { dirname, join } from 'path'
 import { jsonStringify } from '../../utils/slowOperations.js'
-import { getKairosStateDir } from './paths.js'
+import {
+  getKairosGlobalCostsPath,
+  getKairosGlobalEventsPath,
+  getKairosPausePath,
+  getKairosStateDir,
+  getProjectKairosCostsPath,
+  getProjectKairosDir,
+  getProjectKairosEventsPath,
+} from './paths.js'
 
 export type ProjectStatus = {
   projectDir: string
@@ -24,6 +32,16 @@ export type ProjectLogEvent =
   | { kind: 'finished'; t: string; source: 'event' | 'catchup' }
   | { kind: 'project_registered'; t: string; projectDir: string }
   | { kind: 'project_unregistered'; t: string; projectDir: string }
+  | { kind: 'skipped_paused'; t: string; taskId: string; reason: string }
+  | {
+      kind: 'cap_hit_notice'
+      t: string
+      scope: 'project' | 'global'
+      cap: number
+      current: number
+      source: 'daemon'
+      projectDir?: string
+    }
 
 export type GlobalStatus = {
   kind: 'kairos'
@@ -34,6 +52,25 @@ export type GlobalStatus = {
   projects: number
   lastEventAt?: string
   stoppedAt?: string
+}
+
+export type CostsFile = {
+  totalUSD: number
+  totalTurns: number
+  runs: number
+  lastRunUSD?: number
+  lastRunAt?: string
+  updatedAt: string
+}
+
+export type PauseState = {
+  paused: boolean
+  reason?: 'cap_hit'
+  scope?: 'project' | 'global'
+  cap?: number
+  current?: number
+  setAt?: string
+  source: 'daemon' | 'user'
 }
 
 const writeQueues = new Map<string, Promise<void>>()
@@ -71,9 +108,16 @@ async function appendJsonLine(path: string, value: unknown): Promise<void> {
   })
 }
 
-function getProjectKairosDir(projectDir: string): string {
-  return join(projectDir, '.claude', 'kairos')
+async function readJsonFile<T>(path: string): Promise<T | null> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
 }
+
+export type StateWriter = Awaited<ReturnType<typeof createStateWriter>>
 
 export async function createStateWriter() {
   await mkdir(getKairosStateDir(), { recursive: true })
@@ -83,7 +127,7 @@ export async function createStateWriter() {
       await writeJsonAtomic(join(getKairosStateDir(), 'status.json'), status)
     },
     async appendGlobalEvent(event: ProjectLogEvent): Promise<void> {
-      await appendJsonLine(join(getKairosStateDir(), 'events.jsonl'), event)
+      await appendJsonLine(getKairosGlobalEventsPath(), event)
     },
     async ensureProjectDir(projectDir: string): Promise<void> {
       await mkdir(getProjectKairosDir(projectDir), { recursive: true })
@@ -100,6 +144,33 @@ export async function createStateWriter() {
       const dir = getProjectKairosDir(projectDir)
       await mkdir(dir, { recursive: true })
       await appendJsonLine(join(dir, 'log.jsonl'), event)
+    },
+    async appendProjectEvent(
+      projectDir: string,
+      event: Record<string, unknown>,
+    ): Promise<void> {
+      await appendJsonLine(getProjectKairosEventsPath(projectDir), event)
+    },
+    async readGlobalCosts(): Promise<CostsFile | null> {
+      return readJsonFile<CostsFile>(getKairosGlobalCostsPath())
+    },
+    async writeGlobalCosts(costs: CostsFile): Promise<void> {
+      await writeJsonAtomic(getKairosGlobalCostsPath(), costs)
+    },
+    async readProjectCosts(projectDir: string): Promise<CostsFile | null> {
+      return readJsonFile<CostsFile>(getProjectKairosCostsPath(projectDir))
+    },
+    async writeProjectCosts(
+      projectDir: string,
+      costs: CostsFile,
+    ): Promise<void> {
+      await writeJsonAtomic(getProjectKairosCostsPath(projectDir), costs)
+    },
+    async readPauseState(): Promise<PauseState | null> {
+      return readJsonFile<PauseState>(getKairosPausePath())
+    },
+    async writePauseState(state: PauseState): Promise<void> {
+      await writeJsonAtomic(getKairosPausePath(), state)
     },
     getProjectKairosDir,
   }

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -1,9 +1,25 @@
 import { appendFile, mkdir, writeFile } from 'fs/promises'
 import type { Writable } from 'stream'
+import type {
+  ChildLauncher,
+  ChildRunResult,
+} from './childRunner.js'
+import { createSdkChildLauncher, runChild } from './childRunner.js'
+import {
+  createCostTracker,
+  type CapHit,
+  type CostCaps,
+  type CostTracker,
+} from './costTracker.js'
 import { createProjectRegistry } from './projectRegistry.js'
 import { createProjectWorker } from './projectWorker.js'
-import { getKairosStateDir, getKairosStatusPath, getKairosStdoutLogPath } from './paths.js'
-import { createStateWriter } from './stateWriter.js'
+import type { CronTask } from '../../utils/cronTasks.js'
+import {
+  getKairosStateDir,
+  getKairosStatusPath,
+  getKairosStdoutLogPath,
+} from './paths.js'
+import { createStateWriter, type StateWriter } from './stateWriter.js'
 
 type KairosStatus = {
   kind: 'kairos'
@@ -14,11 +30,42 @@ type KairosStatus = {
   stoppedAt?: string
 }
 
+const DEFAULT_ALLOWED_TOOLS = ['Read']
+
+function parseNumberEnv(value: string | undefined): number | undefined {
+  if (value === undefined || value === '') return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function parseAllowedToolsEnv(value: string | undefined): string[] | undefined {
+  if (value === undefined || value === '') return undefined
+  return value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+}
+
 export type RunKairosWorkerOptions = {
   signal?: AbortSignal
   stdout?: Pick<Writable, 'write'>
   now?: () => Date
   pid?: number
+  /**
+   * When provided, fired tasks spawn a child Claude run via this launcher.
+   * When omitted and `enableChildRuns` is false, fired tasks are still
+   * logged but no external run is made. Defaults to the SDK-backed launcher.
+   */
+  childLauncher?: ChildLauncher
+  /**
+   * Explicit opt-out switch. Tests use this to keep the worker's old
+   * no-child-run behavior without also having to stub the launcher.
+   */
+  enableChildRuns?: boolean
+  caps?: CostCaps
+  allowedTools?: string[]
+  maxTurns?: number
+  timeoutMs?: number
 }
 
 function formatLogLine(message: string, now: Date, pid: number): string {
@@ -58,6 +105,143 @@ function waitForAbort(signal?: AbortSignal): Promise<void> {
   })
 }
 
+/**
+ * Computes the effective tool allowlist applied at child spawn time.
+ * A future phase can thread per-task overrides through here; for now
+ * every task gets the same daemon-level allowlist so the child cannot
+ * exceed what the operator opted into.
+ */
+export function computeEffectiveAllowedTools(
+  defaults: string[],
+  _task: CronTask,
+): string[] {
+  return [...defaults]
+}
+
+type CapHitHandler = (params: {
+  capHit: CapHit
+  projectDir: string
+  task: CronTask
+}) => Promise<void>
+
+/**
+ * Handle the cap-hit path **without** starting a recursive child run.
+ * The daemon itself writes the notice directly to global events.jsonl and
+ * flips pause.json. Anything watching those files (e.g. the dashboard from
+ * Phase 4) picks up the state change.
+ */
+export function makeCapHitHandler(
+  stateWriter: StateWriter,
+  now: () => Date,
+): CapHitHandler {
+  return async ({ capHit, projectDir, task }) => {
+    const t = now().toISOString()
+    await stateWriter.writePauseState({
+      paused: true,
+      reason: 'cap_hit',
+      scope: capHit.scope,
+      cap: capHit.cap,
+      current: capHit.current,
+      setAt: t,
+      source: 'daemon',
+    })
+    await stateWriter.appendGlobalEvent({
+      kind: 'cap_hit_notice',
+      t,
+      scope: capHit.scope,
+      cap: capHit.cap,
+      current: capHit.current,
+      source: 'daemon',
+      projectDir: capHit.scope === 'project' ? projectDir : undefined,
+    })
+    await stateWriter.appendProjectEvent(projectDir, {
+      kind: 'cap_hit_notice',
+      t,
+      scope: capHit.scope,
+      cap: capHit.cap,
+      current: capHit.current,
+      source: 'daemon',
+      taskId: task.id,
+    })
+  }
+}
+
+export type RunFiredTaskOptions = {
+  projectDir: string
+  stateWriter: StateWriter
+  costTracker: CostTracker | null
+  launcher: ChildLauncher | null
+  defaultAllowedTools: string[]
+  maxTurns: number
+  timeoutMs: number
+  handleCapHit: CapHitHandler
+  now: () => Date
+}
+
+export function makeRunFiredTask(options: RunFiredTaskOptions) {
+  const {
+    projectDir,
+    stateWriter,
+    costTracker,
+    launcher,
+    defaultAllowedTools,
+    maxTurns,
+    timeoutMs,
+    handleCapHit,
+    now,
+  } = options
+
+  return async function runFiredTask(
+    task: CronTask,
+    source: 'event' | 'catchup',
+  ): Promise<{ ok: boolean; paused: boolean; result?: ChildRunResult }> {
+    if (!launcher) {
+      return { ok: true, paused: false }
+    }
+
+    const allowedTools = computeEffectiveAllowedTools(defaultAllowedTools, task)
+
+    const result = await runChild(
+      {
+        taskId: task.id,
+        prompt: task.prompt,
+        projectDir,
+        allowedTools,
+        maxTurns,
+        timeoutMs,
+      },
+      {
+        launcher,
+        now,
+        onEvent: event =>
+          stateWriter.appendProjectEvent(projectDir, {
+            ...event,
+            source,
+            taskId: task.id,
+          }),
+      },
+    )
+
+    let paused = false
+    if (costTracker) {
+      const { capHit } = await costTracker.record({
+        projectDir,
+        taskId: task.id,
+        runId: result.runId,
+        costUSD: result.costUSD,
+        numTurns: result.numTurns,
+        durationMs: result.durationMs,
+      })
+      if (capHit) {
+        await handleCapHit({ capHit, projectDir, task })
+        paused = true
+      }
+    }
+
+    return { ok: result.ok, paused, result }
+  }
+}
+
 export async function runKairosWorker(
   options: RunKairosWorkerOptions = {},
 ): Promise<number> {
@@ -72,6 +256,37 @@ export async function runKairosWorker(
     string,
     ReturnType<typeof createProjectWorker>
   >()
+
+  const enableChildRuns = options.enableChildRuns ?? !!options.childLauncher
+  const launcher: ChildLauncher | null = enableChildRuns
+    ? options.childLauncher ?? createSdkChildLauncher()
+    : null
+
+  const caps: CostCaps = options.caps ?? {
+    perProjectUSD: parseNumberEnv(process.env.KAIROS_COST_CAP_PROJECT_USD),
+    globalUSD: parseNumberEnv(process.env.KAIROS_COST_CAP_GLOBAL_USD),
+  }
+  const costTracker =
+    caps.perProjectUSD !== undefined || caps.globalUSD !== undefined
+      ? createCostTracker({ caps, stateWriter, now })
+      : null
+
+  const defaultAllowedTools =
+    options.allowedTools ??
+    parseAllowedToolsEnv(process.env.KAIROS_ALLOWED_TOOLS) ??
+    DEFAULT_ALLOWED_TOOLS
+  const maxTurns =
+    options.maxTurns ?? parseNumberEnv(process.env.KAIROS_MAX_TURNS) ?? 3
+  const timeoutMs =
+    options.timeoutMs ??
+    parseNumberEnv(process.env.KAIROS_TIMEOUT_MS) ??
+    2 * 60 * 1000
+
+  const handleCapHit = makeCapHitHandler(stateWriter, now)
+  const checkPaused = async (): Promise<boolean> => {
+    const state = await stateWriter.readPauseState()
+    return !!state?.paused
+  }
 
   const syncGlobalStatus = async (state: 'starting' | 'idle' | 'stopped') => {
     await stateWriter.writeGlobalStatus({
@@ -89,9 +304,22 @@ export async function runKairosWorker(
   const addProject = async (projectDir: string) => {
     if (activeWorkers.has(projectDir)) return
     await stateWriter.ensureProjectDir(projectDir)
+    const runFiredTask = makeRunFiredTask({
+      projectDir,
+      stateWriter,
+      costTracker,
+      launcher,
+      defaultAllowedTools,
+      maxTurns,
+      timeoutMs,
+      handleCapHit,
+      now,
+    })
     const worker = createProjectWorker(projectDir, {
       stateWriter,
       now,
+      runFiredTask,
+      checkPaused,
     })
     activeWorkers.set(projectDir, worker)
     await stateWriter.appendGlobalEvent({


### PR DESCRIPTION
Closes #14.

## Summary
- Fired tasks spawn a short-lived child Claude run via an injectable `ChildLauncher`; the tool allowlist is frozen at spawn time.
- Child stream observation lands in per-project `events.jsonl`; per-run cost is accounted per-project and globally on exit.
- Hitting the cap sets `pause.json` and writes a daemon-originated `cap_hit_notice` to global `events.jsonl`. **No recursive child run is used to notify about the cap hit.**

Scope is strictly `src 2/daemon/**` — no trunk-guarded files touched, so `trunk-guard` should pass without the override label.

## Acceptance coverage
- [x] Fired tasks launch a short-lived child Claude run — `childRunner.ts` + `worker.ts` `makeRunFiredTask`
- [x] Child stream observation writes per-project `events.jsonl` — `stateWriter.appendProjectEvent`
- [x] Child tool set is restricted at spawn time — `computeEffectiveAllowedTools` + allowlist frozen into `ChildRunResult`
- [x] Cost is recorded per project and globally on child exit — `costTracker.ts`
- [x] Cap-hit path sets global pause and writes daemon-originated notice — `makeCapHitHandler`
- [x] No recursive child run is used to notify about the cap hit — verified by `capHit.integration.test.ts` asserting `launcher calls === 1`
- [x] Tests cover: happy path, tool-allowlist boundary, timeout/exit handling, cap-hit handling — 12 new tests in 3 files, 18 total daemon tests pass
- [ ] `trunk-guard` passes without override label — awaiting CI on this PR

## Test plan
- [ ] Verify `bun test ./daemon/` reports `18 pass, 0 fail`
- [ ] Verify `bun run ./daemon/kairos/demo.ts` exits cleanly and prints the cap-hit output
- [ ] Verify `trunk-guard` CI check passes green **without** the `trunk-change-approved` label
- [ ] Attach screen recording: demo terminal from run 1 through cap-hit + pause
- [ ] Attach screenshots of per-project `events.jsonl`, global + per-project `costs.json`, and `pause.json`
- [ ] Attach screenshot of `bun test ./daemon/` output (18 passing)

## Files
All additions/edits are inside `src 2/daemon/kairos/`:
- new: `childRunner.ts`, `costTracker.ts`, `demo.ts`
- new tests: `childRunner.test.ts`, `costTracker.test.ts`, `capHit.integration.test.ts`
- modified: `paths.ts`, `stateWriter.ts`, `projectWorker.ts`, `projectWorker.test.ts`, `worker.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)