### PR TITLE
Add /remind slash command

### DIFF
--- a/src 2/commands.ts
+++ b/src 2/commands.ts
@@ -36,6 +36,7 @@ import mobile from './commands/mobile/index.js'
 import onboarding from './commands/onboarding/index.js'
 import pr_comments from './commands/pr_comments/index.js'
 import releaseNotes from './commands/release-notes/index.js'
+import remind from './commands/remind/index.js'
 import rename from './commands/rename/index.js'
 import resume from './commands/resume/index.js'
 import review, { ultrareview } from './commands/review.js'
@@ -296,6 +297,7 @@ const COMMANDS = memoize((): Command[] => [
   pr_comments,
   releaseNotes,
   reloadPlugins,
+  remind,
   rename,
   resume,
   session,

--- a/src 2/commands/remind/index.ts
+++ b/src 2/commands/remind/index.ts
@@ -1,0 +1,12 @@
+import type { Command } from '../../commands.js'
+
+const remind = {
+  type: 'local',
+  name: 'remind',
+  description: 'Schedule a reminder for a future time',
+  argumentHint: '<time> | <text>',
+  supportsNonInteractive: true,
+  load: () => import('./remind.js'),
+} satisfies Command
+
+export default remind

--- a/src 2/commands/remind/remind.test.ts
+++ b/src 2/commands/remind/remind.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getProjectRoot,
+  setProjectRoot,
+} from '../../bootstrap/state.js'
+import { call } from './remind.js'
+
+const TEMP_DIRS: string[] = []
+let originalProjectRoot: string
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-remind-command-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function readScheduledTasks(projectDir: string): {
+  tasks: Array<{
+    id: string
+    cron: string
+    prompt: string
+    createdAt: number
+  }>
+} {
+  return JSON.parse(
+    readFileSync(join(projectDir, '.claude', 'scheduled_tasks.json'), 'utf-8'),
+  )
+}
+
+beforeEach(() => {
+  originalProjectRoot = getProjectRoot()
+})
+
+afterEach(() => {
+  setProjectRoot(originalProjectRoot)
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('/remind command', () => {
+  test('routes user input through the reminder request flow and scheduler core', async () => {
+    const projectDir = makeProjectDir()
+    setProjectRoot(projectDir)
+
+    const result = await call(
+      '2026-05-15T14:02:00.000Z | Drink water.',
+      {} as never,
+    )
+
+    expect(result.type).toBe('text')
+    if (result.type !== 'text') return
+    expect(result.value).toContain('Reminder scheduled for')
+    expect(result.value).toContain('"Drink water."')
+
+    expect(readScheduledTasks(projectDir).tasks).toHaveLength(1)
+    expect(readScheduledTasks(projectDir).tasks[0]).toMatchObject({
+      prompt: 'Drink water.',
+    })
+  })
+})

--- a/src 2/commands/remind/remind.ts
+++ b/src 2/commands/remind/remind.ts
@@ -1,0 +1,7 @@
+import type { LocalCommandCall } from '../../types/command.js'
+import { runReminderCommand } from '../../services/reminders/reminderCommand.js'
+
+export const call: LocalCommandCall = async args => {
+  const value = await runReminderCommand(args)
+  return { type: 'text', value }
+}


### PR DESCRIPTION
Adds a built-in `/remind` local command and registers it in the command list.
The command delegates to the existing reminder request flow instead of duplicating scheduler logic.
This also adds a command-level test that verifies the user-facing command writes the durable scheduled task.

Tests: `bun test "src 2/services/reminders/reminderScheduler.test.ts" "src 2/services/reminders/createReminderFromUserRequest.test.ts" "src 2/services/reminders/reminderCommand.test.ts" "src 2/commands/remind/remind.test.ts"`