### PR TITLE
Add opt-in browser harness skill

### DIFF
--- a/src 2/entrypoints/cli.tsx
+++ b/src 2/entrypoints/cli.tsx
@@ -1,5 +1,27 @@
 import { feature } from 'bun:bundle';
 
+const DEFAULT_MACRO = {
+  VERSION: '0.0.0-rebuilt',
+  BUILD_TIME: '2026-03-31T00:00:00.000Z',
+  FEEDBACK_CHANNEL: '#claude-code',
+  ISSUES_EXPLAINER: 'open an issue',
+  PACKAGE_URL: '@anthropic-ai/claude-code',
+  NATIVE_PACKAGE_URL: '@anthropic-ai/claude-code-native',
+  VERSION_CHANGELOG: ''
+} as const;
+
+type MacroShape = typeof DEFAULT_MACRO;
+
+const globalWithMacro = globalThis as typeof globalThis & {
+  MACRO?: MacroShape;
+};
+
+// Source execution via `bun ./entrypoints/cli.tsx` does not apply the build's
+// `--define MACRO=...` injection. Provide the same default metadata early so
+// modules that read the global `MACRO` binding can still run in dev mode.
+// Built bundles still inline their own values, so this only affects source runs.
+globalWithMacro.MACRO ??= DEFAULT_MACRO;
+
 const CLI_VERSION =
   typeof MACRO !== 'undefined' && typeof MACRO.VERSION === 'string'
     ? MACRO.VERSION

--- a/src 2/entrypoints/cli.tsx
+++ b/src 2/entrypoints/cli.tsx
@@ -1,27 +1,5 @@
 import { feature } from 'bun:bundle';
 
-const DEFAULT_MACRO = {
-  VERSION: '0.0.0-rebuilt',
-  BUILD_TIME: '2026-03-31T00:00:00.000Z',
-  FEEDBACK_CHANNEL: '#claude-code',
-  ISSUES_EXPLAINER: 'open an issue',
-  PACKAGE_URL: '@anthropic-ai/claude-code',
-  NATIVE_PACKAGE_URL: '@anthropic-ai/claude-code-native',
-  VERSION_CHANGELOG: ''
-} as const;
-
-type MacroShape = typeof DEFAULT_MACRO;
-
-const globalWithMacro = globalThis as typeof globalThis & {
-  MACRO?: MacroShape;
-};
-
-// Source execution via `bun ./entrypoints/cli.tsx` does not apply the build's
-// `--define MACRO=...` injection. Provide the same default metadata early so
-// modules that read the global `MACRO` binding can still run in dev mode.
-// Built bundles still inline their own values, so this only affects source runs.
-globalWithMacro.MACRO ??= DEFAULT_MACRO;
-
 const CLI_VERSION =
   typeof MACRO !== 'undefined' && typeof MACRO.VERSION === 'string'
     ? MACRO.VERSION

--- a/src 2/main.tsx
+++ b/src 2/main.tsx
@@ -101,6 +101,7 @@ import { getActiveAgentsFromList, getAgentDefinitionsWithOverrides, isBuiltInAge
 import type { LogOption } from './types/logs.js';
 import type { Message as MessageType } from './types/message.js';
 import { assertMinVersion } from './utils/autoUpdater.js';
+import { BROWSER_HARNESS_SKILL_HINT, shouldEnableBrowserHarness } from './utils/browserHarness.js';
 import { CLAUDE_IN_CHROME_SKILL_HINT, CLAUDE_IN_CHROME_SKILL_HINT_WITH_WEBBROWSER } from './utils/claudeInChrome/prompt.js';
 import { setupClaudeInChrome, shouldAutoEnableClaudeInChrome, shouldEnableClaudeInChrome } from './utils/claudeInChrome/setup.js';
 import { getContextWindowForModel } from './utils/context.js';
@@ -1575,6 +1576,9 @@ async function run(): Promise<CommanderCommand> {
         // Silently skip any errors for the auto-enable
         logForDebugging(`[Claude in Chrome] Error (auto-enable): ${error}`);
       }
+    }
+    if (shouldEnableBrowserHarness()) {
+      appendSystemPrompt = appendSystemPrompt ? `${appendSystemPrompt}\n\n${BROWSER_HARNESS_SKILL_HINT}` : BROWSER_HARNESS_SKILL_HINT;
     }
 
     // Extract strict MCP config flag

--- a/src 2/skills/bundled/browserHarness.ts
+++ b/src 2/skills/bundled/browserHarness.ts
@@ -1,0 +1,48 @@
+import { getBrowserHarnessCommandDisplayName, resolveBrowserHarnessCommand } from '../../utils/browserHarness.js'
+import { registerBundledSkill } from '../bundledSkills.js'
+import {
+  BROWSER_HARNESS_SKILL_BODY,
+  BROWSER_HARNESS_SKILL_FILES,
+} from './browserHarnessContent.js'
+
+const DESCRIPTION =
+  'Uses an explicitly enabled Browser Harness install for real browser work against the user\'s local browser. Best for logged-in flows, uploads, OAuth, and dynamic UI tasks that normal web tools cannot reliably handle.'
+
+export function registerBrowserHarnessSkill(): void {
+  registerBundledSkill({
+    name: 'browser-harness',
+    description: DESCRIPTION,
+    allowedTools: ['Bash', 'Read', 'Grep', 'Glob', 'Edit', 'Write'],
+    userInvocable: true,
+    files: BROWSER_HARNESS_SKILL_FILES,
+    async getPromptForCommand(args) {
+      const resolvedCommand = await resolveBrowserHarnessCommand()
+      const expectedCommand = getBrowserHarnessCommandDisplayName()
+
+      const runtimeStatus = resolvedCommand
+        ? `## Runtime status
+
+Browser Harness opt-in is enabled for this session.
+
+- Resolved executable: \`${resolvedCommand}\`
+- Integration mode: explicit and optional
+- Default behavior: unchanged unless you deliberately use this skill
+`
+        : `## Runtime status
+
+Browser Harness opt-in is enabled for this session, but the executable is not currently available.
+
+- Expected executable: \`${expectedCommand}\`
+- Action: do not claim browser control is active
+- Next step: follow \`setup.md\` and explain the missing setup clearly if the user asked for a real-browser task
+`
+
+      const parts = [runtimeStatus.trim(), BROWSER_HARNESS_SKILL_BODY]
+      if (args) {
+        parts.push(`## User request\n\n${args}`)
+      }
+
+      return [{ type: 'text', text: parts.join('\n\n') }]
+    },
+  })
+}

--- a/src 2/skills/bundled/browserHarnessContent.ts
+++ b/src 2/skills/bundled/browserHarnessContent.ts
@@ -1,0 +1,113 @@
+export const BROWSER_HARNESS_SKILL_BODY = `# browser-harness
+
+Use this skill only for opt-in real-browser work against the user's already-running local browser. Prefer normal HTTP or WebBrowser-style tools for docs, static fetches, and local dev inspection. Switch to Browser Harness when the task truly needs the user's browser session, such as logged-in flows, uploads, OAuth, or dynamic UI behavior that ordinary web tools cannot reliably handle.
+
+## Operating rules
+
+1. Read \`setup.md\` first if install, bootstrap, reconnect, or attach health might matter.
+2. Read \`trust-model.md\` before touching accounts, uploads, purchases, settings, or other stateful actions.
+3. Tell the user explicitly when you are switching from normal tools to Browser Harness so they understand their real browser is in use.
+4. Use the Browser Harness executable through the Bash tool. Do not claim browser control is active unless the command actually runs.
+5. When Browser Harness is no longer needed, say so explicitly and go back to normal tools.
+
+## Command shape
+
+\`\`\`bash
+browser-harness <<'PY'
+new_tab("https://example.com")
+wait_for_load()
+print(page_info())
+PY
+\`\`\`
+
+## Day-to-day guidance
+
+- The first navigation in a fresh task should usually be \`new_tab(url)\`, not \`goto(url)\`.
+- Use \`browser-harness --doctor\` to diagnose install, daemon, or browser attach problems.
+- Use \`browser-harness --setup\` for attach or reconnect flows.
+- Use \`browser-harness --update -y\` when the harness itself reports an available update.
+- Read \`helpers.py\` in the installed harness repo before inventing new helper behavior.
+- If setup is incomplete, explain the missing prerequisite clearly instead of pretending the browser is connected.`
+
+export const BROWSER_HARNESS_SKILL_FILES: Record<string, string> = {
+  'setup.md': `# Browser Harness setup
+
+This integration is optional. Nothing changes unless the user explicitly enables it for the session.
+
+## Opt-in
+
+Enable the integration with:
+
+- \`CLAUDE_CODE_ENABLE_BROWSER_HARNESS=1\`
+
+You can export that in the shell before starting the CLI, or place it under the CLI's normal \`env\` settings so future sessions inherit it.
+
+If the executable is not on \`PATH\`, point Claude Code at it explicitly:
+
+- \`CLAUDE_CODE_BROWSER_HARNESS_PATH=/absolute/path/to/browser-harness\`
+
+## Recommended install flow
+
+Clone Browser Harness into a durable location and install it as an editable tool so the \`browser-harness\` command works from any project:
+
+\`\`\`bash
+git clone https://github.com/browser-use/browser-harness ~/Developer/browser-harness
+cd ~/Developer/browser-harness
+uv tool install -e .
+command -v browser-harness
+\`\`\`
+
+That keeps the command global while still pointing at the real repo checkout, so edits to \`helpers.py\` take effect immediately on the next run.
+
+## First attach / reconnect
+
+Prefer the built-in setup path:
+
+\`\`\`bash
+browser-harness --setup
+\`\`\`
+
+Use the doctor command when setup is incomplete or a previously working attach goes stale:
+
+\`\`\`bash
+browser-harness --doctor
+\`\`\`
+
+If the harness still cannot attach, fall back to the upstream install docs and follow the attach steps there. Do not silently assume browser control is active.
+
+## Verification
+
+After setup, verify the local browser path with one small task:
+
+\`\`\`bash
+browser-harness <<'PY'
+new_tab("https://browser-use.com")
+wait_for_load()
+print(page_info())
+PY
+\`\`\`
+
+If that succeeds, Browser Harness is ready for real tasks in the user's local browser.`,
+  'trust-model.md': `# Browser Harness trust model
+
+Browser Harness talks to the user's real local browser over CDP. Treat it as a high-trust capability.
+
+## What it can do
+
+- Read and interact with pages already open in the user's browser
+- Reuse logged-in state from the user's normal browser profile
+- Click, type, upload files, navigate, and inspect page state
+- Perform actions that are impossible or unreliable through plain HTTP fetches
+
+## Safety baseline
+
+- Say explicitly when Browser Harness is active
+- Use it only when the task actually needs the user's real browser
+- Ask before account-mutating, destructive, or purchase-like actions
+- Do not keep retrying the same risky browser action once the state looks ambiguous
+- If setup is incomplete or attach fails, say so clearly and stop pretending the browser is connected
+
+## Fallback rule
+
+If normal web tools are enough, do not use Browser Harness. This integration exists for the narrow class of tasks where real browser state is necessary.`,
+}

--- a/src 2/skills/bundled/index.ts
+++ b/src 2/skills/bundled/index.ts
@@ -1,6 +1,8 @@
 import { feature } from 'bun:bundle'
+import { shouldEnableBrowserHarness } from 'src/utils/browserHarness.js'
 import { shouldAutoEnableClaudeInChrome } from 'src/utils/claudeInChrome/setup.js'
 import { registerBatchSkill } from './batch.js'
+import { registerBrowserHarnessSkill } from './browserHarness.js'
 import { registerClaudeInChromeSkill } from './claudeInChrome.js'
 import { registerDebugSkill } from './debug.js'
 import { registerKeybindingsSkill } from './keybindings.js'
@@ -69,6 +71,9 @@ export function initBundledSkills(): void {
   }
   if (shouldAutoEnableClaudeInChrome()) {
     registerClaudeInChromeSkill()
+  }
+  if (shouldEnableBrowserHarness()) {
+    registerBrowserHarnessSkill()
   }
   if (feature('RUN_SKILL_GENERATOR')) {
     /* eslint-disable @typescript-eslint/no-require-imports */

--- a/src 2/utils/browserHarness.test.ts
+++ b/src 2/utils/browserHarness.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  BROWSER_HARNESS_ENABLE_ENV,
+  BROWSER_HARNESS_PATH_ENV,
+  resolveBrowserHarnessCommand,
+  shouldEnableBrowserHarness,
+} from './browserHarness.js'
+
+const ORIGINAL_ENABLE = process.env[BROWSER_HARNESS_ENABLE_ENV]
+const ORIGINAL_PATH = process.env[BROWSER_HARNESS_PATH_ENV]
+const ORIGINAL_SYSTEM_PATH = process.env.PATH
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  process.env[BROWSER_HARNESS_ENABLE_ENV] = ORIGINAL_ENABLE
+  process.env[BROWSER_HARNESS_PATH_ENV] = ORIGINAL_PATH
+  process.env.PATH = ORIGINAL_SYSTEM_PATH
+
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'browser-harness-test-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function makeExecutable(dir: string, name: string): string {
+  const path = join(dir, name)
+  writeFileSync(path, '#!/bin/sh\nexit 0\n', 'utf8')
+  chmodSync(path, 0o755)
+  return path
+}
+
+describe('shouldEnableBrowserHarness', () => {
+  test('defaults to disabled', () => {
+    delete process.env[BROWSER_HARNESS_ENABLE_ENV]
+    expect(shouldEnableBrowserHarness()).toBe(false)
+  })
+
+  test('accepts truthy env values', () => {
+    process.env[BROWSER_HARNESS_ENABLE_ENV] = '1'
+    expect(shouldEnableBrowserHarness()).toBe(true)
+  })
+
+  test('accepts explicit falsy env values', () => {
+    process.env[BROWSER_HARNESS_ENABLE_ENV] = 'false'
+    expect(shouldEnableBrowserHarness()).toBe(false)
+  })
+})
+
+describe('resolveBrowserHarnessCommand', () => {
+  test('prefers an explicit executable path override', async () => {
+    const dir = makeTempDir()
+    const executable = makeExecutable(dir, 'browser-harness')
+    process.env[BROWSER_HARNESS_PATH_ENV] = executable
+
+    await expect(resolveBrowserHarnessCommand()).resolves.toBe(executable)
+  })
+
+  test('returns null when the explicit path override is missing', async () => {
+    process.env[BROWSER_HARNESS_PATH_ENV] = '/tmp/does-not-exist-browser-harness'
+
+    await expect(resolveBrowserHarnessCommand()).resolves.toBeNull()
+  })
+
+  test('falls back to PATH lookup when no override is configured', async () => {
+    const dir = makeTempDir()
+    makeExecutable(dir, 'browser-harness')
+    delete process.env[BROWSER_HARNESS_PATH_ENV]
+    process.env.PATH = dir
+
+    const resolved = await resolveBrowserHarnessCommand()
+    expect(resolved).not.toBeNull()
+    expect(resolved!.endsWith('/browser-harness')).toBe(true)
+  })
+})

--- a/src 2/utils/browserHarness.ts
+++ b/src 2/utils/browserHarness.ts
@@ -1,0 +1,44 @@
+import { constants as fsConstants } from 'fs'
+import { access } from 'fs/promises'
+import { isEnvDefinedFalsy, isEnvTruthy } from './envUtils.js'
+import { which } from './which.js'
+
+export const BROWSER_HARNESS_ENABLE_ENV =
+  'CLAUDE_CODE_ENABLE_BROWSER_HARNESS'
+export const BROWSER_HARNESS_PATH_ENV = 'CLAUDE_CODE_BROWSER_HARNESS_PATH'
+
+const DEFAULT_BROWSER_HARNESS_COMMAND = 'browser-harness'
+
+export const BROWSER_HARNESS_SKILL_HINT = `**Real Browser Tasks**: Browser Harness is an explicitly enabled integration for the user's real local browser. Use normal web tools by default. When the task needs login state, uploads, OAuth, or a messy real-world UI flow, invoke Skill(skill: "browser-harness") first so you can confirm setup and then use Browser Harness deliberately.`
+
+export function shouldEnableBrowserHarness(): boolean {
+  if (isEnvTruthy(process.env[BROWSER_HARNESS_ENABLE_ENV])) {
+    return true
+  }
+  if (isEnvDefinedFalsy(process.env[BROWSER_HARNESS_ENABLE_ENV])) {
+    return false
+  }
+  return false
+}
+
+export function getBrowserHarnessCommandDisplayName(): string {
+  return process.env[BROWSER_HARNESS_PATH_ENV]?.trim() || DEFAULT_BROWSER_HARNESS_COMMAND
+}
+
+export async function resolveBrowserHarnessCommand(): Promise<string | null> {
+  const explicitPath = process.env[BROWSER_HARNESS_PATH_ENV]?.trim()
+  if (explicitPath) {
+    return (await isExecutableFile(explicitPath)) ? explicitPath : null
+  }
+
+  return which(DEFAULT_BROWSER_HARNESS_COMMAND)
+}
+
+async function isExecutableFile(path: string): Promise<boolean> {
+  try {
+    await access(path, fsConstants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Adds an explicitly enabled Browser Harness integration as a bundled skill, with setup and trust-model guidance plus runtime checks for the local executable. Injects a system hint only when the feature flag is enabled, so default CLI behavior stays unchanged. Also adds focused tests for enablement and command resolution.