### PR TITLE
Fix Kairos Tier 3 review blockers

### DIFF
--- a/src 2/daemon/kairos/tier3.test.ts
+++ b/src 2/daemon/kairos/tier3.test.ts
@@ -16,13 +16,19 @@ import type {
 } from './childRunner.js'
 import { getKairosGlobalEventsPath, getProjectKairosEventsPath } from './paths.js'
 import { createStateWriter } from './stateWriter.js'
-import { runTier3Reflection } from './tier3.js'
+import { runTier3Reflection, parseTier3Decision } from './tier3.js'
+import {
+  getSessionSettingsCache,
+  resetSettingsCache,
+  setSessionSettingsCache,
+} from '../../utils/settings/settingsCache.js'
 
 const TEMP_DIRS: string[] = []
 
 afterEach(() => {
   delete process.env.CLAUDE_CONFIG_DIR
   delete process.env.KAIROS_TIER3_INTERVAL_MS
+  resetSettingsCache()
   for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -70,6 +76,23 @@ function makeAssistantJsonMessage(json: string): ChildStreamMessage {
 }
 
 describe('Kairos Tier 3 reflection', () => {
+  test('parses JSON wrapped in conversational text and markdown fences', () => {
+    expect(
+      parseTier3Decision(
+        'Sure, here is the decision:\n```json\n{"surface":false}\n```\nNo further action.',
+      ),
+    ).toEqual({ surface: false })
+
+    expect(
+      parseTier3Decision(
+        'Based on the latest context, use this:\n{"surface":true,"message":"Surface the failing auth tests."}\nThanks.',
+      ),
+    ).toEqual({
+      surface: true,
+      message: 'Surface the failing auth tests.',
+    })
+  })
+
   test('is disabled by default', async () => {
     const configDir = makeTempDir('kairos-tier3-config-')
     const projectDir = makeTempDir('kairos-tier3-project-')
@@ -281,6 +304,76 @@ describe('Kairos Tier 3 reflection', () => {
       'utf8',
     )
     expect(log).toContain('"outcome":"surface"')
+  })
+
+  test('re-reads tier3 settings without clearing the global settings cache', async () => {
+    const configDir = makeTempDir('kairos-tier3-reread-config-')
+    const projectDir = makeTempDir('kairos-tier3-reread-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+
+    const cachedSettings = { settings: {}, errors: [] }
+    setSessionSettingsCache(cachedSettings)
+
+    const disabledLauncher = makeLauncher([
+      makeAssistantJsonMessage('{"surface":false}'),
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        duration_ms: 50,
+        total_cost_usd: 0.01,
+      },
+    ])
+
+    const disabled = await runTier3Reflection({
+      projectDir,
+      stateWriter,
+      launcher: disabledLauncher.launcher,
+      costTracker: null,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 3,
+      timeoutMs: 5_000,
+      handleCapHit: async () => {},
+      now: () => new Date('2026-04-22T14:30:00.000Z'),
+    })
+
+    expect(disabled.outcome).toBe('disabled')
+    expect(disabledLauncher.calls).toHaveLength(0)
+    expect(getSessionSettingsCache()).toBe(cachedSettings)
+
+    writeTier3Settings(projectDir, { enabled: true })
+
+    const enabledLauncher = makeLauncher([
+      makeAssistantJsonMessage('{"surface":false}'),
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        duration_ms: 50,
+        total_cost_usd: 0.01,
+      },
+    ])
+
+    const enabled = await runTier3Reflection({
+      projectDir,
+      stateWriter,
+      launcher: enabledLauncher.launcher,
+      costTracker: null,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 3,
+      timeoutMs: 5_000,
+      handleCapHit: async () => {},
+      now: () => new Date('2026-04-22T15:30:00.000Z'),
+    })
+
+    expect(enabled.outcome).toBe('noop')
+    expect(enabledLauncher.calls).toHaveLength(1)
+    expect(getSessionSettingsCache()).toBe(cachedSettings)
   })
 
   test('settings interval does not lower the hourly cap, but env override can', async () => {

--- a/src 2/daemon/kairos/tier3.ts
+++ b/src 2/daemon/kairos/tier3.ts
@@ -4,7 +4,7 @@ import { z } from 'zod/v4'
 import type { CronTask } from '../../utils/cronTasks.js'
 import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
 import { parseSettingsFile } from '../../utils/settings/settings.js'
-import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import { clearCachedParsedFile } from '../../utils/settings/settingsCache.js'
 import type { ChildLauncher, ChildRunResult } from './childRunner.js'
 import { runChild } from './childRunner.js'
 import type { CapHit, CostTracker } from './costTracker.js'
@@ -111,7 +111,7 @@ function parsePositiveNumber(value: unknown): number | undefined {
     : undefined
 }
 
-function readTier3ConfigPartial(settings: unknown): Pick<Tier3Config, 'enabled'> | {} {
+function readTier3ConfigPartial(settings: unknown): Partial<Tier3Config> {
   if (!settings || typeof settings !== 'object') return {}
   const kairos = (settings as Record<string, unknown>).kairos
   if (!kairos || typeof kairos !== 'object') return {}
@@ -119,10 +119,11 @@ function readTier3ConfigPartial(settings: unknown): Pick<Tier3Config, 'enabled'>
   if (!tier3 || typeof tier3 !== 'object') return {}
 
   const record = tier3 as Record<string, unknown>
-  return {
-    enabled:
-      typeof record.enabled === 'boolean' ? record.enabled : undefined,
+  const partial: Partial<Tier3Config> = {}
+  if (typeof record.enabled === 'boolean') {
+    partial.enabled = record.enabled
   }
+  return partial
 }
 
 export function getTier3WindowKey(now: Date, intervalMs: number): string {
@@ -142,10 +143,9 @@ export function computeTier3AllowedTools(
 }
 
 async function readTier3Config(projectDir: string): Promise<Tier3Config & { intervalMs: number }> {
-  resetSettingsCache()
-
   const merged: Partial<Tier3Config> = {}
   for (const path of getProjectSettingsPaths(projectDir)) {
+    clearCachedParsedFile(path)
     const { settings } = parseSettingsFile(path)
     const partial = readTier3ConfigPartial(settings)
     if (partial.enabled !== undefined) {
@@ -191,12 +191,53 @@ function truncateForLog(value: string | undefined, max = 160): string | undefine
 }
 
 function normalizeStructuredOutput(raw: string): string {
-  return raw
-    .trim()
-    .replace(/^```json\s*/i, '')
-    .replace(/^```\s*/i, '')
-    .replace(/\s*```$/, '')
-    .trim()
+  const trimmed = raw.trim()
+  const fencedJson = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)?.[1]?.trim()
+  const candidate = fencedJson ?? trimmed
+
+  const objectStart = candidate.indexOf('{')
+  if (objectStart === -1) {
+    return candidate
+  }
+
+  let depth = 0
+  let inString = false
+  let escaped = false
+
+  for (let index = objectStart; index < candidate.length; index += 1) {
+    const char = candidate[index]
+    if (!char) continue
+
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (char === '\\') {
+        escaped = true
+      } else if (char === '"') {
+        inString = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inString = true
+      continue
+    }
+
+    if (char === '{') {
+      depth += 1
+      continue
+    }
+
+    if (char === '}') {
+      depth -= 1
+      if (depth === 0) {
+        return candidate.slice(objectStart, index + 1)
+      }
+    }
+  }
+
+  return candidate
 }
 
 export function parseTier3Decision(raw: string): Tier3Decision {

--- a/src 2/dist/employee-smoke.js
+++ b/src 2/dist/employee-smoke.js
@@ -34814,11 +34814,11 @@ var init_types = () => {};
 var exports_dist_es2 = {};
 __export(exports_dist_es2, {
   providerConfigFromInit: () => providerConfigFromInit,
-  httpRequest: () => httpRequest2,
-  getInstanceMetadataEndpoint: () => getInstanceMetadataEndpoint2,
+  httpRequest: () => httpRequest,
+  getInstanceMetadataEndpoint: () => getInstanceMetadataEndpoint,
   fromInstanceMetadata: () => fromInstanceMetadata,
   fromContainerMetadata: () => fromContainerMetadata,
-  Endpoint: () => Endpoint2,
+  Endpoint: () => Endpoint,
   ENV_CMDS_RELATIVE_URI: () => ENV_CMDS_RELATIVE_URI,
   ENV_CMDS_FULL_URI: () => ENV_CMDS_FULL_URI,
   ENV_CMDS_AUTH_TOKEN: () => ENV_CMDS_AUTH_TOKEN,
@@ -34826,6 +34826,9 @@ __export(exports_dist_es2, {
   DEFAULT_MAX_RETRIES: () => DEFAULT_MAX_RETRIES
 });
 var init_dist_es2 = __esm(() => {
+  init_httpRequest();
+  init_getInstanceMetadataEndpoint();
+  init_Endpoint();
   init_fromContainerMetadata();
   init_fromInstanceMetadata();
   init_types();
@@ -41826,7 +41829,7 @@ var require_dist_cjs37 = __commonJS((exports) => {
   }
 
   class HttpApiKeyAuthSigner {
-    async sign(httpRequest4, identity6, signingProperties) {
+    async sign(httpRequest3, identity6, signingProperties) {
       if (!signingProperties) {
         throw new Error("request could not be signed with `apiKey` since the `name` and `in` signer properties are missing");
       }
@@ -41839,7 +41842,7 @@ var require_dist_cjs37 = __commonJS((exports) => {
       if (!identity6.apiKey) {
         throw new Error("request could not be signed with `apiKey` since the `apiKey` is not defined");
       }
-      const clonedRequest = protocolHttp.HttpRequest.clone(httpRequest4);
+      const clonedRequest = protocolHttp.HttpRequest.clone(httpRequest3);
       if (signingProperties.in === types3.HttpApiKeyAuthLocation.QUERY) {
         clonedRequest.query[signingProperties.name] = identity6.apiKey;
       } else if (signingProperties.in === types3.HttpApiKeyAuthLocation.HEADER) {
@@ -41852,8 +41855,8 @@ var require_dist_cjs37 = __commonJS((exports) => {
   }
 
   class HttpBearerAuthSigner {
-    async sign(httpRequest4, identity6, signingProperties) {
-      const clonedRequest = protocolHttp.HttpRequest.clone(httpRequest4);
+    async sign(httpRequest3, identity6, signingProperties) {
+      const clonedRequest = protocolHttp.HttpRequest.clone(httpRequest3);
       if (!identity6.token) {
         throw new Error("request could not be signed with `token` since the `token` is not defined");
       }
@@ -41863,8 +41866,8 @@ var require_dist_cjs37 = __commonJS((exports) => {
   }
 
   class NoAuthSigner {
-    async sign(httpRequest4, identity6, signingProperties) {
-      return httpRequest4;
+    async sign(httpRequest3, identity6, signingProperties) {
+      return httpRequest3;
     }
   }
   var createIsIdentityExpiredFunction = (expirationMs) => function isIdentityExpired2(identity6) {
@@ -42564,8 +42567,8 @@ var require_httpAuthSchemes = __commonJS((exports) => {
   };
 
   class AwsSdkSigV4Signer {
-    async sign(httpRequest4, identity6, signingProperties) {
-      if (!protocolHttp.HttpRequest.isInstance(httpRequest4)) {
+    async sign(httpRequest3, identity6, signingProperties) {
+      if (!protocolHttp.HttpRequest.isInstance(httpRequest3)) {
         throw new Error("The request is not an instance of `HttpRequest` and cannot be signed");
       }
       const validatedProps = await validateSigningProperties(signingProperties);
@@ -42579,7 +42582,7 @@ var require_httpAuthSchemes = __commonJS((exports) => {
           signingName = second?.signingName ?? signingName;
         }
       }
-      const signedRequest = await signer.sign(httpRequest4, {
+      const signedRequest = await signer.sign(httpRequest3, {
         signingDate: getSkewCorrectedDate(config3.systemClockOffset),
         signingRegion,
         signingService: signingName
@@ -42612,14 +42615,14 @@ var require_httpAuthSchemes = __commonJS((exports) => {
   var AWSSDKSigV4Signer = AwsSdkSigV4Signer;
 
   class AwsSdkSigV4ASigner extends AwsSdkSigV4Signer {
-    async sign(httpRequest4, identity6, signingProperties) {
-      if (!protocolHttp.HttpRequest.isInstance(httpRequest4)) {
+    async sign(httpRequest3, identity6, signingProperties) {
+      if (!protocolHttp.HttpRequest.isInstance(httpRequest3)) {
         throw new Error("The request is not an instance of `HttpRequest` and cannot be signed");
       }
       const { config: config3, signer, signingRegion, signingRegionSet, signingName } = await validateSigningProperties(signingProperties);
       const configResolvedSigningRegionSet = await config3.sigv4aSigningRegionSet?.();
       const multiRegionOverride = (configResolvedSigningRegionSet ?? signingRegionSet ?? [signingRegion]).join(",");
-      const signedRequest = await signer.sign(httpRequest4, {
+      const signedRequest = await signer.sign(httpRequest3, {
         signingDate: getSkewCorrectedDate(config3.systemClockOffset),
         signingRegion: multiRegionOverride,
         signingService: signingName
@@ -48463,7 +48466,7 @@ var require_package = __commonJS((exports, module) => {
 
 // node_modules/@aws-sdk/util-user-agent-node/dist-cjs/index.js
 var require_dist_cjs72 = __commonJS((exports) => {
-  var __dirname = "/Users/gaganarora/Downloads/src 2/node_modules/@aws-sdk/util-user-agent-node/dist-cjs";
+  var __dirname = "/Users/gaganarora/conductor/workspaces/again/cayenne/src 2/node_modules/@aws-sdk/util-user-agent-node/dist-cjs";
   var node_os = __require("os");
   var node_process = __require("process");
   var utilConfigProvider = require_dist_cjs57();
@@ -48786,9 +48789,9 @@ var require_dist_cjs77 = __commonJS((exports) => {
     }
     if (!process.env[ENV_IMDS_DISABLED2]) {
       try {
-        const { getInstanceMetadataEndpoint: getInstanceMetadataEndpoint3, httpRequest: httpRequest4 } = await Promise.resolve().then(() => (init_dist_es2(), exports_dist_es2));
-        const endpoint2 = await getInstanceMetadataEndpoint3();
-        return (await httpRequest4({ ...endpoint2, path: IMDS_REGION_PATH })).toString();
+        const { getInstanceMetadataEndpoint: getInstanceMetadataEndpoint2, httpRequest: httpRequest3 } = await Promise.resolve().then(() => (init_dist_es2(), exports_dist_es2));
+        const endpoint2 = await getInstanceMetadataEndpoint2();
+        return (await httpRequest3({ ...endpoint2, path: IMDS_REGION_PATH })).toString();
       } catch (e) {}
     }
   };
@@ -101833,7 +101836,7 @@ async function runAwsAuthRefresh() {
   if (isAwsAuthRefreshFromProjectSettings()) {
     const hasTrust = checkHasTrustDialogAccepted();
     if (!hasTrust && !getIsNonInteractiveSession()) {
-      const error49 = new Error(`Security: awsAuthRefresh executed before workspace trust is confirmed. If you see this message, post in ${MACRO.FEEDBACK_CHANNEL}.`);
+      const error49 = new Error(`Security: awsAuthRefresh executed before workspace trust is confirmed. If you see this message, post in ${{ VERSION: "0.0.0-rebuilt", BUILD_TIME: "2026-03-31T00:00:00.000Z", FEEDBACK_CHANNEL: "#claude-code", ISSUES_EXPLAINER: "open an issue", PACKAGE_URL: "@anthropic-ai/claude-code", NATIVE_PACKAGE_URL: "@anthropic-ai/claude-code-native", VERSION_CHANGELOG: "" }.FEEDBACK_CHANNEL}.`);
       logAntError("awsAuthRefresh invoked before trust check", error49);
       logEvent("tengu_awsAuthRefresh_missing_trust", {});
       return false;
@@ -101894,7 +101897,7 @@ async function getAwsCredsFromCredentialExport() {
   if (isAwsCredentialExportFromProjectSettings()) {
     const hasTrust = checkHasTrustDialogAccepted();
     if (!hasTrust && !getIsNonInteractiveSession()) {
-      const error49 = new Error(`Security: awsCredentialExport executed before workspace trust is confirmed. If you see this message, post in ${MACRO.FEEDBACK_CHANNEL}.`);
+      const error49 = new Error(`Security: awsCredentialExport executed before workspace trust is confirmed. If you see this message, post in ${{ VERSION: "0.0.0-rebuilt", BUILD_TIME: "2026-03-31T00:00:00.000Z", FEEDBACK_CHANNEL: "#claude-code", ISSUES_EXPLAINER: "open an issue", PACKAGE_URL: "@anthropic-ai/claude-code", NATIVE_PACKAGE_URL: "@anthropic-ai/claude-code-native", VERSION_CHANGELOG: "" }.FEEDBACK_CHANNEL}.`);
       logAntError("awsCredentialExport invoked before trust check", error49);
       logEvent("tengu_awsCredentialExport_missing_trust", {});
       return null;
@@ -101986,7 +101989,7 @@ async function runGcpAuthRefresh() {
   if (isGcpAuthRefreshFromProjectSettings()) {
     const hasTrust = checkHasTrustDialogAccepted();
     if (!hasTrust && !getIsNonInteractiveSession()) {
-      const error49 = new Error(`Security: gcpAuthRefresh executed before workspace trust is confirmed. If you see this message, post in ${MACRO.FEEDBACK_CHANNEL}.`);
+      const error49 = new Error(`Security: gcpAuthRefresh executed before workspace trust is confirmed. If you see this message, post in ${{ VERSION: "0.0.0-rebuilt", BUILD_TIME: "2026-03-31T00:00:00.000Z", FEEDBACK_CHANNEL: "#claude-code", ISSUES_EXPLAINER: "open an issue", PACKAGE_URL: "@anthropic-ai/claude-code", NATIVE_PACKAGE_URL: "@anthropic-ai/claude-code-native", VERSION_CHANGELOG: "" }.FEEDBACK_CHANNEL}.`);
       logAntError("gcpAuthRefresh invoked before trust check", error49);
       logEvent("tengu_gcpAuthRefresh_missing_trust", {});
       return false;
@@ -102210,7 +102213,7 @@ var getCoreUserData = memoize_default((includeAnalyticsMetadata) => {
     deviceId,
     sessionId: getSessionId(),
     email: getEmail(),
-    appVersion: MACRO.VERSION,
+    appVersion: { VERSION: "0.0.0-rebuilt", BUILD_TIME: "2026-03-31T00:00:00.000Z", FEEDBACK_CHANNEL: "#claude-code", ISSUES_EXPLAINER: "open an issue", PACKAGE_URL: "@anthropic-ai/claude-code", NATIVE_PACKAGE_URL: "@anthropic-ai/claude-code-native", VERSION_CHANGELOG: "" }.VERSION,
     platform: getHostPlatformForAnalytics(),
     organizationUuid,
     accountUuid,
@@ -102460,7 +102463,7 @@ var FILE_COMMANDS = new Set([
   "sed"
 ]);
 var getVersionBase = memoize_default(() => {
-  const match = MACRO.VERSION.match(/^\d+\.\d+\.\d+(?:-[a-z]+)?/);
+  const match = { VERSION: "0.0.0-rebuilt", BUILD_TIME: "2026-03-31T00:00:00.000Z", FEEDBACK_CHANNEL: "#claude-code", ISSUES_EXPLAINER: "open an issue", PACKAGE_URL: "@anthropic-ai/claude-code", NATIVE_PACKAGE_URL: "@anthropic-ai/claude-code-native", VERSION_CHANGELOG: "" }.VERSION.match(/^\d+\.\d+\.\d+(?:-[a-z]+)?/);
   return match ? match[0] : undefined;
 });
 var buildEnvContext = memoize_default(async () => {
@@ -102500,9 +102503,9 @@ var buildEnvContext = memoize_default(async () => {
     isGithubAction: isEnvTruthy(process.env.GITHUB_ACTIONS),
     isClaudeCodeAction: isEnvTruthy(process.env.CLAUDE_CODE_ACTION),
     isClaudeAiAuth: isClaudeAISubscriber(),
-    version: MACRO.VERSION,
+    version: { VERSION: "0.0.0-rebuilt", BUILD_TIME: "2026-03-31T00:00:00.000Z", FEEDBACK_CHANNEL: "#claude-code", ISSUES_EXPLAINER: "open an issue", PACKAGE_URL: "@anthropic-ai/claude-code", NATIVE_PACKAGE_URL: "@anthropic-ai/claude-code-native", VERSION_CHANGELOG: "" }.VERSION,
     versionBase: getVersionBase(),
-    buildTime: MACRO.BUILD_TIME,
+    buildTime: { VERSION: "0.0.0-rebuilt", BUILD_TIME: "2026-03-31T00:00:00.000Z", FEEDBACK_CHANNEL: "#claude-code", ISSUES_EXPLAINER: "open an issue", PACKAGE_URL: "@anthropic-ai/claude-code", NATIVE_PACKAGE_URL: "@anthropic-ai/claude-code-native", VERSION_CHANGELOG: "" }.BUILD_TIME,
     deploymentEnvironment: env3.detectDeploymentEnvironment(),
     ...isEnvTruthy(process.env.GITHUB_ACTIONS) && {
       githubEventName: process.env.GITHUB_EVENT_NAME,
@@ -103074,7 +103077,8 @@ Complete the user's request by providing accurate, documentation-based guidance.
 }
 function getFeedbackGuideline() {
   if (isUsing3PServices()) {
-    return `- When you cannot find an answer or the feature doesn't exist, direct the user to ${MACRO.ISSUES_EXPLAINER}`;
+    const macro = globalThis.MACRO;
+    return `- When you cannot find an answer or the feature doesn't exist, direct the user to ${macro?.ISSUES_EXPLAINER ?? "use /feedback to report a feature request or bug"}`;
   }
   return "- When you cannot find an answer or the feature doesn't exist, direct the user to use /feedback to report a feature request or bug";
 }

--- a/src 2/utils/settings/settingsCache.ts
+++ b/src 2/utils/settings/settingsCache.ts
@@ -52,6 +52,10 @@ export function setCachedParsedFile(path: string, value: ParsedSettings): void {
   parseFileCache.set(path, value)
 }
 
+export function clearCachedParsedFile(path: string): void {
+  parseFileCache.delete(path)
+}
+
 export function resetSettingsCache(): void {
   sessionSettingsCache = null
   perSourceCache.clear()


### PR DESCRIPTION
This updates Kairos Tier 3 config loading to return a strict-safe partial config, reread only the relevant parsed settings files, and avoid clearing the global settings cache on each poll. It also hardens structured-output parsing so Tier 3 can recover JSON wrapped in markdown fences or conversational preamble/postamble. The PR adds regression coverage for both behaviors in the Tier 3 test suite. Regenerated bundle artifacts are included in src 2/dist/cli.js and src 2/dist/employee-smoke.js to match the source changes.