### PR TITLE
Add SubscribePR command and polling support

### DIFF
--- a/src 2/commands.ts
+++ b/src 2/commands.ts
@@ -328,7 +328,6 @@ const COMMANDS = memoize((): Command[] => [
   ...(bridge ? [bridge] : []),
   ...(remoteControlServerCommand ? [remoteControlServerCommand] : []),
   ...(voiceCommand ? [voiceCommand] : []),
-  ...(subscribePr ? [subscribePr] : []),
   thinkback,
   thinkbackPlay,
   permissions,

--- a/src 2/commands.ts
+++ b/src 2/commands.ts
@@ -328,6 +328,7 @@ const COMMANDS = memoize((): Command[] => [
   ...(bridge ? [bridge] : []),
   ...(remoteControlServerCommand ? [remoteControlServerCommand] : []),
   ...(voiceCommand ? [voiceCommand] : []),
+  ...(subscribePr ? [subscribePr] : []),
   thinkback,
   thinkbackPlay,
   permissions,

--- a/src 2/commands/subscribe-pr.ts
+++ b/src 2/commands/subscribe-pr.ts
@@ -1,0 +1,242 @@
+import type { Command } from '../commands.js'
+import type { LocalJSXCommandContext, LocalJSXCommandOnDone } from '../types/command.js'
+import { removeCronTasks } from '../utils/cronTasks.js'
+import {
+  deletePRSubscriptionById,
+  getPRSubscriptionByUrl,
+  readPRSubscriptions,
+  type PRSubscription,
+  upsertPRSubscription,
+} from '../tools/SubscribePRTool/prStore.js'
+import {
+  GitHubRateLimitError,
+  parsePullRequestUrl,
+  pollPullRequest,
+} from '../tools/SubscribePRTool/poller.js'
+import { subscribeToPullRequest } from '../tools/SubscribePRTool/SubscribePRTool.js'
+
+const HELP_TEXT = `Usage:
+/subscribe-pr <url>
+/subscribe-pr list
+/subscribe-pr remove <url>`
+
+function formatSubscription(subscription: PRSubscription): string {
+  const state = subscription.lastState
+    ? `${subscription.lastState.state}, checks ${subscription.lastState.checkSummary}, comments ${subscription.lastState.commentCount}`
+    : 'not checked yet'
+  return [
+    subscription.url,
+    `  interval: ${subscription.intervalSec}s`,
+    `  last checked: ${subscription.lastCheckedAt ?? 'never'}`,
+    `  last state: ${state}`,
+    `  last event: ${subscription.lastEventSummary ?? 'none'}`,
+  ].join('\n')
+}
+
+async function maybeSendPushNotification(message: string): Promise<void> {
+  try {
+    const transport = await import('../tools/PushNotificationTool/transport.js')
+    await transport.sendPushNotification({
+      title: 'GitHub PR update',
+      body: message,
+      priority: 'normal',
+      tag: 'PR',
+    })
+  } catch {
+    // Optional integration only.
+  }
+}
+
+function shouldSkipPoll(subscription: PRSubscription, nowMs: number): boolean {
+  const lastCheckedMs = subscription.lastCheckedAt
+    ? new Date(subscription.lastCheckedAt).getTime()
+    : 0
+  if (subscription.backoffUntil) {
+    const backoffMs = new Date(subscription.backoffUntil).getTime()
+    if (Number.isFinite(backoffMs) && backoffMs > nowMs) {
+      return true
+    }
+  }
+  return lastCheckedMs > 0 && nowMs - lastCheckedMs < subscription.intervalSec * 1000
+}
+
+async function handleList(onDone: LocalJSXCommandOnDone): Promise<void> {
+  const subscriptions = await readPRSubscriptions()
+  if (subscriptions.length === 0) {
+    onDone('No active PR subscriptions.', { display: 'system' })
+    return
+  }
+  onDone(
+    subscriptions.map(subscription => formatSubscription(subscription)).join('\n\n'),
+    { display: 'system' },
+  )
+}
+
+async function handleRemove(
+  onDone: LocalJSXCommandOnDone,
+  rawUrl: string,
+): Promise<void> {
+  const parsed = parsePullRequestUrl(rawUrl)
+  if (!parsed) {
+    onDone(
+      'Invalid GitHub PR URL. Expected https://github.com/owner/repo/pull/N',
+      { display: 'system' },
+    )
+    return
+  }
+
+  const subscription = await getPRSubscriptionByUrl(parsed.url)
+  if (!subscription) {
+    onDone(`No active subscription for ${parsed.url}.`, { display: 'system' })
+    return
+  }
+
+  await removeCronTasks([subscription.cronTaskId])
+  await deletePRSubscriptionById(subscription.id)
+  onDone(`Stopped watching ${subscription.url}.`, { display: 'system' })
+}
+
+async function handlePoll(
+  onDone: LocalJSXCommandOnDone,
+  context: LocalJSXCommandContext,
+  rawUrl: string,
+): Promise<void> {
+  const parsed = parsePullRequestUrl(rawUrl)
+  if (!parsed) {
+    onDone(undefined, { display: 'skip' })
+    return
+  }
+
+  const subscription = await getPRSubscriptionByUrl(parsed.url)
+  if (!subscription) {
+    onDone(undefined, { display: 'skip' })
+    return
+  }
+
+  const nowMs = Date.now()
+  if (shouldSkipPoll(subscription, nowMs)) {
+    onDone(undefined, { display: 'skip' })
+    return
+  }
+
+  try {
+    const result = await pollPullRequest(subscription)
+    const now = new Date(nowMs).toISOString()
+    const nextSubscription: PRSubscription = {
+      ...subscription,
+      updatedAt: now,
+      lastCheckedAt: now,
+      lastState: result.snapshot,
+      consecutiveFailures: 0,
+      backoffUntil: undefined,
+      lastError: undefined,
+      ...(result.changes.length > 0
+        ? {
+            lastEventAt: now,
+            lastEventSummary: result.changes.map(change => change.message).join('; '),
+          }
+        : {}),
+    }
+    await upsertPRSubscription(nextSubscription)
+
+    if (result.changes.length === 0) {
+      onDone(undefined, { display: 'skip' })
+      return
+    }
+
+    const message = result.changes.map(change => change.message).join('\n')
+    context.addNotification?.({
+      key: `subscribe-pr:${subscription.id}`,
+      text: message,
+      priority: 'high',
+    })
+    await maybeSendPushNotification(message)
+    onDone(message, { display: 'system' })
+  } catch (error) {
+    const failures = (subscription.consecutiveFailures ?? 0) + 1
+    const now = new Date(nowMs).toISOString()
+
+    if (error instanceof GitHubRateLimitError) {
+      const backoffUntil = new Date(
+        nowMs + Math.max(error.retryAfterMs, 30_000 * 2 ** (failures - 1)),
+      ).toISOString()
+      await upsertPRSubscription({
+        ...subscription,
+        updatedAt: now,
+        consecutiveFailures: failures,
+        lastCheckedAt: now,
+        backoffUntil,
+        lastError: error.message,
+        lastEventAt: now,
+        lastEventSummary: `Rate limited until ${backoffUntil}`,
+      })
+      const message = `PR watcher for ${subscription.url} hit a GitHub rate limit. Backing off until ${backoffUntil}.`
+      context.addNotification?.({
+        key: `subscribe-pr-rate-limit:${subscription.id}`,
+        text: message,
+        priority: 'high',
+      })
+      onDone(message, { display: 'system' })
+      return
+    }
+
+    await upsertPRSubscription({
+      ...subscription,
+      updatedAt: now,
+      consecutiveFailures: failures,
+      lastCheckedAt: now,
+      lastError: error instanceof Error ? error.message : String(error),
+    })
+    onDone(undefined, { display: 'skip' })
+  }
+}
+
+export async function call(
+  onDone: LocalJSXCommandOnDone,
+  context: LocalJSXCommandContext,
+  args: string,
+): Promise<undefined> {
+  const trimmed = args.trim()
+  if (!trimmed) {
+    onDone(HELP_TEXT, { display: 'system' })
+    return
+  }
+
+  if (trimmed === 'list') {
+    await handleList(onDone)
+    return
+  }
+
+  if (trimmed.startsWith('remove ')) {
+    await handleRemove(onDone, trimmed.slice('remove '.length).trim())
+    return
+  }
+
+  if (trimmed.startsWith('poll ')) {
+    await handlePoll(onDone, context, trimmed.slice('poll '.length).trim())
+    return
+  }
+
+  try {
+    const result = await subscribeToPullRequest({ url: trimmed })
+    const action = result.created ? 'Watching' : 'Updated watch for'
+    onDone(
+      `${action} ${result.subscription.url} every ${result.subscription.intervalSec}s. Changes: ${result.subscription.events.join(', ')}.`,
+      { display: 'system' },
+    )
+  } catch (error) {
+    onDone(error instanceof Error ? error.message : String(error), {
+      display: 'system',
+    })
+  }
+}
+
+const subscribePr = {
+  type: 'local-jsx',
+  name: 'subscribe-pr',
+  description: 'Watch a GitHub pull request and notify on new activity',
+  argumentHint: '<url>|list|remove <url>',
+  load: () => Promise.resolve({ call }),
+} satisfies Command
+
+export default subscribePr

--- a/src 2/tools/SubscribePRTool/SubscribePRTool.test.ts
+++ b/src 2/tools/SubscribePRTool/SubscribePRTool.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { parsePullRequestUrl, pollPullRequest } from './poller.js'
+import {
+  getPRSubscriptionByUrl,
+  type PRSubscription,
+  readPRSubscriptions,
+  upsertPRSubscription,
+} from './prStore.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('SubscribePRTool poller', () => {
+  test('parses canonical GitHub PR URLs', () => {
+    expect(
+      parsePullRequestUrl('https://github.com/octo/repo/pull/123'),
+    ).toEqual({
+      owner: 'octo',
+      repo: 'repo',
+      number: 123,
+      url: 'https://github.com/octo/repo/pull/123',
+    })
+    expect(parsePullRequestUrl('https://example.com/octo/repo/pull/123')).toBe(
+      null,
+    )
+  })
+
+  test('detects commit, comment, check, and state changes', async () => {
+    const calls: string[] = []
+    const fetchImpl: typeof fetch = async input => {
+      const url = String(input)
+      calls.push(url)
+      if (url.endsWith('/repos/octo/repo/pulls/123')) {
+        return jsonResponse({
+          state: 'closed',
+          merged_at: '2026-04-22T10:00:00.000Z',
+          head: { sha: 'bbbbbbb2222222' },
+          comments: 1,
+          review_comments: 0,
+        })
+      }
+      if (url.includes('/issues/123/comments?')) {
+        return jsonResponse([
+          {
+            id: 42,
+            body: 'testing the subscription',
+            html_url: 'https://github.com/octo/repo/pull/123#issuecomment-42',
+            created_at: '2026-04-22T10:00:00.000Z',
+            user: { login: 'gagan114662' },
+          },
+        ])
+      }
+      if (url.includes('/pulls/123/comments?')) {
+        return jsonResponse([])
+      }
+      if (url.endsWith('/commits/bbbbbbb2222222/status')) {
+        return jsonResponse({
+          state: 'success',
+          statuses: [{ state: 'success' }],
+        })
+      }
+      if (url.endsWith('/commits/bbbbbbb2222222/check-runs')) {
+        return jsonResponse({
+          check_runs: [{ status: 'completed', conclusion: 'success' }],
+        })
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    }
+
+    const subscription: Pick<
+      PRSubscription,
+      'events' | 'lastState' | 'number' | 'owner' | 'repo' | 'url'
+    > = {
+      owner: 'octo',
+      repo: 'repo',
+      number: 123,
+      url: 'https://github.com/octo/repo/pull/123',
+      events: ['commit', 'comment', 'check', 'state'],
+      lastState: {
+        state: 'open',
+        headSha: 'aaaaaaa1111111',
+        commentCount: 0,
+        checkSummary: 'pending',
+      },
+    }
+
+    const result = await pollPullRequest(subscription, {
+      fetchImpl,
+      getToken: async () => 'token',
+    })
+
+    expect(result.snapshot.state).toBe('merged')
+    expect(result.snapshot.checkSummary).toBe('passed')
+    expect(result.snapshot.commentCount).toBe(1)
+    expect(result.changes.map(change => change.type)).toEqual([
+      'state',
+      'commit',
+      'comment',
+      'check',
+    ])
+    expect(result.changes.map(change => change.message)).toEqual([
+      'PR #123 merged',
+      'PR #123 — new commits (aaaaaaa -> bbbbbbb)',
+      'PR #123 — new comment by @gagan114662: "testing the subscription"',
+      'PR #123 — checks passed',
+    ])
+    expect(
+      calls.some(url => url.endsWith('/repos/octo/repo/pulls/123')),
+    ).toBeTrue()
+  })
+})
+
+describe('SubscribePRTool store', () => {
+  test('writes and reads subscriptions from the Claude config dir', async () => {
+    process.env.CLAUDE_CONFIG_DIR = makeTempDir('subscribe-pr-store-')
+
+    const subscription: PRSubscription = {
+      id: 'sub-1234',
+      url: 'https://github.com/octo/repo/pull/123',
+      owner: 'octo',
+      repo: 'repo',
+      number: 123,
+      intervalSec: 60,
+      events: ['commit', 'comment', 'check', 'state'],
+      cron: '* * * * *',
+      cronTaskId: 'cron-1234',
+      createdAt: '2026-04-22T09:00:00.000Z',
+      updatedAt: '2026-04-22T09:00:00.000Z',
+      lastCheckedAt: '2026-04-22T09:00:00.000Z',
+      lastState: {
+        state: 'open',
+        headSha: 'aaaaaaa1111111',
+        commentCount: 0,
+        checkSummary: 'pending',
+      },
+      consecutiveFailures: 0,
+    }
+
+    await upsertPRSubscription(subscription)
+
+    expect(await readPRSubscriptions()).toEqual([subscription])
+    expect(
+      await getPRSubscriptionByUrl('https://github.com/octo/repo/pull/123'),
+    ).toEqual(subscription)
+  })
+})

--- a/src 2/tools/SubscribePRTool/SubscribePRTool.ts
+++ b/src 2/tools/SubscribePRTool/SubscribePRTool.ts
@@ -1,0 +1,201 @@
+import { feature } from 'bun:bundle'
+import { z } from 'zod/v4'
+import { setScheduledTasksEnabled } from '../../bootstrap/state.js'
+import type { ValidationResult } from '../../Tool.js'
+import { buildTool, type ToolDef } from '../../Tool.js'
+import { addCronTask, removeCronTasks } from '../../utils/cronTasks.js'
+import { lazySchema } from '../../utils/lazySchema.js'
+import {
+  createSubscriptionId,
+  type PRSnapshot,
+  type PRSubscription,
+  type SubscribePREvent,
+  getPRSubscriptionByUrl,
+  normalizeSubscriptionEvents,
+  upsertPRSubscription,
+} from './prStore.js'
+import { fetchPullRequestSnapshot, parsePullRequestUrl } from './poller.js'
+import {
+  DESCRIPTION,
+  SUBSCRIBE_PR_TOOL_NAME,
+  SUBSCRIBE_PR_TOOL_PROMPT,
+} from './prompt.js'
+
+const DEFAULT_INTERVAL_SEC = 60
+const MIN_INTERVAL_SEC = 30
+const MAX_INTERVAL_SEC = 3600
+const CRON_EXPRESSION = '* * * * *'
+
+const inputSchema = lazySchema(() =>
+  z.strictObject({
+    url: z
+      .string()
+      .describe(
+        'Full GitHub PR URL like https://github.com/owner/repo/pull/123',
+      ),
+    intervalSec: z
+      .number()
+      .int()
+      .min(MIN_INTERVAL_SEC)
+      .max(MAX_INTERVAL_SEC)
+      .optional()
+      .describe('Polling interval in seconds. Defaults to 60.'),
+    events: z
+      .array(z.enum(['commit', 'comment', 'check', 'state']))
+      .optional()
+      .describe(
+        'Optional event filter. Defaults to commit, comment, check, and state.',
+      ),
+  }),
+)
+type InputSchema = ReturnType<typeof inputSchema>
+
+const outputSchema = lazySchema(() =>
+  z.object({
+    created: z.boolean(),
+    id: z.string(),
+    url: z.string(),
+    intervalSec: z.number(),
+    events: z.array(z.enum(['commit', 'comment', 'check', 'state'])),
+    cronTaskId: z.string(),
+    state: z.enum(['open', 'closed', 'merged']),
+    checkSummary: z.enum(['none', 'pending', 'passed', 'failed']),
+  }),
+)
+type OutputSchema = ReturnType<typeof outputSchema>
+
+export type SubscribePRToolOutput = z.infer<OutputSchema>
+
+export type SubscribeToPullRequestResult = {
+  created: boolean
+  subscription: PRSubscription
+  initialSnapshot: PRSnapshot
+}
+
+export function buildSubscribePRCronPrompt(url: string): string {
+  return `/subscribe-pr poll ${url}`
+}
+
+export async function subscribeToPullRequest(input: {
+  url: string
+  intervalSec?: number
+  events?: readonly SubscribePREvent[]
+}): Promise<SubscribeToPullRequestResult> {
+  const parsed = parsePullRequestUrl(input.url)
+  if (!parsed) {
+    throw new Error(
+      'Invalid GitHub PR URL. Expected https://github.com/owner/repo/pull/N',
+    )
+  }
+
+  const now = new Date().toISOString()
+  const intervalSec = input.intervalSec ?? DEFAULT_INTERVAL_SEC
+  const events = normalizeSubscriptionEvents(input.events)
+  const existing = await getPRSubscriptionByUrl(parsed.url)
+  const initialSnapshot = await fetchPullRequestSnapshot(parsed)
+  const cronTaskId = await addCronTask(
+    CRON_EXPRESSION,
+    buildSubscribePRCronPrompt(parsed.url),
+    true,
+    true,
+  )
+
+  if (existing?.cronTaskId) {
+    await removeCronTasks([existing.cronTaskId])
+  }
+
+  setScheduledTasksEnabled(true)
+
+  const subscription: PRSubscription = {
+    id: existing?.id ?? createSubscriptionId(),
+    url: parsed.url,
+    owner: parsed.owner,
+    repo: parsed.repo,
+    number: parsed.number,
+    intervalSec,
+    events,
+    cron: CRON_EXPRESSION,
+    cronTaskId,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+    lastCheckedAt: now,
+    lastState: initialSnapshot,
+    consecutiveFailures: 0,
+  }
+
+  await upsertPRSubscription(subscription)
+
+  return {
+    created: existing == null,
+    subscription,
+    initialSnapshot,
+  }
+}
+
+function formatUseMessage(input: { url?: string }): string {
+  return input.url ? `Watching PR ${input.url}` : 'Watching a GitHub PR'
+}
+
+export const SubscribePRTool = buildTool({
+  name: SUBSCRIBE_PR_TOOL_NAME,
+  searchHint: 'watch a GitHub pull request for activity',
+  maxResultSizeChars: 20_000,
+  get inputSchema(): InputSchema {
+    return inputSchema()
+  },
+  get outputSchema(): OutputSchema {
+    return outputSchema()
+  },
+  isEnabled() {
+    return feature('KAIROS_GITHUB_WEBHOOKS')
+  },
+  isConcurrencySafe() {
+    return true
+  },
+  toAutoClassifierInput(input) {
+    return `${input.url}\n${input.intervalSec ?? DEFAULT_INTERVAL_SEC}`
+  },
+  async validateInput(input): Promise<ValidationResult> {
+    if (!parsePullRequestUrl(input.url)) {
+      return {
+        result: false,
+        message:
+          'Invalid GitHub PR URL. Expected https://github.com/owner/repo/pull/N',
+        errorCode: 1,
+      }
+    }
+    return { result: true }
+  },
+  async description() {
+    return DESCRIPTION
+  },
+  async prompt() {
+    return SUBSCRIBE_PR_TOOL_PROMPT
+  },
+  renderToolUseMessage(input) {
+    return formatUseMessage(input)
+  },
+  mapToolResultToToolResultBlockParam(output, toolUseID) {
+    const action = output.created ? 'Watching' : 'Updated watch for'
+    return {
+      tool_use_id: toolUseID,
+      type: 'tool_result',
+      content: `${action} ${output.url} every ${output.intervalSec}s for ${output.events.join(', ')}.`,
+    }
+  },
+  async call({ url, intervalSec = DEFAULT_INTERVAL_SEC, events }) {
+    const result = await subscribeToPullRequest({ url, intervalSec, events })
+    return {
+      data: {
+        created: result.created,
+        id: result.subscription.id,
+        url: result.subscription.url,
+        intervalSec: result.subscription.intervalSec,
+        events: result.subscription.events,
+        cronTaskId: result.subscription.cronTaskId,
+        state: result.initialSnapshot.state,
+        checkSummary: result.initialSnapshot.checkSummary,
+      },
+    }
+  },
+} satisfies ToolDef<InputSchema, SubscribePRToolOutput>)

--- a/src 2/tools/SubscribePRTool/poller.ts
+++ b/src 2/tools/SubscribePRTool/poller.ts
@@ -1,0 +1,369 @@
+import { execa } from 'execa'
+import type {
+  PRCheckSummary,
+  PRCommentSnapshot,
+  PRSnapshot,
+  PRSubscription,
+  SubscribePREvent,
+} from './prStore.js'
+
+const GITHUB_API_BASE = 'https://api.github.com'
+const GITHUB_API_VERSION = '2022-11-28'
+const GH_TOKEN_ARGS = ['auth', 'token'] as const
+const MAX_COMMENT_PREVIEW = 80
+const RATE_LIMIT_STATUSES = new Set([403, 429])
+
+let cachedGitHubToken: string | null = null
+
+type PullResponse = {
+  state: 'open' | 'closed'
+  merged_at: string | null
+  head: { sha: string }
+  comments?: number
+  review_comments?: number
+}
+
+type CombinedStatusResponse = {
+  state?: string
+  statuses?: Array<{ state?: string | null }>
+}
+
+type CheckRunsResponse = {
+  check_runs?: Array<{
+    status?: string | null
+    conclusion?: string | null
+  }>
+}
+
+type CommentResponse = {
+  id: number
+  body?: string | null
+  html_url?: string | null
+  created_at?: string | null
+  user?: { login?: string | null } | null
+}
+
+export type ParsedPullRequestUrl = {
+  owner: string
+  repo: string
+  number: number
+  url: string
+}
+
+export type PullRequestChange = {
+  type: SubscribePREvent
+  message: string
+}
+
+export type PollerResult = {
+  snapshot: PRSnapshot
+  changes: PullRequestChange[]
+}
+
+export type GitHubPollerDeps = {
+  fetchImpl?: typeof fetch
+  getToken?: () => Promise<string>
+}
+
+export class GitHubRateLimitError extends Error {
+  retryAfterMs: number
+
+  constructor(message: string, retryAfterMs: number) {
+    super(message)
+    this.name = 'GitHubRateLimitError'
+    this.retryAfterMs = retryAfterMs
+  }
+}
+
+function truncateCommentBody(body: string): string {
+  const singleLine = body.replace(/\s+/g, ' ').trim()
+  if (singleLine.length <= MAX_COMMENT_PREVIEW) {
+    return singleLine
+  }
+  return `${singleLine.slice(0, MAX_COMMENT_PREVIEW - 1)}...`
+}
+
+function shortSha(sha: string): string {
+  return sha.slice(0, 7)
+}
+
+function defaultRetryAfterMs(headers: Headers): number {
+  const retryAfter = headers.get('retry-after')
+  if (retryAfter) {
+    const seconds = Number.parseInt(retryAfter, 10)
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return seconds * 1000
+    }
+  }
+
+  const rateLimitReset = headers.get('x-ratelimit-reset')
+  if (rateLimitReset) {
+    const resetSeconds = Number.parseInt(rateLimitReset, 10)
+    if (Number.isFinite(resetSeconds) && resetSeconds > 0) {
+      return Math.max(30_000, resetSeconds * 1000 - Date.now())
+    }
+  }
+
+  return 5 * 60 * 1000
+}
+
+async function defaultGetToken(): Promise<string> {
+  if (cachedGitHubToken) {
+    return cachedGitHubToken
+  }
+  const { stdout } = await execa('gh', [...GH_TOKEN_ARGS], {
+    reject: false,
+  })
+  const token = stdout.trim()
+  if (!token) {
+    throw new Error('`gh auth token` returned an empty token.')
+  }
+  cachedGitHubToken = token
+  return token
+}
+
+async function githubApiRequest<T>(
+  path: string,
+  deps: GitHubPollerDeps = {},
+): Promise<T> {
+  const fetchImpl = deps.fetchImpl ?? fetch
+  const token = await (deps.getToken ?? defaultGetToken)()
+  const response = await fetchImpl(`${GITHUB_API_BASE}${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'User-Agent': 'claude-code-subscribe-pr',
+      'X-GitHub-Api-Version': GITHUB_API_VERSION,
+    },
+  })
+
+  if (RATE_LIMIT_STATUSES.has(response.status)) {
+    throw new GitHubRateLimitError(
+      'GitHub rate limit hit while polling this PR.',
+      defaultRetryAfterMs(response.headers),
+    )
+  }
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      cachedGitHubToken = null
+    }
+    throw new Error(
+      `GitHub API request failed: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  return (await response.json()) as T
+}
+
+async function fetchLatestComment(
+  owner: string,
+  repo: string,
+  number: number,
+  deps: GitHubPollerDeps,
+): Promise<PRCommentSnapshot | undefined> {
+  const [issueComments, reviewComments] = await Promise.all([
+    githubApiRequest<CommentResponse[]>(
+      `/repos/${owner}/${repo}/issues/${number}/comments?per_page=100`,
+      deps,
+    ),
+    githubApiRequest<CommentResponse[]>(
+      `/repos/${owner}/${repo}/pulls/${number}/comments?per_page=100`,
+      deps,
+    ),
+  ])
+
+  const latest = [...issueComments, ...reviewComments].sort((a, b) =>
+    String(a.created_at ?? '').localeCompare(String(b.created_at ?? '')),
+  )[
+    [...issueComments, ...reviewComments].length - 1
+  ]
+
+  if (!latest) {
+    return undefined
+  }
+
+  return {
+    id: latest.id,
+    author: latest.user?.login ?? 'unknown',
+    body: truncateCommentBody(latest.body ?? ''),
+    url: latest.html_url ?? '',
+    createdAt: latest.created_at ?? new Date().toISOString(),
+  }
+}
+
+function summarizeChecks(
+  combinedStatus: CombinedStatusResponse,
+  checkRuns: CheckRunsResponse,
+): PRCheckSummary {
+  const statuses = combinedStatus.statuses ?? []
+  const runs = checkRuns.check_runs ?? []
+  const hasChecks =
+    Boolean(combinedStatus.state) || statuses.length > 0 || runs.length > 0
+
+  if (!hasChecks) {
+    return 'none'
+  }
+
+  const hasPendingStatus = statuses.some(status => status.state === 'pending')
+  const hasPendingRun = runs.some(
+    run => run.status !== 'completed' || run.conclusion == null,
+  )
+  if (combinedStatus.state === 'pending' || hasPendingStatus || hasPendingRun) {
+    return 'pending'
+  }
+
+  const hasFailedStatus = statuses.some(status =>
+    ['error', 'failure'].includes(status.state ?? ''),
+  )
+  const hasFailedRun = runs.some(run =>
+    [
+      'action_required',
+      'cancelled',
+      'failure',
+      'stale',
+      'startup_failure',
+      'timed_out',
+    ].includes(run.conclusion ?? ''),
+  )
+  if (
+    combinedStatus.state === 'failure' ||
+    combinedStatus.state === 'error' ||
+    hasFailedStatus ||
+    hasFailedRun
+  ) {
+    return 'failed'
+  }
+
+  return 'passed'
+}
+
+export function parsePullRequestUrl(input: string): ParsedPullRequestUrl | null {
+  const match = input
+    .trim()
+    .match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?(?:[?#].*)?$/i)
+  if (!match?.[1] || !match[2] || !match[3]) {
+    return null
+  }
+  const owner = match[1]
+  const repo = match[2]
+  const number = Number.parseInt(match[3], 10)
+  if (!owner || !repo || !Number.isFinite(number)) {
+    return null
+  }
+  return {
+    owner,
+    repo,
+    number,
+    url: `https://github.com/${owner}/${repo}/pull/${number}`,
+  }
+}
+
+export async function fetchPullRequestSnapshot(
+  parsed: ParsedPullRequestUrl,
+  previousCommentCount?: number,
+  deps: GitHubPollerDeps = {},
+): Promise<PRSnapshot> {
+  const pull = await githubApiRequest<PullResponse>(
+    `/repos/${parsed.owner}/${parsed.repo}/pulls/${parsed.number}`,
+    deps,
+  )
+  const [combinedStatus, checkRuns] = await Promise.all([
+    githubApiRequest<CombinedStatusResponse>(
+      `/repos/${parsed.owner}/${parsed.repo}/commits/${pull.head.sha}/status`,
+      deps,
+    ),
+    githubApiRequest<CheckRunsResponse>(
+      `/repos/${parsed.owner}/${parsed.repo}/commits/${pull.head.sha}/check-runs`,
+      deps,
+    ),
+  ])
+  const commentCount = (pull.comments ?? 0) + (pull.review_comments ?? 0)
+  const latestComment =
+    commentCount > (previousCommentCount ?? 0)
+      ? await fetchLatestComment(parsed.owner, parsed.repo, parsed.number, deps)
+      : undefined
+
+  return {
+    state: pull.merged_at ? 'merged' : pull.state,
+    headSha: pull.head.sha,
+    commentCount,
+    checkSummary: summarizeChecks(combinedStatus, checkRuns),
+    ...(latestComment ? { latestComment } : {}),
+  }
+}
+
+export async function pollPullRequest(
+  subscription: Pick<
+    PRSubscription,
+    'events' | 'lastState' | 'number' | 'owner' | 'repo' | 'url'
+  >,
+  deps: GitHubPollerDeps = {},
+): Promise<PollerResult> {
+  const parsed = parsePullRequestUrl(subscription.url)
+  if (!parsed) {
+    throw new Error(`Invalid GitHub PR URL: ${subscription.url}`)
+  }
+
+  const snapshot = await fetchPullRequestSnapshot(
+    parsed,
+    subscription.lastState?.commentCount,
+    deps,
+  )
+
+  const changes: PullRequestChange[] = []
+  const previous = subscription.lastState
+
+  if (!previous) {
+    return { snapshot, changes }
+  }
+
+  if (
+    subscription.events.includes('state') &&
+    previous.state !== snapshot.state
+  ) {
+    const stateMessage =
+      snapshot.state === 'merged'
+        ? `PR #${parsed.number} merged`
+        : snapshot.state === 'closed'
+          ? `PR #${parsed.number} closed`
+          : `PR #${parsed.number} reopened`
+    changes.push({ type: 'state', message: stateMessage })
+  }
+
+  if (
+    subscription.events.includes('commit') &&
+    previous.headSha !== snapshot.headSha
+  ) {
+    changes.push({
+      type: 'commit',
+      message: `PR #${parsed.number} — new commits (${shortSha(previous.headSha)} -> ${shortSha(snapshot.headSha)})`,
+    })
+  }
+
+  if (
+    subscription.events.includes('comment') &&
+    snapshot.commentCount > previous.commentCount
+  ) {
+    const author = snapshot.latestComment?.author ?? 'unknown'
+    const body = snapshot.latestComment?.body
+      ? `: "${snapshot.latestComment.body}"`
+      : ''
+    changes.push({
+      type: 'comment',
+      message: `PR #${parsed.number} — new comment by @${author}${body}`,
+    })
+  }
+
+  if (
+    subscription.events.includes('check') &&
+    previous.checkSummary !== snapshot.checkSummary
+  ) {
+    changes.push({
+      type: 'check',
+      message: `PR #${parsed.number} — checks ${snapshot.checkSummary}`,
+    })
+  }
+
+  return { snapshot, changes }
+}

--- a/src 2/tools/SubscribePRTool/prStore.ts
+++ b/src 2/tools/SubscribePRTool/prStore.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { logForDebugging } from '../../utils/debug.js'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+import { safeParseJSON } from '../../utils/json.js'
+import { jsonStringify } from '../../utils/slowOperations.js'
+
+export const SUBSCRIBE_PR_EVENTS = [
+  'commit',
+  'comment',
+  'check',
+  'state',
+] as const
+
+export type SubscribePREvent = (typeof SUBSCRIBE_PR_EVENTS)[number]
+
+export type PRCheckSummary = 'none' | 'pending' | 'passed' | 'failed'
+export type PRLifecycleState = 'open' | 'closed' | 'merged'
+
+export type PRCommentSnapshot = {
+  id: number
+  author: string
+  body: string
+  url: string
+  createdAt: string
+}
+
+export type PRSnapshot = {
+  state: PRLifecycleState
+  headSha: string
+  commentCount: number
+  checkSummary: PRCheckSummary
+  latestComment?: PRCommentSnapshot
+}
+
+export type PRSubscription = {
+  id: string
+  url: string
+  owner: string
+  repo: string
+  number: number
+  intervalSec: number
+  events: SubscribePREvent[]
+  cron: string
+  cronTaskId: string
+  createdAt: string
+  updatedAt: string
+  lastCheckedAt?: string
+  lastState?: PRSnapshot
+  lastEventAt?: string
+  lastEventSummary?: string
+  consecutiveFailures?: number
+  backoffUntil?: string
+  lastError?: string
+}
+
+type SubscriptionFile = {
+  subscriptions: PRSubscription[]
+}
+
+export function getPRSubscriptionStorePath(): string {
+  return join(getClaudeConfigHomeDir(), 'subscriptions.json')
+}
+
+export function createSubscriptionId(): string {
+  return randomUUID().slice(0, 8)
+}
+
+export function normalizeSubscriptionEvents(
+  events?: readonly SubscribePREvent[],
+): SubscribePREvent[] {
+  if (!events || events.length === 0) {
+    return [...SUBSCRIBE_PR_EVENTS]
+  }
+  return SUBSCRIBE_PR_EVENTS.filter(event => events.includes(event))
+}
+
+export async function readPRSubscriptions(): Promise<PRSubscription[]> {
+  try {
+    const raw = await readFile(getPRSubscriptionStorePath(), 'utf8')
+    const parsed = safeParseJSON(raw, false) as SubscriptionFile | null
+    if (!parsed || !Array.isArray(parsed.subscriptions)) {
+      return []
+    }
+    return parsed.subscriptions.filter(
+      subscription =>
+        subscription &&
+        typeof subscription.id === 'string' &&
+        typeof subscription.url === 'string' &&
+        typeof subscription.owner === 'string' &&
+        typeof subscription.repo === 'string' &&
+        typeof subscription.number === 'number' &&
+        typeof subscription.intervalSec === 'number' &&
+        Array.isArray(subscription.events) &&
+        typeof subscription.cron === 'string' &&
+        typeof subscription.cronTaskId === 'string' &&
+        typeof subscription.createdAt === 'string' &&
+        typeof subscription.updatedAt === 'string',
+    )
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return []
+    }
+    logForDebugging(`[SubscribePR] failed to read store: ${String(error)}`)
+    return []
+  }
+}
+
+export async function writePRSubscriptions(
+  subscriptions: PRSubscription[],
+): Promise<void> {
+  const path = getPRSubscriptionStorePath()
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(
+    path,
+    jsonStringify({ subscriptions } satisfies SubscriptionFile, null, 2) + '\n',
+    'utf8',
+  )
+}
+
+export async function getPRSubscriptionByUrl(
+  url: string,
+): Promise<PRSubscription | null> {
+  const subscriptions = await readPRSubscriptions()
+  return subscriptions.find(subscription => subscription.url === url) ?? null
+}
+
+export async function upsertPRSubscription(
+  nextSubscription: PRSubscription,
+): Promise<void> {
+  const subscriptions = await readPRSubscriptions()
+  const next = subscriptions.filter(
+    subscription => subscription.id !== nextSubscription.id,
+  )
+  next.push(nextSubscription)
+  next.sort((a, b) => a.url.localeCompare(b.url))
+  await writePRSubscriptions(next)
+}
+
+export async function deletePRSubscriptionById(id: string): Promise<void> {
+  const subscriptions = await readPRSubscriptions()
+  const next = subscriptions.filter(subscription => subscription.id !== id)
+  if (next.length === subscriptions.length) {
+    return
+  }
+  await writePRSubscriptions(next)
+}

--- a/src 2/tools/SubscribePRTool/prompt.ts
+++ b/src 2/tools/SubscribePRTool/prompt.ts
@@ -1,0 +1,14 @@
+export const SUBSCRIBE_PR_TOOL_NAME = 'SubscribePR'
+
+export const DESCRIPTION =
+  'Watch a GitHub pull request and notify the user when its state changes'
+
+export const SUBSCRIBE_PR_TOOL_PROMPT = `Subscribe to a GitHub pull request so Claude can keep watching it in the background.
+
+Use this when the user asks you to watch, monitor, or subscribe to a PR.
+
+\`url\` must be a full GitHub pull request URL like \`https://github.com/owner/repo/pull/123\`.
+\`intervalSec\` defaults to 60, has a minimum of 30, and a maximum of 3600.
+\`events\` defaults to all supported changes: commits, comments, checks, and state transitions.
+
+The subscription is durable, creates a recurring cron wake-up, and survives CLI restarts.`


### PR DESCRIPTION
Adds a SubscribePR tool and /subscribe-pr command for durable GitHub PR subscriptions. This includes subscription persistence, GitHub polling and change detection, and slash-command/manual poll flows wired into command registration. It also adds targeted tests for URL parsing, store persistence, and comment/check/state/commit change detection. The tracked dist/cli.js bundle is rebuilt to match the source changes.