### PR TITLE
feat(kairos): add local dashboard

### DIFF
--- a/src 2/daemon/dashboard/app.js
+++ b/src 2/daemon/dashboard/app.js
@@ -1,0 +1,227 @@
+const elements = {
+  connectionPill: document.getElementById('connection-pill'),
+  pauseButton: document.getElementById('pause-button'),
+  resumeButton: document.getElementById('resume-button'),
+  optInButton: document.getElementById('opt-in-button'),
+  optOutButton: document.getElementById('opt-out-button'),
+  demoButton: document.getElementById('demo-button'),
+  projectDirInput: document.getElementById('project-dir-input'),
+  projectSelect: document.getElementById('project-select'),
+  flash: document.getElementById('flash'),
+  projectCount: document.getElementById('project-count'),
+  generatedAt: document.getElementById('generated-at'),
+  globalSummary: document.getElementById('global-summary'),
+  projectSummary: document.getElementById('project-summary'),
+  selectedProjectLabel: document.getElementById('selected-project-label'),
+  globalEvents: document.getElementById('global-events'),
+  daemonLog: document.getElementById('daemon-log'),
+  projectLog: document.getElementById('project-log'),
+  projectEvents: document.getElementById('project-events'),
+}
+
+let snapshot = null
+let selectedProjectDir = ''
+
+function formatValue(value) {
+  if (value === null || value === undefined || value === '') return '—'
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  return String(value)
+}
+
+function renderCards(target, entries, emptyText) {
+  if (entries.length === 0) {
+    target.classList.add('empty-state')
+    target.textContent = emptyText
+    return
+  }
+  target.classList.remove('empty-state')
+  target.innerHTML = entries
+    .map(
+      ([label, value]) => `
+        <div class="summary-card">
+          <strong>${label}</strong>
+          <span>${formatValue(value)}</span>
+        </div>
+      `,
+    )
+    .join('')
+}
+
+function pretty(value) {
+  return JSON.stringify(value ?? [], null, 2)
+}
+
+function currentProject() {
+  if (!snapshot) return null
+  return (
+    snapshot.projects.find(project => project.projectDir === selectedProjectDir) ??
+    snapshot.projects[0] ??
+    null
+  )
+}
+
+function syncProjectOptions() {
+  const projects = snapshot?.global.projects ?? []
+  const options = projects
+    .map(projectDir => `<option value="${projectDir}">${projectDir}</option>`)
+    .join('')
+  elements.projectSelect.innerHTML =
+    options || '<option value="">No opted-in projects</option>'
+
+  if (!selectedProjectDir || !projects.includes(selectedProjectDir)) {
+    selectedProjectDir = projects[0] ?? ''
+  }
+  elements.projectSelect.value = selectedProjectDir
+}
+
+function renderSnapshot(nextSnapshot) {
+  snapshot = nextSnapshot
+  syncProjectOptions()
+  const project = currentProject()
+
+  elements.generatedAt.textContent = new Date(snapshot.generatedAt).toLocaleString()
+  elements.projectCount.textContent = `${snapshot.global.projects.length} opted in`
+  elements.projectDirInput.placeholder =
+    selectedProjectDir || '/absolute/path/to/project'
+
+  renderCards(
+    elements.globalSummary,
+    [
+      ['Daemon state', snapshot.global.status?.state],
+      ['PID', snapshot.global.status?.pid],
+      ['Projects', snapshot.global.projects.length],
+      ['Paused', snapshot.global.pause?.paused ?? false],
+      ['Global cost', snapshot.global.costs?.totalUSD?.toFixed?.(4)],
+      ['Runs', snapshot.global.costs?.runs],
+    ],
+    'No global state has been written yet.',
+  )
+
+  if (!project) {
+    elements.selectedProjectLabel.textContent = 'No project selected'
+    renderCards(
+      elements.projectSummary,
+      [],
+      'Opt a project in to see per-project state, logs, costs, and events.',
+    )
+    elements.projectLog.textContent = '[]'
+    elements.projectEvents.textContent = '[]'
+  } else {
+    elements.selectedProjectLabel.textContent = project.projectDir
+    renderCards(
+      elements.projectSummary,
+      [
+        ['Worker running', project.status?.running],
+        ['Dirty', project.status?.dirty],
+        ['Pending count', project.status?.pendingCount],
+        ['Last event', project.status?.lastEvent],
+        ['Project cost', project.costs?.totalUSD?.toFixed?.(4)],
+        ['Queued tasks', project.tasks.length],
+      ],
+      'This project has no KAIROS state yet.',
+    )
+    elements.projectLog.textContent = pretty(project.log)
+    elements.projectEvents.textContent = pretty(project.events)
+  }
+
+  elements.globalEvents.textContent = pretty(snapshot.global.events)
+  elements.daemonLog.textContent = pretty(snapshot.global.stdoutLog)
+}
+
+function setConnectionState(text, live) {
+  elements.connectionPill.textContent = text
+  elements.connectionPill.className = `pill ${live ? 'live' : 'muted'}`
+}
+
+function flash(message) {
+  elements.flash.textContent = message
+  window.clearTimeout(flash.timer)
+  flash.timer = window.setTimeout(() => {
+    elements.flash.textContent = ''
+  }, 4000)
+}
+
+async function post(path, payload = {}) {
+  const response = await fetch(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  const body = await response.json()
+  if (!response.ok) {
+    throw new Error(body.error ?? `Request failed: ${response.status}`)
+  }
+  return body
+}
+
+async function refresh() {
+  const response = await fetch('/api/state')
+  const body = await response.json()
+  renderSnapshot(body)
+}
+
+elements.projectSelect.addEventListener('change', event => {
+  selectedProjectDir = event.target.value
+  if (snapshot) renderSnapshot(snapshot)
+})
+
+elements.optInButton.addEventListener('click', async () => {
+  const projectDir = elements.projectDirInput.value.trim()
+  if (!projectDir) {
+    flash('Enter a project path to opt in.')
+    return
+  }
+  const nextSnapshot = await post('/api/projects/opt-in', { projectDir })
+  elements.projectDirInput.value = ''
+  flash(`Opted in ${projectDir}`)
+  renderSnapshot(nextSnapshot)
+})
+
+elements.optOutButton.addEventListener('click', async () => {
+  const projectDir = elements.projectDirInput.value.trim() || selectedProjectDir
+  if (!projectDir) {
+    flash('Choose a project to opt out.')
+    return
+  }
+  const nextSnapshot = await post('/api/projects/opt-out', { projectDir })
+  elements.projectDirInput.value = ''
+  flash(`Opted out ${projectDir}`)
+  renderSnapshot(nextSnapshot)
+})
+
+elements.demoButton.addEventListener('click', async () => {
+  const projectDir = selectedProjectDir || elements.projectDirInput.value.trim()
+  if (!projectDir) {
+    flash('Choose a project before queueing a demo task.')
+    return
+  }
+  const result = await post('/api/projects/demo', { projectDir })
+  flash(`Queued demo task ${result.taskId} for ${projectDir}`)
+  renderSnapshot(result.snapshot)
+})
+
+elements.pauseButton.addEventListener('click', async () => {
+  renderSnapshot(await post('/api/pause'))
+  flash('Paused KAIROS globally.')
+})
+
+elements.resumeButton.addEventListener('click', async () => {
+  renderSnapshot(await post('/api/resume'))
+  flash('Resumed KAIROS.')
+})
+
+const events = new EventSource('/api/events')
+events.addEventListener('snapshot', event => {
+  setConnectionState('Live SSE', true)
+  renderSnapshot(JSON.parse(event.data))
+})
+events.addEventListener('error', () => {
+  setConnectionState('Reconnecting...', false)
+})
+
+window.addEventListener('load', () => {
+  void refresh().catch(error => {
+    flash(error.message)
+    setConnectionState('Unavailable', false)
+  })
+})

--- a/src 2/daemon/dashboard/index.html
+++ b/src 2/daemon/dashboard/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>KAIROS Dashboard</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <section class="hero">
+        <p class="eyebrow">Loopback Only</p>
+        <h1>KAIROS Dashboard</h1>
+        <p class="lede">
+          Live daemon health, project activity, costs, and controls without
+          leaving the browser.
+        </p>
+        <div class="hero-actions">
+          <button id="pause-button" class="button warning">Pause</button>
+          <button id="resume-button" class="button">Resume</button>
+          <span id="connection-pill" class="pill muted">Connecting...</span>
+        </div>
+      </section>
+
+      <section class="panel controls">
+        <div class="panel-header">
+          <h2>Projects</h2>
+          <span id="project-count" class="panel-meta">0 opted in</span>
+        </div>
+        <div class="project-inputs">
+          <input
+            id="project-dir-input"
+            type="text"
+            placeholder="/absolute/path/to/project"
+            spellcheck="false"
+          />
+          <button id="opt-in-button" class="button accent">Opt In</button>
+          <button id="opt-out-button" class="button subtle">Opt Out</button>
+        </div>
+        <div class="selector-row">
+          <label for="project-select">Selected project</label>
+          <select id="project-select"></select>
+          <button id="demo-button" class="button accent">Queue Demo Task</button>
+        </div>
+        <p id="flash" class="flash"></p>
+      </section>
+
+      <section class="grid">
+        <article class="panel">
+          <div class="panel-header">
+            <h2>Global State</h2>
+            <span id="generated-at" class="panel-meta"></span>
+          </div>
+          <div id="global-summary" class="summary-grid"></div>
+        </article>
+
+        <article class="panel">
+          <div class="panel-header">
+            <h2>Per-Project State</h2>
+            <span id="selected-project-label" class="panel-meta">No project selected</span>
+          </div>
+          <div id="project-summary" class="summary-grid empty-state"></div>
+        </article>
+      </section>
+
+      <section class="grid">
+        <article class="panel">
+          <div class="panel-header">
+            <h2>Global Events</h2>
+          </div>
+          <pre id="global-events" class="code-block"></pre>
+        </article>
+
+        <article class="panel">
+          <div class="panel-header">
+            <h2>Daemon Output</h2>
+          </div>
+          <pre id="daemon-log" class="code-block"></pre>
+        </article>
+      </section>
+
+      <section class="grid">
+        <article class="panel">
+          <div class="panel-header">
+            <h2>Project Logs</h2>
+          </div>
+          <pre id="project-log" class="code-block"></pre>
+        </article>
+
+        <article class="panel">
+          <div class="panel-header">
+            <h2>Project Events</h2>
+          </div>
+          <pre id="project-events" class="code-block"></pre>
+        </article>
+      </section>
+    </main>
+
+    <script type="module" src="/app.js"></script>
+  </body>
+</html>

--- a/src 2/daemon/dashboard/model.ts
+++ b/src 2/daemon/dashboard/model.ts
@@ -1,0 +1,222 @@
+import { randomUUID } from 'crypto'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import type { CronTask } from '../../utils/cronTasks.js'
+import { readCronTasks, writeCronTasks } from '../../utils/cronTasks.js'
+import { safeParseJSON } from '../../utils/json.js'
+import { createProjectRegistry } from '../kairos/projectRegistry.js'
+import {
+  getKairosGlobalCostsPath,
+  getKairosGlobalEventsPath,
+  getKairosPausePath,
+  getKairosStateDir,
+  getKairosStatusPath,
+  getKairosStdoutLogPath,
+  getProjectKairosCostsPath,
+  getProjectKairosEventsPath,
+  getProjectKairosLogPath,
+  getProjectKairosStatusPath,
+} from '../kairos/paths.js'
+import { createStateWriter } from '../kairos/stateWriter.js'
+import type {
+  CostsFile,
+  GlobalStatus,
+  PauseState,
+  ProjectStatus,
+} from '../kairos/stateWriter.js'
+
+const DEFAULT_TAIL_LIMIT = 50
+const DEMO_PROMPT =
+  'KAIROS dashboard demo: inspect the current repository state and report one concrete next step in 2 short sentences.'
+
+export type DashboardEvent = Record<string, unknown>
+
+export type DashboardProjectSnapshot = {
+  projectDir: string
+  status: ProjectStatus | null
+  costs: CostsFile | null
+  log: DashboardEvent[]
+  events: DashboardEvent[]
+  tasks: CronTask[]
+}
+
+export type DashboardSnapshot = {
+  generatedAt: string
+  global: {
+    status: GlobalStatus | null
+    costs: CostsFile | null
+    pause: PauseState | null
+    events: DashboardEvent[]
+    stdoutLog: string[]
+    projects: string[]
+  }
+  projects: DashboardProjectSnapshot[]
+}
+
+async function readJsonFile<T>(path: string): Promise<T | null> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    const parsed = safeParseJSON(raw, false)
+    return parsed === null ? null : (parsed as T)
+  } catch {
+    return null
+  }
+}
+
+async function readJsonLines(
+  path: string,
+  limit = DEFAULT_TAIL_LIMIT,
+): Promise<DashboardEvent[]> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    return raw
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .slice(-limit)
+      .map(line => safeParseJSON(line, false))
+      .filter((value): value is DashboardEvent => !!value && typeof value === 'object')
+  } catch {
+    return []
+  }
+}
+
+async function readTailLines(
+  path: string,
+  limit = DEFAULT_TAIL_LIMIT,
+): Promise<string[]> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    return raw
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .slice(-limit)
+  } catch {
+    return []
+  }
+}
+
+function buildOneShotCron(now: Date): string {
+  const fireAt = new Date(now)
+  fireAt.setSeconds(0, 0)
+  fireAt.setMinutes(fireAt.getMinutes() + 1)
+  return `${fireAt.getMinutes()} ${fireAt.getHours()} ${fireAt.getDate()} ${fireAt.getMonth() + 1} *`
+}
+
+export async function readDashboardSnapshot(
+  now: () => Date = () => new Date(),
+): Promise<DashboardSnapshot> {
+  const registry = await createProjectRegistry()
+  const projects = await registry.read()
+
+  const [status, costs, pause, events, stdoutLog, projectSnapshots] =
+    await Promise.all([
+      readJsonFile<GlobalStatus>(getKairosStatusPath()),
+      readJsonFile<CostsFile>(getKairosGlobalCostsPath()),
+      readJsonFile<PauseState>(getKairosPausePath()),
+      readJsonLines(getKairosGlobalEventsPath()),
+      readTailLines(getKairosStdoutLogPath()),
+      Promise.all(
+        projects.map(async projectDir => ({
+          projectDir,
+          status: await readJsonFile<ProjectStatus>(
+            getProjectKairosStatusPath(projectDir),
+          ),
+          costs: await readJsonFile<CostsFile>(
+            getProjectKairosCostsPath(projectDir),
+          ),
+          log: await readJsonLines(getProjectKairosLogPath(projectDir)),
+          events: await readJsonLines(getProjectKairosEventsPath(projectDir)),
+          tasks: await readCronTasks(projectDir),
+        })),
+      ),
+    ])
+
+  return {
+    generatedAt: now().toISOString(),
+    global: {
+      status,
+      costs,
+      pause,
+      events,
+      stdoutLog,
+      projects,
+    },
+    projects: projectSnapshots,
+  }
+}
+
+export async function getDashboardWatchPaths(): Promise<string[]> {
+  const registry = await createProjectRegistry()
+  const projects = await registry.read()
+  return [
+    getKairosStateDir(),
+    ...projects.flatMap(projectDir => [
+      join(projectDir, '.claude', 'kairos'),
+      join(projectDir, '.claude', 'scheduled_tasks.json'),
+    ]),
+  ]
+}
+
+export async function optInProject(projectDir: string): Promise<void> {
+  const registry = await createProjectRegistry()
+  const projects = await registry.read()
+  await registry.write([...projects, projectDir])
+}
+
+export async function optOutProject(projectDir: string): Promise<void> {
+  const registry = await createProjectRegistry()
+  const projects = await registry.read()
+  await registry.write(projects.filter(entry => entry !== projectDir))
+}
+
+export async function enqueueDemoTask(
+  projectDir: string,
+  now: () => Date = () => new Date(),
+): Promise<string> {
+  const stateWriter = await createStateWriter()
+  await stateWriter.ensureProjectDir(projectDir)
+
+  const tasks = await readCronTasks(projectDir)
+  const taskId = randomUUID().slice(0, 8)
+  tasks.push({
+    id: taskId,
+    cron: buildOneShotCron(now()),
+    prompt: DEMO_PROMPT,
+    createdAt: now().getTime(),
+  })
+  await writeCronTasks(tasks, projectDir)
+
+  const t = now().toISOString()
+  await stateWriter.appendProjectLog(projectDir, {
+    kind: 'dashboard_demo_enqueued',
+    t,
+    taskId,
+  })
+  await stateWriter.appendProjectEvent(projectDir, {
+    kind: 'dashboard_demo_enqueued',
+    t,
+    taskId,
+    source: 'dashboard',
+  })
+
+  return taskId
+}
+
+export async function setPauseState(
+  paused: boolean,
+  now: () => Date = () => new Date(),
+): Promise<void> {
+  const stateWriter = await createStateWriter()
+  await stateWriter.writePauseState({
+    paused,
+    source: 'user',
+    ...(paused
+      ? {
+          scope: 'global' as const,
+          setAt: now().toISOString(),
+        }
+      : {}),
+  })
+}

--- a/src 2/daemon/dashboard/server.test.ts
+++ b/src 2/daemon/dashboard/server.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { writeCronTasks } from '../../utils/cronTasks.js'
+import { createProjectRegistry } from '../kairos/projectRegistry.js'
+import { getKairosPausePath } from '../kairos/paths.js'
+import { createStateWriter } from '../kairos/stateWriter.js'
+import { startKairosDashboardServer } from './server.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await Bun.sleep(50)
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`)
+}
+
+async function seedState(projectDir: string): Promise<void> {
+  const registry = await createProjectRegistry()
+  await registry.write([projectDir])
+
+  const stateWriter = await createStateWriter()
+  await stateWriter.ensureProjectDir(projectDir)
+  await stateWriter.writeGlobalStatus({
+    kind: 'kairos',
+    state: 'idle',
+    pid: 42,
+    startedAt: '2026-04-22T12:00:00.000Z',
+    updatedAt: '2026-04-22T12:00:00.000Z',
+    projects: 1,
+    lastEventAt: '2026-04-22T12:00:00.000Z',
+  })
+  await stateWriter.writeProjectStatus({
+    projectDir,
+    running: false,
+    dirty: false,
+    pendingCount: 0,
+    lastEvent: 'worker_started',
+    updatedAt: '2026-04-22T12:00:00.000Z',
+    nextFireAt: null,
+  })
+  await stateWriter.writeGlobalCosts({
+    totalUSD: 0.25,
+    totalTurns: 3,
+    runs: 2,
+    updatedAt: '2026-04-22T12:00:00.000Z',
+  })
+  await stateWriter.writeProjectCosts(projectDir, {
+    totalUSD: 0.15,
+    totalTurns: 2,
+    runs: 1,
+    updatedAt: '2026-04-22T12:00:00.000Z',
+  })
+  await stateWriter.appendGlobalEvent({
+    kind: 'project_registered',
+    t: '2026-04-22T12:00:00.000Z',
+    projectDir,
+  })
+  await stateWriter.appendProjectLog(projectDir, {
+    kind: 'worker_started',
+    t: '2026-04-22T12:00:00.000Z',
+  })
+  await stateWriter.appendProjectEvent(projectDir, {
+    kind: 'child_finished',
+    t: '2026-04-22T12:00:01.000Z',
+    source: 'event',
+    taskId: 'abc12345',
+  })
+  await writeCronTasks(
+    [
+      {
+        id: 'demo1234',
+        cron: '5 12 22 4 *',
+        prompt: 'demo task',
+        createdAt: Date.now(),
+      },
+    ],
+    projectDir,
+  )
+}
+
+async function readSseUntil(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  needle: string,
+  timeoutMs = 6_000,
+): Promise<string> {
+  const decoder = new TextDecoder()
+  let text = ''
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const chunk = await Promise.race([
+      reader.read(),
+      Bun.sleep(250).then(() => null),
+    ])
+    if (!chunk) continue
+    if (chunk.done) break
+    text += decoder.decode(chunk.value, { stream: true })
+    if (text.includes(needle)) return text
+  }
+  throw new Error(`Timed out waiting for SSE payload containing ${needle}`)
+}
+
+describe('KAIROS dashboard server', () => {
+  test('serves snapshot and control endpoints', async () => {
+    const configDir = makeTempDir('kairos-dashboard-config-')
+    const projectDir = makeTempDir('kairos-dashboard-project-')
+    const projectDir2 = makeTempDir('kairos-dashboard-project-extra-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    await seedState(projectDir)
+
+    const server = await startKairosDashboardServer({ port: 0 })
+
+    try {
+      const stateResponse = await fetch(`${server.url}/api/state`)
+      const snapshot = await stateResponse.json()
+      expect(snapshot.global.status.state).toBe('idle')
+      expect(snapshot.global.projects).toEqual([projectDir])
+      expect(snapshot.projects).toHaveLength(1)
+      expect(snapshot.projects[0].tasks[0].id).toBe('demo1234')
+
+      const pauseResponse = await fetch(`${server.url}/api/pause`, {
+        method: 'POST',
+      })
+      expect(pauseResponse.ok).toBe(true)
+      const paused = JSON.parse(readFileSync(getKairosPausePath(), 'utf8'))
+      expect(paused).toMatchObject({ paused: true, source: 'user' })
+
+      const resumeResponse = await fetch(`${server.url}/api/resume`, {
+        method: 'POST',
+      })
+      expect(resumeResponse.ok).toBe(true)
+      const resumed = JSON.parse(readFileSync(getKairosPausePath(), 'utf8'))
+      expect(resumed).toMatchObject({ paused: false, source: 'user' })
+
+      const optInResponse = await fetch(`${server.url}/api/projects/opt-in`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ projectDir: projectDir2 }),
+      })
+      expect(optInResponse.ok).toBe(true)
+      const registry = await createProjectRegistry()
+      expect(await registry.read()).toEqual(
+        [projectDir, projectDir2].sort(),
+      )
+
+      const demoResponse = await fetch(`${server.url}/api/projects/demo`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ projectDir }),
+      })
+      const demoBody = await demoResponse.json()
+      expect(demoResponse.ok).toBe(true)
+      expect(demoBody.taskId).toHaveLength(8)
+
+      const tasksFile = JSON.parse(
+        readFileSync(join(projectDir, '.claude', 'scheduled_tasks.json'), 'utf8'),
+      )
+      expect(tasksFile.tasks).toHaveLength(2)
+
+      const optOutResponse = await fetch(`${server.url}/api/projects/opt-out`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ projectDir: projectDir2 }),
+      })
+      expect(optOutResponse.ok).toBe(true)
+      expect(await registry.read()).toEqual([projectDir])
+    } finally {
+      await server.stop()
+    }
+  })
+
+  test(
+    'rebroadcasts snapshots over SSE when control actions change state',
+    { timeout: 10_000 },
+    async () => {
+      const configDir = makeTempDir('kairos-dashboard-sse-config-')
+      const projectDir = makeTempDir('kairos-dashboard-sse-project-')
+      process.env.CLAUDE_CONFIG_DIR = configDir
+      await seedState(projectDir)
+
+      const server = await startKairosDashboardServer({ port: 0 })
+      const controller = new AbortController()
+
+      try {
+        const response = await fetch(`${server.url}/api/events`, {
+          signal: controller.signal,
+        })
+        expect(response.ok).toBe(true)
+        const reader = response.body?.getReader()
+        expect(reader).toBeDefined()
+        if (!reader) throw new Error('Missing SSE reader')
+
+        await readSseUntil(reader, '"state":"idle"')
+
+        const pauseResponse = await fetch(`${server.url}/api/pause`, {
+          method: 'POST',
+        })
+        expect(pauseResponse.ok).toBe(true)
+        await waitFor(() =>
+          readFileSync(getKairosPausePath(), 'utf8').includes('"paused": true'),
+        )
+
+        const ssePayload = await readSseUntil(reader, '"paused":true')
+        expect(ssePayload).toContain('"paused":true')
+        expect(readFileSync(getKairosPausePath(), 'utf8')).toContain(
+          '"paused": true',
+        )
+
+        controller.abort()
+        await reader.cancel()
+      } finally {
+        await server.stop()
+      }
+    },
+  )
+})

--- a/src 2/daemon/dashboard/server.ts
+++ b/src 2/daemon/dashboard/server.ts
@@ -1,0 +1,310 @@
+import type { FSWatcher } from 'chokidar'
+import { createServer, type IncomingMessage, type ServerResponse } from 'http'
+import { readFile } from 'fs/promises'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+import { safeParseJSON } from '../../utils/json.js'
+import {
+  enqueueDemoTask,
+  getDashboardWatchPaths,
+  optInProject,
+  optOutProject,
+  readDashboardSnapshot,
+  setPauseState,
+  type DashboardSnapshot,
+} from './model.js'
+
+const DEFAULT_HOST = '127.0.0.1'
+const DEFAULT_PORT = 7777
+const WATCH_STABILITY_MS = 150
+const BROADCAST_DEBOUNCE_MS = 75
+const SSE_KEEPALIVE_MS = 15_000
+const SNAPSHOT_POLL_MS = 500
+const ASSET_DIR = dirname(fileURLToPath(import.meta.url))
+
+type StaticAsset = {
+  body: Buffer
+  contentType: string
+}
+
+export type KairosDashboardServerOptions = {
+  host?: string
+  port?: number
+  now?: () => Date
+}
+
+export type KairosDashboardServer = {
+  url: string
+  stop(): Promise<void>
+}
+
+function sendJson(
+  res: ServerResponse,
+  statusCode: number,
+  body: unknown,
+): void {
+  res.writeHead(statusCode, { 'content-type': 'application/json; charset=utf-8' })
+  res.end(`${JSON.stringify(body, null, 2)}\n`)
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  let raw = ''
+  for await (const chunk of req) {
+    raw += String(chunk)
+  }
+  if (raw.trim() === '') return {}
+  const parsed = safeParseJSON(raw, false)
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Expected a JSON object body.')
+  }
+  return parsed as Record<string, unknown>
+}
+
+async function loadStaticAsset(
+  filename: string,
+  contentType: string,
+): Promise<StaticAsset> {
+  return {
+    body: await readFile(join(ASSET_DIR, filename)),
+    contentType,
+  }
+}
+
+function writeSse(
+  res: ServerResponse,
+  event: string,
+  payload: Record<string, unknown> | DashboardSnapshot,
+): void {
+  res.write(`event: ${event}\n`)
+  res.write(`data: ${JSON.stringify(payload)}\n\n`)
+}
+
+export async function startKairosDashboardServer(
+  options: KairosDashboardServerOptions = {},
+): Promise<KairosDashboardServer> {
+  const host = options.host ?? DEFAULT_HOST
+  const port = options.port ?? DEFAULT_PORT
+  const now = options.now ?? (() => new Date())
+  const clients = new Set<ServerResponse>()
+  let watcher: FSWatcher | null = null
+  let keepAlive: ReturnType<typeof setInterval> | null = null
+  let snapshotPoll: ReturnType<typeof setInterval> | null = null
+  let broadcastTimer: ReturnType<typeof setTimeout> | null = null
+  let lastSnapshotJson: string | null = null
+
+  const [indexHtml, appJs, stylesCss] = await Promise.all([
+    loadStaticAsset('index.html', 'text/html; charset=utf-8'),
+    loadStaticAsset('app.js', 'application/javascript; charset=utf-8'),
+    loadStaticAsset('styles.css', 'text/css; charset=utf-8'),
+  ])
+
+  async function refreshWatcher(): Promise<void> {
+    const watchPaths = await getDashboardWatchPaths()
+    if (!watcher) return
+    watcher.add(watchPaths)
+  }
+
+  async function broadcastSnapshot(): Promise<void> {
+    if (clients.size === 0) return
+    try {
+      const snapshot = await readDashboardSnapshot(now)
+      const nextJson = JSON.stringify(snapshot)
+      if (nextJson === lastSnapshotJson) {
+        return
+      }
+      lastSnapshotJson = nextJson
+      for (const client of clients) {
+        writeSse(client, 'snapshot', snapshot)
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unknown dashboard error'
+      for (const client of clients) {
+        writeSse(client, 'error', {
+          generatedAt: now().toISOString(),
+          message,
+        })
+      }
+    }
+  }
+
+  function scheduleBroadcast(): void {
+    if (broadcastTimer) return
+    broadcastTimer = setTimeout(() => {
+      broadcastTimer = null
+      void broadcastSnapshot()
+    }, BROADCAST_DEBOUNCE_MS)
+    broadcastTimer.unref?.()
+  }
+
+  const server = createServer(async (req, res) => {
+    const method = req.method ?? 'GET'
+    const url = new URL(req.url ?? '/', `http://${host}:${port}`)
+
+    try {
+      if (method === 'GET' && url.pathname === '/') {
+        res.writeHead(200, { 'content-type': indexHtml.contentType })
+        res.end(indexHtml.body)
+        return
+      }
+      if (method === 'GET' && url.pathname === '/app.js') {
+        res.writeHead(200, { 'content-type': appJs.contentType })
+        res.end(appJs.body)
+        return
+      }
+      if (method === 'GET' && url.pathname === '/styles.css') {
+        res.writeHead(200, { 'content-type': stylesCss.contentType })
+        res.end(stylesCss.body)
+        return
+      }
+      if (method === 'GET' && url.pathname === '/api/state') {
+        sendJson(res, 200, await readDashboardSnapshot(now))
+        return
+      }
+      if (method === 'GET' && url.pathname === '/api/events') {
+        res.writeHead(200, {
+          'content-type': 'text/event-stream; charset=utf-8',
+          'cache-control': 'no-cache, no-transform',
+          connection: 'keep-alive',
+        })
+        res.write(': connected\n\n')
+        clients.add(res)
+        const snapshot = await readDashboardSnapshot(now)
+        lastSnapshotJson = JSON.stringify(snapshot)
+        writeSse(res, 'snapshot', snapshot)
+        req.on('close', () => {
+          clients.delete(res)
+          res.end()
+        })
+        return
+      }
+      if (method === 'POST' && url.pathname === '/api/projects/opt-in') {
+        const body = await readJsonBody(req)
+        const projectDir = String(body.projectDir ?? '').trim()
+        if (!projectDir) {
+          sendJson(res, 400, { error: 'projectDir is required.' })
+          return
+        }
+        await optInProject(projectDir)
+        await refreshWatcher()
+        sendJson(res, 200, await readDashboardSnapshot(now))
+        scheduleBroadcast()
+        return
+      }
+      if (method === 'POST' && url.pathname === '/api/projects/opt-out') {
+        const body = await readJsonBody(req)
+        const projectDir = String(body.projectDir ?? '').trim()
+        if (!projectDir) {
+          sendJson(res, 400, { error: 'projectDir is required.' })
+          return
+        }
+        await optOutProject(projectDir)
+        await refreshWatcher()
+        sendJson(res, 200, await readDashboardSnapshot(now))
+        scheduleBroadcast()
+        return
+      }
+      if (method === 'POST' && url.pathname === '/api/projects/demo') {
+        const body = await readJsonBody(req)
+        const projectDir = String(body.projectDir ?? '').trim()
+        if (!projectDir) {
+          sendJson(res, 400, { error: 'projectDir is required.' })
+          return
+        }
+        const taskId = await enqueueDemoTask(projectDir, now)
+        sendJson(res, 200, {
+          taskId,
+          snapshot: await readDashboardSnapshot(now),
+        })
+        scheduleBroadcast()
+        return
+      }
+      if (method === 'POST' && url.pathname === '/api/pause') {
+        await setPauseState(true, now)
+        sendJson(res, 200, await readDashboardSnapshot(now))
+        scheduleBroadcast()
+        return
+      }
+      if (method === 'POST' && url.pathname === '/api/resume') {
+        await setPauseState(false, now)
+        sendJson(res, 200, await readDashboardSnapshot(now))
+        scheduleBroadcast()
+        return
+      }
+      sendJson(res, 404, { error: `No route for ${method} ${url.pathname}` })
+    } catch (error) {
+      sendJson(res, 500, {
+        error: error instanceof Error ? error.message : 'Unknown server error',
+      })
+    }
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(port, host, () => resolve())
+  })
+
+  const address = server.address()
+  const boundPort =
+    typeof address === 'object' && address ? address.port : DEFAULT_PORT
+
+  const { default: chokidar } = await import('chokidar')
+  watcher = chokidar.watch(await getDashboardWatchPaths(), {
+    ignoreInitial: true,
+    awaitWriteFinish: {
+      stabilityThreshold: WATCH_STABILITY_MS,
+    },
+  })
+  watcher.on('add', scheduleBroadcast)
+  watcher.on('change', scheduleBroadcast)
+  watcher.on('unlink', scheduleBroadcast)
+  watcher.on('addDir', scheduleBroadcast)
+  watcher.on('unlinkDir', scheduleBroadcast)
+  await new Promise<void>((resolve, reject) => {
+    watcher?.once('ready', () => resolve())
+    watcher?.once('error', reject)
+  })
+
+  keepAlive = setInterval(() => {
+    for (const client of clients) {
+      client.write(': keepalive\n\n')
+    }
+  }, SSE_KEEPALIVE_MS)
+  keepAlive.unref?.()
+  snapshotPoll = setInterval(() => {
+    void broadcastSnapshot()
+  }, SNAPSHOT_POLL_MS)
+  snapshotPoll.unref?.()
+
+  return {
+    url: `http://${host}:${boundPort}`,
+    async stop() {
+      if (broadcastTimer) {
+        clearTimeout(broadcastTimer)
+        broadcastTimer = null
+      }
+      if (keepAlive) {
+        clearInterval(keepAlive)
+        keepAlive = null
+      }
+      if (snapshotPoll) {
+        clearInterval(snapshotPoll)
+        snapshotPoll = null
+      }
+      for (const client of clients) {
+        client.end()
+      }
+      clients.clear()
+      await watcher?.close()
+      await new Promise<void>((resolve, reject) => {
+        server.close(error => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
+        })
+      })
+    },
+  }
+}

--- a/src 2/daemon/dashboard/styles.css
+++ b/src 2/daemon/dashboard/styles.css
@@ -1,0 +1,262 @@
+:root {
+  --bg: #f4efe6;
+  --panel: rgba(255, 252, 247, 0.88);
+  --panel-strong: #fffdf9;
+  --ink: #1f1b16;
+  --muted: #6c6257;
+  --line: rgba(74, 57, 41, 0.14);
+  --accent: #9a3412;
+  --accent-soft: rgba(154, 52, 18, 0.12);
+  --warning: #b45309;
+  --shadow: 0 18px 45px rgba(76, 56, 38, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top, rgba(246, 197, 146, 0.35), transparent 35%),
+    linear-gradient(180deg, #f7f2e9 0%, #efe7db 100%);
+  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.layout {
+  width: min(1200px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0 48px;
+}
+
+.hero,
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+}
+
+.hero {
+  padding: 28px;
+  margin-bottom: 20px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+h1,
+h2 {
+  margin: 0;
+  font-weight: 700;
+}
+
+h1 {
+  font-size: clamp(2.1rem, 5vw, 4rem);
+  line-height: 0.95;
+}
+
+h2 {
+  font-size: 1.25rem;
+}
+
+.lede,
+.panel-meta,
+.flash,
+label {
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+}
+
+.lede {
+  max-width: 54rem;
+  margin: 12px 0 0;
+  color: var(--muted);
+}
+
+.hero-actions,
+.project-inputs,
+.selector-row,
+.panel-header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.hero-actions {
+  margin-top: 18px;
+}
+
+.panel {
+  padding: 20px;
+}
+
+.controls {
+  margin-bottom: 20px;
+}
+
+.panel-header {
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.panel-meta {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.summary-card {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--panel-strong);
+  padding: 14px;
+}
+
+.summary-card strong {
+  display: block;
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+
+.summary-card span {
+  display: block;
+  font-size: 1.05rem;
+}
+
+.button,
+.pill,
+input,
+select {
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--panel-strong);
+  color: var(--ink);
+}
+
+.button {
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: transform 140ms ease, background 140ms ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.button.accent {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fffaf5;
+}
+
+.button.subtle {
+  background: transparent;
+}
+
+.button.warning {
+  background: var(--warning);
+  border-color: var(--warning);
+  color: white;
+}
+
+.pill {
+  padding: 8px 12px;
+}
+
+.pill.live {
+  background: #14532d;
+  border-color: #14532d;
+  color: #f0fdf4;
+}
+
+.pill.muted {
+  color: var(--muted);
+}
+
+input,
+select {
+  min-height: 44px;
+  padding: 0 16px;
+}
+
+input {
+  flex: 1 1 360px;
+}
+
+.selector-row select {
+  min-width: 280px;
+}
+
+.flash {
+  min-height: 22px;
+  margin: 12px 2px 0;
+  color: var(--accent);
+}
+
+.code-block {
+  margin: 0;
+  min-height: 240px;
+  max-height: 420px;
+  overflow: auto;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid var(--line);
+  background: #201a15;
+  color: #f8efe3;
+  font-family: "SFMono-Regular", "Menlo", monospace;
+  font-size: 0.83rem;
+  line-height: 1.5;
+}
+
+.empty-state {
+  color: var(--muted);
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    width: min(100vw - 20px, 1200px);
+    padding-top: 20px;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero,
+  .panel {
+    border-radius: 20px;
+  }
+}

--- a/src 2/daemon/kairos/paths.ts
+++ b/src 2/daemon/kairos/paths.ts
@@ -29,6 +29,14 @@ export function getProjectKairosDir(projectDir: string): string {
   return join(projectDir, '.claude', 'kairos')
 }
 
+export function getProjectKairosStatusPath(projectDir: string): string {
+  return join(getProjectKairosDir(projectDir), 'status.json')
+}
+
+export function getProjectKairosLogPath(projectDir: string): string {
+  return join(getProjectKairosDir(projectDir), 'log.jsonl')
+}
+
 export function getProjectKairosEventsPath(projectDir: string): string {
   return join(getProjectKairosDir(projectDir), 'events.jsonl')
 }

--- a/src 2/daemon/kairos/projectRegistry.ts
+++ b/src 2/daemon/kairos/projectRegistry.ts
@@ -96,6 +96,10 @@ export async function createProjectRegistry(): Promise<ProjectRegistry> {
           onChange({ added: [], removed, projects: [] })
         })(),
       )
+      await new Promise<void>((resolve, reject) => {
+        watcher.once('ready', () => resolve())
+        watcher.once('error', reject)
+      })
 
       return async () => {
         await watcher.close()

--- a/src 2/daemon/kairos/projectWorker.test.ts
+++ b/src 2/daemon/kairos/projectWorker.test.ts
@@ -33,6 +33,18 @@ function makeTask(id: string): CronTask {
   }
 }
 
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 3_000,
+): Promise<void> {
+  const started = Date.now()
+  while (Date.now() - started < timeoutMs) {
+    if (predicate()) return
+    await Bun.sleep(25)
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`)
+}
+
 describe('Kairos project worker', () => {
   test('project registry reads, writes, and diffs projects.json', async () => {
     const configDir = makeTempConfigDir('kairos-registry-')
@@ -49,9 +61,8 @@ describe('Kairos project worker', () => {
       changes.push({ added: change.added, removed: change.removed })
     })
 
-    await Bun.sleep(50)
     await registry.write(['/repo/b', '/repo/c'])
-    await Bun.sleep(400)
+    await waitFor(() => changes.length > 0)
     await stop()
 
     expect(changes).toEqual([

--- a/src 2/daemon/kairos/worker.test.ts
+++ b/src 2/daemon/kairos/worker.test.ts
@@ -7,6 +7,7 @@ import { getKairosStateDir, getKairosStatusPath, getKairosStdoutLogPath } from '
 import { runKairosWorker } from './worker.js'
 
 const TEMP_DIRS: string[] = []
+const DAEMON_MAIN_URL = new URL('../main.ts', import.meta.url).href
 
 afterEach(() => {
   delete process.env.CLAUDE_CONFIG_DIR
@@ -79,12 +80,11 @@ describe('Kairos daemon worker', () => {
 
   test('daemon main exits with code 0 on SIGTERM', async () => {
     const configDir = makeTempConfigDir()
-    const daemonRoot = join(process.cwd(), 'daemon')
     const child = spawn(
       process.execPath,
       [
         '--eval',
-        'import { daemonMain } from "./daemon/main.ts"; await daemonMain(["kairos"]);',
+        `import { daemonMain } from ${JSON.stringify(DAEMON_MAIN_URL)}; await daemonMain(["kairos"], { dashboard: { port: 0 } });`,
       ],
       {
         cwd: process.cwd(),

--- a/src 2/daemon/main.ts
+++ b/src 2/daemon/main.ts
@@ -1,4 +1,8 @@
 import { runKairosWorker } from './kairos/worker.js'
+import {
+  startKairosDashboardServer,
+  type KairosDashboardServerOptions,
+} from './dashboard/server.js'
 
 type SignalHandler = () => void
 
@@ -6,6 +10,7 @@ export type DaemonMainOptions = {
   registerSignalHandlers?: (
     handler: SignalHandler,
   ) => (() => void) | Promise<() => void>
+  dashboard?: KairosDashboardServerOptions
 }
 
 async function defaultRegisterSignalHandlers(
@@ -34,11 +39,13 @@ export async function daemonMain(
   const register =
     options.registerSignalHandlers ?? defaultRegisterSignalHandlers
   const unregister = await register(() => controller.abort())
+  const dashboard = await startKairosDashboardServer(options.dashboard)
 
   try {
     const exitCode = await runKairosWorker({ signal: controller.signal })
     process.exitCode = exitCode
   } finally {
+    await dashboard.stop()
     unregister()
   }
 }


### PR DESCRIPTION
Implements issue #15 by adding a loopback-only KAIROS dashboard under `src 2/daemon/dashboard` with static HTML/CSS/JS, JSON APIs, SSE live updates, project selection, and pause/resume, opt-in/out, and demo controls.

The daemon now starts the dashboard alongside the worker, and the daemon path layer exposes per-project status/log helpers needed by the UI.

This PR also hardens the related daemon tests and watcher readiness so the dashboard and registry tests pass reliably in batch runs.

Verification: `cd "src 2" && find ./daemon/kairos ./daemon/dashboard -name '*.test.ts' -print0 | xargs -0 bun test`.\n\nVisual proof screenshots/recording are still needed separately for the issue checklist.