### PR TITLE
feat(kairos): add tier 3 reflection runner

### DIFF
--- a/src 2/daemon/kairos/childRunner.test.ts
+++ b/src 2/daemon/kairos/childRunner.test.ts
@@ -56,7 +56,13 @@ describe('childRunner.runChild', () => {
         tools: ['Read'],
         session_id: 'sess-1',
       },
-      { type: 'assistant', session_id: 'sess-1' },
+      {
+        type: 'assistant',
+        session_id: 'sess-1',
+        message: {
+          content: [{ type: 'text', text: '{"surface":false}' }],
+        },
+      },
       {
         type: 'result',
         subtype: 'success',
@@ -93,6 +99,7 @@ describe('childRunner.runChild', () => {
     expect(result.numTurns).toBe(2)
     expect(result.sessionId).toBe('sess-1')
     expect(result.allowedTools).toEqual(['Read'])
+    expect(result.lastAssistantText).toBe('{"surface":false}')
 
     expect(calls).toHaveLength(1)
     const startEvents = events.filter(e => e.kind === 'child_started')

--- a/src 2/daemon/kairos/childRunner.ts
+++ b/src 2/daemon/kairos/childRunner.ts
@@ -77,6 +77,7 @@ export type ChildRunResult = {
   numTurns: number
   durationMs: number
   allowedTools: string[]
+  lastAssistantText?: string
   errorMessage?: string
 }
 
@@ -145,6 +146,36 @@ function exitReasonFromResult(
   }
 }
 
+function extractAssistantText(message: unknown): string | undefined {
+  if (!message || typeof message !== 'object') {
+    return undefined
+  }
+
+  const content = (message as { content?: unknown }).content
+  if (typeof content === 'string') {
+    const trimmed = content.trim()
+    return trimmed.length > 0 ? trimmed : undefined
+  }
+
+  if (!Array.isArray(content)) {
+    return undefined
+  }
+
+  const text = content
+    .filter(
+      (block): block is { type: 'text'; text: string } =>
+        !!block &&
+        typeof block === 'object' &&
+        (block as { type?: unknown }).type === 'text' &&
+        typeof (block as { text?: unknown }).text === 'string',
+    )
+    .map(block => block.text)
+    .join('\n')
+    .trim()
+
+  return text.length > 0 ? text : undefined
+}
+
 export async function runChild(
   options: ChildRunOptions,
   deps: ChildRunDeps,
@@ -184,6 +215,7 @@ export async function runChild(
   let resultMessage:
     | Extract<ChildStreamMessage, { type: 'result' }>
     | undefined
+  let lastAssistantText: string | undefined
   let streamError: Error | null = null
 
   try {
@@ -207,6 +239,11 @@ export async function runChild(
         messageType: String(message.type),
         sessionId,
       })
+
+      if (message.type === 'assistant') {
+        lastAssistantText =
+          extractAssistantText(message.message) ?? lastAssistantText
+      }
 
       if (message.type === 'result') {
         resultMessage = message as Extract<
@@ -241,6 +278,7 @@ export async function runChild(
       numTurns: resultMessage?.num_turns ?? 0,
       durationMs,
       allowedTools,
+      lastAssistantText,
       errorMessage: `child run exceeded ${timeoutMs}ms`,
     }
     await deps.onEvent({
@@ -273,6 +311,7 @@ export async function runChild(
       numTurns: resultMessage?.num_turns ?? 0,
       durationMs,
       allowedTools,
+      lastAssistantText,
       errorMessage: streamError.message,
     }
     await deps.onEvent({
@@ -299,6 +338,7 @@ export async function runChild(
       numTurns: 0,
       durationMs,
       allowedTools,
+      lastAssistantText,
       errorMessage: 'child stream ended without a result message',
     }
     await deps.onEvent({
@@ -333,6 +373,7 @@ export async function runChild(
     numTurns: resultMessage.num_turns ?? 0,
     durationMs: resultMessage.duration_ms ?? durationMs,
     allowedTools,
+    lastAssistantText,
     errorMessage: resultMessage.errors?.[0],
   }
 

--- a/src 2/daemon/kairos/stateWriter.ts
+++ b/src 2/daemon/kairos/stateWriter.ts
@@ -42,6 +42,35 @@ export type ProjectLogEvent =
       source: 'daemon'
       projectDir?: string
     }
+  | {
+      kind: 'tier3_reflection'
+      t: string
+      windowKey: string
+      outcome:
+        | 'skipped_hourly_cap'
+        | 'skipped_paused'
+        | 'noop'
+        | 'surface'
+        | 'invalid_output'
+        | 'child_error'
+      runId?: string
+      enabled: true
+      allowedTools?: string[]
+      costUSD?: number
+      numTurns?: number
+      durationMs?: number
+      message?: string
+      errorMessage?: string
+      paused?: boolean
+    }
+  | {
+      kind: 'tier3_surface'
+      t: string
+      projectDir: string
+      runId: string
+      message: string
+      source: 'daemon'
+    }
 
 export type GlobalStatus = {
   kind: 'kairos'

--- a/src 2/daemon/kairos/tier3.test.ts
+++ b/src 2/daemon/kairos/tier3.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type {
+  ChildLauncher,
+  ChildLauncherParams,
+  ChildStreamMessage,
+} from './childRunner.js'
+import { getKairosGlobalEventsPath, getProjectKairosEventsPath } from './paths.js'
+import { createStateWriter } from './stateWriter.js'
+import { runTier3Reflection } from './tier3.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  delete process.env.KAIROS_TIER3_INTERVAL_MS
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function writeTier3Settings(
+  projectDir: string,
+  settings: { enabled: boolean; intervalMs?: number },
+): void {
+  const settingsDir = join(projectDir, '.claude')
+  mkdirSync(settingsDir, { recursive: true })
+  writeFileSync(
+    join(settingsDir, 'settings.local.json'),
+    JSON.stringify({ kairos: { tier3: settings } }, null, 2),
+  )
+}
+
+function makeLauncher(messages: ChildStreamMessage[]): {
+  launcher: ChildLauncher
+  calls: ChildLauncherParams[]
+} {
+  const calls: ChildLauncherParams[] = []
+  const launcher: ChildLauncher = async function* (params) {
+    calls.push(params)
+    for (const message of messages) {
+      yield message
+    }
+  }
+  return { launcher, calls }
+}
+
+function makeAssistantJsonMessage(json: string): ChildStreamMessage {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{ type: 'text', text: json }],
+    },
+  }
+}
+
+describe('Kairos Tier 3 reflection', () => {
+  test('is disabled by default', async () => {
+    const configDir = makeTempDir('kairos-tier3-config-')
+    const projectDir = makeTempDir('kairos-tier3-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+
+    const { launcher, calls } = makeLauncher([
+      makeAssistantJsonMessage('{"surface":false}'),
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        duration_ms: 50,
+        total_cost_usd: 0.01,
+      },
+    ])
+
+    const result = await runTier3Reflection({
+      projectDir,
+      stateWriter,
+      launcher,
+      costTracker: null,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 3,
+      timeoutMs: 5_000,
+      handleCapHit: async () => {},
+      now: () => new Date('2026-04-22T12:00:00.000Z'),
+    })
+
+    expect(result.outcome).toBe('disabled')
+    expect(calls).toHaveLength(0)
+    expect(existsSync(join(projectDir, '.claude', 'kairos', 'log.jsonl'))).toBe(
+      false,
+    )
+  })
+
+  test('runs at most once per interval window per project', async () => {
+    const configDir = makeTempDir('kairos-tier3-cap-config-')
+    const projectDir = makeTempDir('kairos-tier3-cap-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    writeTier3Settings(projectDir, { enabled: true, intervalMs: 60 * 60 * 1000 })
+
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+
+    const { launcher, calls } = makeLauncher([
+      makeAssistantJsonMessage('{"surface":false}'),
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        duration_ms: 80,
+        total_cost_usd: 0.01,
+      },
+    ])
+
+    const now = () => new Date('2026-04-22T12:15:00.000Z')
+    const first = await runTier3Reflection({
+      projectDir,
+      stateWriter,
+      launcher,
+      costTracker: null,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 3,
+      timeoutMs: 5_000,
+      handleCapHit: async () => {},
+      now,
+    })
+    const second = await runTier3Reflection({
+      projectDir,
+      stateWriter,
+      launcher,
+      costTracker: null,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 3,
+      timeoutMs: 5_000,
+      handleCapHit: async () => {},
+      now,
+    })
+
+    expect(first.outcome).toBe('noop')
+    expect(second.outcome).toBe('skipped_hourly_cap')
+    expect(calls).toHaveLength(1)
+
+    const log = readFileSync(
+      join(projectDir, '.claude', 'kairos', 'log.jsonl'),
+      'utf8',
+    )
+    expect(log).toContain('"outcome":"noop"')
+    expect(log).toContain('"outcome":"skipped_hourly_cap"')
+  })
+
+  test('surface=false logs a no-op without surfacing a message event', async () => {
+    const configDir = makeTempDir('kairos-tier3-noop-config-')
+    const projectDir = makeTempDir('kairos-tier3-noop-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    writeTier3Settings(projectDir, { enabled: true, intervalMs: 60 * 60 * 1000 })
+
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+
+    const { launcher } = makeLauncher([
+      makeAssistantJsonMessage('{"surface":false}'),
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        duration_ms: 90,
+        total_cost_usd: 0.01,
+      },
+    ])
+
+    const result = await runTier3Reflection({
+      projectDir,
+      stateWriter,
+      launcher,
+      costTracker: null,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 3,
+      timeoutMs: 5_000,
+      handleCapHit: async () => {},
+      now: () => new Date('2026-04-22T13:00:00.000Z'),
+    })
+
+    expect(result.outcome).toBe('noop')
+
+    const projectEvents = readFileSync(
+      getProjectKairosEventsPath(projectDir),
+      'utf8',
+    )
+    expect(projectEvents).not.toContain('"kind":"tier3_surface"')
+
+    const log = readFileSync(
+      join(projectDir, '.claude', 'kairos', 'log.jsonl'),
+      'utf8',
+    )
+    expect(log).toContain('"outcome":"noop"')
+  })
+
+  test('surface=true writes visible message events and filters unsafe tools', async () => {
+    const configDir = makeTempDir('kairos-tier3-surface-config-')
+    const projectDir = makeTempDir('kairos-tier3-surface-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    writeTier3Settings(projectDir, { enabled: true, intervalMs: 60 * 60 * 1000 })
+
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+
+    const { launcher, calls } = makeLauncher([
+      makeAssistantJsonMessage(
+        '{"surface":true,"message":"Tests are failing in auth.ts and should be surfaced before the next run."}',
+      ),
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 2,
+        duration_ms: 120,
+        total_cost_usd: 0.02,
+        session_id: 'tier3-session',
+      },
+    ])
+
+    const result = await runTier3Reflection({
+      projectDir,
+      stateWriter,
+      launcher,
+      costTracker: null,
+      defaultAllowedTools: ['Read', 'Bash'],
+      maxTurns: 3,
+      timeoutMs: 5_000,
+      handleCapHit: async () => {},
+      now: () => new Date('2026-04-22T14:00:00.000Z'),
+    })
+
+    expect(result.outcome).toBe('surface')
+    expect(result.message).toContain('Tests are failing')
+    expect(calls[0]?.allowedTools).toEqual(['Read'])
+
+    const projectEvents = readFileSync(
+      getProjectKairosEventsPath(projectDir),
+      'utf8',
+    )
+    expect(projectEvents).toContain('"kind":"tier3_surface"')
+    expect(projectEvents).toContain('Tests are failing in auth.ts')
+
+    const globalEvents = readFileSync(getKairosGlobalEventsPath(), 'utf8')
+    expect(globalEvents).toContain('"kind":"tier3_surface"')
+    expect(globalEvents).toContain(projectDir)
+
+    const log = readFileSync(
+      join(projectDir, '.claude', 'kairos', 'log.jsonl'),
+      'utf8',
+    )
+    expect(log).toContain('"outcome":"surface"')
+  })
+})

--- a/src 2/daemon/kairos/tier3.test.ts
+++ b/src 2/daemon/kairos/tier3.test.ts
@@ -36,7 +36,7 @@ function makeTempDir(prefix: string): string {
 
 function writeTier3Settings(
   projectDir: string,
-  settings: { enabled: boolean; intervalMs?: number },
+  settings: { enabled: boolean },
 ): void {
   const settingsDir = join(projectDir, '.claude')
   mkdirSync(settingsDir, { recursive: true })
@@ -114,7 +114,7 @@ describe('Kairos Tier 3 reflection', () => {
     const projectDir = makeTempDir('kairos-tier3-cap-project-')
     process.env.CLAUDE_CONFIG_DIR = configDir
 
-    writeTier3Settings(projectDir, { enabled: true, intervalMs: 60 * 60 * 1000 })
+    writeTier3Settings(projectDir, { enabled: true })
 
     const stateWriter = await createStateWriter()
     await stateWriter.ensureProjectDir(projectDir)
@@ -172,7 +172,7 @@ describe('Kairos Tier 3 reflection', () => {
     const projectDir = makeTempDir('kairos-tier3-noop-project-')
     process.env.CLAUDE_CONFIG_DIR = configDir
 
-    writeTier3Settings(projectDir, { enabled: true, intervalMs: 60 * 60 * 1000 })
+    writeTier3Settings(projectDir, { enabled: true })
 
     const stateWriter = await createStateWriter()
     await stateWriter.ensureProjectDir(projectDir)
@@ -221,7 +221,7 @@ describe('Kairos Tier 3 reflection', () => {
     const projectDir = makeTempDir('kairos-tier3-surface-project-')
     process.env.CLAUDE_CONFIG_DIR = configDir
 
-    writeTier3Settings(projectDir, { enabled: true, intervalMs: 60 * 60 * 1000 })
+    writeTier3Settings(projectDir, { enabled: true })
 
     const stateWriter = await createStateWriter()
     await stateWriter.ensureProjectDir(projectDir)
@@ -240,6 +240,8 @@ describe('Kairos Tier 3 reflection', () => {
         session_id: 'tier3-session',
       },
     ])
+    const surfaced: Array<{ projectDir: string; runId: string; message: string }> =
+      []
 
     const result = await runTier3Reflection({
       projectDir,
@@ -250,12 +252,18 @@ describe('Kairos Tier 3 reflection', () => {
       maxTurns: 3,
       timeoutMs: 5_000,
       handleCapHit: async () => {},
+      onSurface: async params => {
+        surfaced.push(params)
+      },
       now: () => new Date('2026-04-22T14:00:00.000Z'),
     })
 
     expect(result.outcome).toBe('surface')
     expect(result.message).toContain('Tests are failing')
     expect(calls[0]?.allowedTools).toEqual(['Read'])
+    expect(surfaced).toHaveLength(1)
+    expect(surfaced[0]?.projectDir).toBe(projectDir)
+    expect(surfaced[0]?.message).toContain('Tests are failing')
 
     const projectEvents = readFileSync(
       getProjectKairosEventsPath(projectDir),
@@ -273,5 +281,93 @@ describe('Kairos Tier 3 reflection', () => {
       'utf8',
     )
     expect(log).toContain('"outcome":"surface"')
+  })
+
+  test('settings interval does not lower the hourly cap, but env override can', async () => {
+    const configDir = makeTempDir('kairos-tier3-interval-config-')
+    const projectDir = makeTempDir('kairos-tier3-interval-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    const settingsDir = join(projectDir, '.claude')
+    mkdirSync(settingsDir, { recursive: true })
+    writeFileSync(
+      join(settingsDir, 'settings.local.json'),
+      JSON.stringify(
+        { kairos: { tier3: { enabled: true, intervalMs: 15_000 } } },
+        null,
+        2,
+      ),
+    )
+
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+
+    const firstLauncher = makeLauncher([
+      makeAssistantJsonMessage('{"surface":false}'),
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        duration_ms: 80,
+        total_cost_usd: 0.01,
+      },
+    ])
+
+    const sameHour = () => new Date('2026-04-22T12:15:00.000Z')
+    const first = await runTier3Reflection({
+      projectDir,
+      stateWriter,
+      launcher: firstLauncher.launcher,
+      costTracker: null,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 3,
+      timeoutMs: 5_000,
+      handleCapHit: async () => {},
+      now: sameHour,
+    })
+    const second = await runTier3Reflection({
+      projectDir,
+      stateWriter,
+      launcher: firstLauncher.launcher,
+      costTracker: null,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 3,
+      timeoutMs: 5_000,
+      handleCapHit: async () => {},
+      now: sameHour,
+    })
+
+    expect(first.outcome).toBe('noop')
+    expect(second.outcome).toBe('skipped_hourly_cap')
+    expect(firstLauncher.calls).toHaveLength(1)
+
+    process.env.KAIROS_TIER3_INTERVAL_MS = '15000'
+    const envOverrideLauncher = makeLauncher([
+      makeAssistantJsonMessage('{"surface":false}'),
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        duration_ms: 80,
+        total_cost_usd: 0.01,
+      },
+    ])
+
+    const third = await runTier3Reflection({
+      projectDir,
+      stateWriter,
+      launcher: envOverrideLauncher.launcher,
+      costTracker: null,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 3,
+      timeoutMs: 5_000,
+      handleCapHit: async () => {},
+      now: () => new Date('2026-04-22T12:15:15.000Z'),
+    })
+
+    expect(third.outcome).toBe('noop')
+    expect(envOverrideLauncher.calls).toHaveLength(1)
   })
 })

--- a/src 2/daemon/kairos/tier3.ts
+++ b/src 2/daemon/kairos/tier3.ts
@@ -4,6 +4,7 @@ import { z } from 'zod/v4'
 import type { CronTask } from '../../utils/cronTasks.js'
 import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
 import { parseSettingsFile } from '../../utils/settings/settings.js'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
 import type { ChildLauncher, ChildRunResult } from './childRunner.js'
 import { runChild } from './childRunner.js'
 import type { CapHit, CostTracker } from './costTracker.js'
@@ -46,7 +47,6 @@ type Tier3State = {
 
 type Tier3Config = {
   enabled: boolean
-  intervalMs: number
 }
 
 export type Tier3ReflectionOutcome =
@@ -80,6 +80,11 @@ export type RunTier3ReflectionOptions = {
   timeoutMs: number
   checkPaused?: () => Promise<boolean>
   handleCapHit: Tier3CapHitHandler
+  onSurface?: (params: {
+    projectDir: string
+    runId: string
+    message: string
+  }) => Promise<void>
   now?: () => Date
 }
 
@@ -106,7 +111,7 @@ function parsePositiveNumber(value: unknown): number | undefined {
     : undefined
 }
 
-function readTier3ConfigPartial(settings: unknown): Partial<Tier3Config> {
+function readTier3ConfigPartial(settings: unknown): Pick<Tier3Config, 'enabled'> | {} {
   if (!settings || typeof settings !== 'object') return {}
   const kairos = (settings as Record<string, unknown>).kairos
   if (!kairos || typeof kairos !== 'object') return {}
@@ -117,7 +122,6 @@ function readTier3ConfigPartial(settings: unknown): Partial<Tier3Config> {
   return {
     enabled:
       typeof record.enabled === 'boolean' ? record.enabled : undefined,
-    intervalMs: parsePositiveNumber(record.intervalMs),
   }
 }
 
@@ -137,16 +141,15 @@ export function computeTier3AllowedTools(
   return defaultAllowedTools.filter(tool => SAFE_TIER3_TOOLS.has(tool))
 }
 
-async function readTier3Config(projectDir: string): Promise<Tier3Config> {
+async function readTier3Config(projectDir: string): Promise<Tier3Config & { intervalMs: number }> {
+  resetSettingsCache()
+
   const merged: Partial<Tier3Config> = {}
   for (const path of getProjectSettingsPaths(projectDir)) {
     const { settings } = parseSettingsFile(path)
     const partial = readTier3ConfigPartial(settings)
     if (partial.enabled !== undefined) {
       merged.enabled = partial.enabled
-    }
-    if (partial.intervalMs !== undefined) {
-      merged.intervalMs = partial.intervalMs
     }
   }
 
@@ -158,7 +161,7 @@ async function readTier3Config(projectDir: string): Promise<Tier3Config> {
 
   return {
     enabled: merged.enabled === true,
-    intervalMs: envInterval ?? merged.intervalMs ?? DEFAULT_TIER3_INTERVAL_MS,
+    intervalMs: envInterval ?? DEFAULT_TIER3_INTERVAL_MS,
   }
 }
 
@@ -433,6 +436,11 @@ export async function runTier3Reflection(
     message: decision.message!,
     source: 'daemon' as const,
   }
+  await options.onSurface?.({
+    projectDir: options.projectDir,
+    runId: runResult.runId,
+    message: decision.message!,
+  })
   await options.stateWriter.appendProjectEvent(options.projectDir, surfaceEvent)
   await options.stateWriter.appendGlobalEvent(surfaceEvent)
   await appendReflectionLog(options.stateWriter, options.projectDir, {

--- a/src 2/daemon/kairos/tier3.ts
+++ b/src 2/daemon/kairos/tier3.ts
@@ -1,0 +1,504 @@
+import { mkdir, readFile, rename, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
+import { z } from 'zod/v4'
+import type { CronTask } from '../../utils/cronTasks.js'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+import { parseSettingsFile } from '../../utils/settings/settings.js'
+import type { ChildLauncher, ChildRunResult } from './childRunner.js'
+import { runChild } from './childRunner.js'
+import type { CapHit, CostTracker } from './costTracker.js'
+import type { StateWriter } from './stateWriter.js'
+
+const DEFAULT_TIER3_INTERVAL_MS = 60 * 60 * 1000
+const MAX_SURFACED_MESSAGE_CHARS = 280
+const MAX_TIER3_TURNS = 4
+const SAFE_TIER3_TOOLS = new Set(['Read', 'Glob', 'Grep', 'LS'])
+
+const Tier3DecisionSchema = z
+  .object({
+    surface: z.boolean(),
+    message: z.string().trim().min(1).max(MAX_SURFACED_MESSAGE_CHARS).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.surface && !value.message) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'message is required when surface=true',
+        path: ['message'],
+      })
+    }
+  })
+
+type Tier3Decision = z.infer<typeof Tier3DecisionSchema>
+
+type Tier3State = {
+  lastWindowKey?: string
+  lastRunAt?: string
+  lastOutcome?:
+    | 'noop'
+    | 'surface'
+    | 'invalid_output'
+    | 'child_error'
+    | 'skipped_hourly_cap'
+    | 'skipped_paused'
+  lastRunId?: string
+}
+
+type Tier3Config = {
+  enabled: boolean
+  intervalMs: number
+}
+
+export type Tier3ReflectionOutcome =
+  | 'disabled'
+  | 'skipped_hourly_cap'
+  | 'skipped_paused'
+  | 'noop'
+  | 'surface'
+  | 'invalid_output'
+  | 'child_error'
+
+export type Tier3ReflectionResult = {
+  outcome: Tier3ReflectionOutcome
+  runResult?: ChildRunResult
+  message?: string
+}
+
+type Tier3CapHitHandler = (params: {
+  capHit: CapHit
+  projectDir: string
+  task: CronTask
+}) => Promise<void>
+
+export type RunTier3ReflectionOptions = {
+  projectDir: string
+  stateWriter: StateWriter
+  launcher: ChildLauncher | null
+  costTracker: CostTracker | null
+  defaultAllowedTools: string[]
+  maxTurns: number
+  timeoutMs: number
+  checkPaused?: () => Promise<boolean>
+  handleCapHit: Tier3CapHitHandler
+  now?: () => Date
+}
+
+export type Tier3Controller = {
+  start(): void
+  stop(): Promise<void>
+}
+
+function getTier3StatePath(projectDir: string): string {
+  return join(projectDir, '.claude', 'kairos', 'tier3.json')
+}
+
+function getProjectSettingsPaths(projectDir: string): string[] {
+  return [
+    join(getClaudeConfigHomeDir(), 'settings.json'),
+    join(projectDir, '.claude', 'settings.json'),
+    join(projectDir, '.claude', 'settings.local.json'),
+  ]
+}
+
+function parsePositiveNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined
+}
+
+function readTier3ConfigPartial(settings: unknown): Partial<Tier3Config> {
+  if (!settings || typeof settings !== 'object') return {}
+  const kairos = (settings as Record<string, unknown>).kairos
+  if (!kairos || typeof kairos !== 'object') return {}
+  const tier3 = (kairos as Record<string, unknown>).tier3
+  if (!tier3 || typeof tier3 !== 'object') return {}
+
+  const record = tier3 as Record<string, unknown>
+  return {
+    enabled:
+      typeof record.enabled === 'boolean' ? record.enabled : undefined,
+    intervalMs: parsePositiveNumber(record.intervalMs),
+  }
+}
+
+export function getTier3WindowKey(now: Date, intervalMs: number): string {
+  const bucketStartMs = Math.floor(now.getTime() / intervalMs) * intervalMs
+  return new Date(bucketStartMs).toISOString()
+}
+
+export function getNextTier3DelayMs(now: Date, intervalMs: number): number {
+  const remainder = now.getTime() % intervalMs
+  return remainder === 0 ? intervalMs : intervalMs - remainder
+}
+
+export function computeTier3AllowedTools(
+  defaultAllowedTools: string[],
+): string[] {
+  return defaultAllowedTools.filter(tool => SAFE_TIER3_TOOLS.has(tool))
+}
+
+async function readTier3Config(projectDir: string): Promise<Tier3Config> {
+  const merged: Partial<Tier3Config> = {}
+  for (const path of getProjectSettingsPaths(projectDir)) {
+    const { settings } = parseSettingsFile(path)
+    const partial = readTier3ConfigPartial(settings)
+    if (partial.enabled !== undefined) {
+      merged.enabled = partial.enabled
+    }
+    if (partial.intervalMs !== undefined) {
+      merged.intervalMs = partial.intervalMs
+    }
+  }
+
+  const envInterval = parsePositiveNumber(
+    process.env.KAIROS_TIER3_INTERVAL_MS
+      ? Number(process.env.KAIROS_TIER3_INTERVAL_MS)
+      : undefined,
+  )
+
+  return {
+    enabled: merged.enabled === true,
+    intervalMs: envInterval ?? merged.intervalMs ?? DEFAULT_TIER3_INTERVAL_MS,
+  }
+}
+
+async function readTier3State(projectDir: string): Promise<Tier3State> {
+  try {
+    const raw = await readFile(getTier3StatePath(projectDir), 'utf8')
+    return JSON.parse(raw) as Tier3State
+  } catch {
+    return {}
+  }
+}
+
+async function writeTier3State(
+  projectDir: string,
+  state: Tier3State,
+): Promise<void> {
+  const path = getTier3StatePath(projectDir)
+  const tempPath = `${path}.tmp`
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(tempPath, `${JSON.stringify(state, null, 2)}\n`, 'utf8')
+  await rename(tempPath, path)
+}
+
+function truncateForLog(value: string | undefined, max = 160): string | undefined {
+  if (!value) return undefined
+  return value.length > max ? `${value.slice(0, max - 3)}...` : value
+}
+
+function normalizeStructuredOutput(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^```json\s*/i, '')
+    .replace(/^```\s*/i, '')
+    .replace(/\s*```$/, '')
+    .trim()
+}
+
+export function parseTier3Decision(raw: string): Tier3Decision {
+  const normalized = normalizeStructuredOutput(raw)
+  return Tier3DecisionSchema.parse(JSON.parse(normalized))
+}
+
+export function buildTier3Prompt(projectDir: string, now: Date): string {
+  return [
+    'You are the KAIROS Tier 3 reflection runner for a local code project.',
+    `Current time: ${now.toISOString()}`,
+    `Project root: ${projectDir}`,
+    'Goal: decide whether there is exactly one concise proactive message worth surfacing to the user right now.',
+    'You may inspect local project context, especially:',
+    `- ${join(projectDir, '.claude', 'kairos', 'events.jsonl')}`,
+    `- ${join(projectDir, '.claude', 'kairos', 'log.jsonl')}`,
+    `- ${join(projectDir, '.claude', 'scheduled_tasks.json')}`,
+    'Rules:',
+    '- Use at most one tool call. Prefer answering without tools if the prompt already gives enough context.',
+    '- Never take actions on the user’s behalf.',
+    '- Never ask to run tools or change files.',
+    '- If there is no clearly useful proactive message, return surface=false.',
+    `- If surface=true, message must be plain text under ${MAX_SURFACED_MESSAGE_CHARS} characters.`,
+    '- Return exactly one JSON object and nothing else.',
+    'Valid responses:',
+    '{"surface":false}',
+    '{"surface":true,"message":"..."}',
+  ].join('\n')
+}
+
+function buildSyntheticTier3Task(windowKey: string): CronTask {
+  return {
+    id: `tier3-${windowKey}`,
+    cron: '@hourly',
+    prompt: 'Reflect on recent Kairos context and surface one proactive message only if justified.',
+    createdAt: Date.now(),
+  }
+}
+
+async function appendReflectionLog(
+  stateWriter: StateWriter,
+  projectDir: string,
+  event: Parameters<StateWriter['appendProjectLog']>[1],
+): Promise<void> {
+  await stateWriter.appendProjectLog(projectDir, event)
+}
+
+export async function runTier3Reflection(
+  options: RunTier3ReflectionOptions,
+): Promise<Tier3ReflectionResult> {
+  const now = options.now ?? (() => new Date())
+  const startedAt = now()
+  const config = await readTier3Config(options.projectDir)
+  if (!config.enabled || !options.launcher) {
+    return { outcome: 'disabled' }
+  }
+
+  const windowKey = getTier3WindowKey(startedAt, config.intervalMs)
+
+  if (options.checkPaused && (await options.checkPaused())) {
+    await appendReflectionLog(options.stateWriter, options.projectDir, {
+      kind: 'tier3_reflection',
+      t: startedAt.toISOString(),
+      windowKey,
+      outcome: 'skipped_paused',
+      enabled: true,
+      paused: true,
+    })
+    return { outcome: 'skipped_paused' }
+  }
+
+  const existingState = await readTier3State(options.projectDir)
+  if (existingState.lastWindowKey === windowKey) {
+    await appendReflectionLog(options.stateWriter, options.projectDir, {
+      kind: 'tier3_reflection',
+      t: startedAt.toISOString(),
+      windowKey,
+      outcome: 'skipped_hourly_cap',
+      enabled: true,
+    })
+    return { outcome: 'skipped_hourly_cap' }
+  }
+
+  await writeTier3State(options.projectDir, {
+    lastWindowKey: windowKey,
+    lastRunAt: startedAt.toISOString(),
+  })
+
+  const allowedTools = computeTier3AllowedTools(options.defaultAllowedTools)
+  const runResult = await runChild(
+    {
+      taskId: `tier3:${windowKey}`,
+      prompt: buildTier3Prompt(options.projectDir, startedAt),
+      projectDir: options.projectDir,
+      allowedTools,
+      maxTurns: Math.max(1, Math.min(options.maxTurns, MAX_TIER3_TURNS)),
+      timeoutMs: options.timeoutMs,
+    },
+    {
+      launcher: options.launcher,
+      now,
+      onEvent: event =>
+        options.stateWriter.appendProjectEvent(options.projectDir, {
+          ...event,
+          source: 'tier3',
+          windowKey,
+        }),
+    },
+  )
+
+  let paused = false
+  if (options.costTracker) {
+    const { capHit } = await options.costTracker.record({
+      projectDir: options.projectDir,
+      taskId: `tier3:${windowKey}`,
+      runId: runResult.runId,
+      costUSD: runResult.costUSD,
+      numTurns: runResult.numTurns,
+      durationMs: runResult.durationMs,
+    })
+    if (capHit) {
+      await options.handleCapHit({
+        capHit,
+        projectDir: options.projectDir,
+        task: buildSyntheticTier3Task(windowKey),
+      })
+      paused = true
+    }
+  }
+
+  if (!runResult.ok) {
+    await appendReflectionLog(options.stateWriter, options.projectDir, {
+      kind: 'tier3_reflection',
+      t: now().toISOString(),
+      windowKey,
+      outcome: 'child_error',
+      enabled: true,
+      runId: runResult.runId,
+      allowedTools,
+      costUSD: runResult.costUSD,
+      numTurns: runResult.numTurns,
+      durationMs: runResult.durationMs,
+      errorMessage: runResult.errorMessage,
+      paused,
+    })
+    await writeTier3State(options.projectDir, {
+      lastWindowKey: windowKey,
+      lastRunAt: startedAt.toISOString(),
+      lastOutcome: 'child_error',
+      lastRunId: runResult.runId,
+    })
+    return { outcome: 'child_error', runResult }
+  }
+
+  if (!runResult.lastAssistantText) {
+    await appendReflectionLog(options.stateWriter, options.projectDir, {
+      kind: 'tier3_reflection',
+      t: now().toISOString(),
+      windowKey,
+      outcome: 'invalid_output',
+      enabled: true,
+      runId: runResult.runId,
+      allowedTools,
+      costUSD: runResult.costUSD,
+      numTurns: runResult.numTurns,
+      durationMs: runResult.durationMs,
+      errorMessage: 'missing structured assistant output',
+      paused,
+    })
+    await writeTier3State(options.projectDir, {
+      lastWindowKey: windowKey,
+      lastRunAt: startedAt.toISOString(),
+      lastOutcome: 'invalid_output',
+      lastRunId: runResult.runId,
+    })
+    return { outcome: 'invalid_output', runResult }
+  }
+
+  let decision: Tier3Decision
+  try {
+    decision = parseTier3Decision(runResult.lastAssistantText)
+  } catch (error) {
+    await appendReflectionLog(options.stateWriter, options.projectDir, {
+      kind: 'tier3_reflection',
+      t: now().toISOString(),
+      windowKey,
+      outcome: 'invalid_output',
+      enabled: true,
+      runId: runResult.runId,
+      allowedTools,
+      costUSD: runResult.costUSD,
+      numTurns: runResult.numTurns,
+      durationMs: runResult.durationMs,
+      errorMessage: truncateForLog(
+        error instanceof Error ? error.message : String(error),
+      ),
+      message: truncateForLog(runResult.lastAssistantText),
+      paused,
+    })
+    await writeTier3State(options.projectDir, {
+      lastWindowKey: windowKey,
+      lastRunAt: startedAt.toISOString(),
+      lastOutcome: 'invalid_output',
+      lastRunId: runResult.runId,
+    })
+    return { outcome: 'invalid_output', runResult }
+  }
+
+  if (!decision.surface) {
+    await appendReflectionLog(options.stateWriter, options.projectDir, {
+      kind: 'tier3_reflection',
+      t: now().toISOString(),
+      windowKey,
+      outcome: 'noop',
+      enabled: true,
+      runId: runResult.runId,
+      allowedTools,
+      costUSD: runResult.costUSD,
+      numTurns: runResult.numTurns,
+      durationMs: runResult.durationMs,
+      paused,
+    })
+    await writeTier3State(options.projectDir, {
+      lastWindowKey: windowKey,
+      lastRunAt: startedAt.toISOString(),
+      lastOutcome: 'noop',
+      lastRunId: runResult.runId,
+    })
+    return { outcome: 'noop', runResult }
+  }
+
+  const surfaceEvent = {
+    kind: 'tier3_surface' as const,
+    t: now().toISOString(),
+    projectDir: options.projectDir,
+    runId: runResult.runId,
+    message: decision.message!,
+    source: 'daemon' as const,
+  }
+  await options.stateWriter.appendProjectEvent(options.projectDir, surfaceEvent)
+  await options.stateWriter.appendGlobalEvent(surfaceEvent)
+  await appendReflectionLog(options.stateWriter, options.projectDir, {
+    kind: 'tier3_reflection',
+    t: surfaceEvent.t,
+    windowKey,
+    outcome: 'surface',
+    enabled: true,
+    runId: runResult.runId,
+    allowedTools,
+    costUSD: runResult.costUSD,
+    numTurns: runResult.numTurns,
+    durationMs: runResult.durationMs,
+    message: decision.message,
+    paused,
+  })
+  await writeTier3State(options.projectDir, {
+    lastWindowKey: windowKey,
+    lastRunAt: startedAt.toISOString(),
+    lastOutcome: 'surface',
+    lastRunId: runResult.runId,
+  })
+  return { outcome: 'surface', runResult, message: decision.message }
+}
+
+export function createTier3Controller(
+  options: RunTier3ReflectionOptions,
+): Tier3Controller {
+  const now = options.now ?? (() => new Date())
+  let stopped = false
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let inFlight: Promise<void> | null = null
+
+  const clearTimer = () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  const scheduleNext = async (): Promise<void> => {
+    if (stopped) return
+    const config = await readTier3Config(options.projectDir)
+    const delayMs = getNextTier3DelayMs(now(), config.intervalMs)
+    timer = setTimeout(() => {
+      timer = null
+      inFlight = (async () => {
+        try {
+          await runTier3Reflection(options)
+        } finally {
+          inFlight = null
+          await scheduleNext()
+        }
+      })()
+    }, delayMs)
+    timer.unref?.()
+  }
+
+  return {
+    start() {
+      void scheduleNext()
+    },
+    async stop() {
+      stopped = true
+      clearTimer()
+      await inFlight
+    },
+  }
+}

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -20,6 +20,7 @@ import {
   getKairosStdoutLogPath,
 } from './paths.js'
 import { createStateWriter, type StateWriter } from './stateWriter.js'
+import { createTier3Controller, type Tier3Controller } from './tier3.js'
 
 type KairosStatus = {
   kind: 'kairos'
@@ -256,8 +257,9 @@ export async function runKairosWorker(
     string,
     ReturnType<typeof createProjectWorker>
   >()
+  const tier3Controllers = new Map<string, Tier3Controller>()
 
-  const enableChildRuns = options.enableChildRuns ?? !!options.childLauncher
+  const enableChildRuns = options.enableChildRuns ?? true
   const launcher: ChildLauncher | null = enableChildRuns
     ? options.childLauncher ?? createSdkChildLauncher()
     : null
@@ -322,6 +324,22 @@ export async function runKairosWorker(
       checkPaused,
     })
     activeWorkers.set(projectDir, worker)
+    if (launcher) {
+      const tier3 = createTier3Controller({
+        projectDir,
+        stateWriter,
+        launcher,
+        costTracker,
+        defaultAllowedTools,
+        maxTurns,
+        timeoutMs,
+        handleCapHit,
+        now,
+        checkPaused,
+      })
+      tier3Controllers.set(projectDir, tier3)
+      tier3.start()
+    }
     await stateWriter.appendGlobalEvent({
       kind: 'project_registered',
       t: now().toISOString(),
@@ -335,6 +353,9 @@ export async function runKairosWorker(
     const worker = activeWorkers.get(projectDir)
     if (!worker) return
     activeWorkers.delete(projectDir)
+    const tier3 = tier3Controllers.get(projectDir)
+    tier3Controllers.delete(projectDir)
+    await tier3?.stop()
     await worker.stop()
     await stateWriter.appendGlobalEvent({
       kind: 'project_unregistered',

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -336,6 +336,16 @@ export async function runKairosWorker(
         handleCapHit,
         now,
         checkPaused,
+        onSurface: async ({ projectDir, message }) => {
+          await logLine(
+            `[tier3] project=${projectDir} surfaced=${JSON.stringify(message)}`,
+            {
+              stdout: options.stdout,
+              now: now(),
+              pid,
+            },
+          )
+        },
       })
       tier3Controllers.set(projectDir, tier3)
       tier3.start()


### PR DESCRIPTION
Adds daemon-side Kairos Tier 3 reflection scheduling behind `settings.kairos.tier3.enabled`, with per-project window gating and structured `noop`/`surface` logging. Extends the child runner to retain the final assistant text so Tier 3 can validate structured JSON output, and wires the scheduler into Kairos worker startup and shutdown with child runs enabled by default for daemon execution. Adds tests for disabled-by-default, once-per-window behavior, noop/surface outcomes, and child-run parsing updates. Verified with `bun test ./daemon/kairos/tier3.test.ts ./daemon/kairos/childRunner.test.ts ./daemon/kairos/capHit.integration.test.ts ./daemon/kairos/projectWorker.test.ts ./daemon/kairos/worker.test.ts`, `bun run typecheck`, and `bun run lint`.