### PR TITLE
feat(kairos): add /kairos command + LaunchAgent install (Phase 5A, closes #16)

### DIFF
--- a/src 2/commands/kairos.test.ts
+++ b/src 2/commands/kairos.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  getProjectRoot,
+  setProjectRoot,
+} from '../bootstrap/state.js'
+import { runKairosCommand } from './kairos.js'
+
+const TEMP_DIRS: string[] = []
+let originalProjectRoot: string
+
+function makeTempConfigDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-cmd-config-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-cmd-project-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+beforeEach(() => {
+  originalProjectRoot = getProjectRoot()
+  process.env.CLAUDE_CONFIG_DIR = makeTempConfigDir()
+})
+
+afterEach(() => {
+  setProjectRoot(originalProjectRoot)
+  delete process.env.CLAUDE_CONFIG_DIR
+  delete process.env.KAIROS_DASHBOARD_URL
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('/kairos command', () => {
+  test('prints help when called with no args', async () => {
+    const out = await runKairosCommand('')
+    expect(out).toContain('/kairos status')
+    expect(out).toContain('/kairos opt-in')
+    expect(out).toContain('/kairos demo')
+  })
+
+  test('prints help for unknown subcommands', async () => {
+    const out = await runKairosCommand('bogus')
+    expect(out).toContain('Usage:')
+  })
+
+  test('opt-in and opt-out modify projects.json', async () => {
+    const projectDir = makeProjectDir()
+    const projectsFile = join(
+      process.env.CLAUDE_CONFIG_DIR as string,
+      'kairos',
+      'projects.json',
+    )
+
+    const optIn = await runKairosCommand(`opt-in ${projectDir}`)
+    expect(optIn).toContain('Opted in')
+    expect(readJson(projectsFile)).toEqual({ projects: [projectDir] })
+
+    const optOut = await runKairosCommand(`opt-out ${projectDir}`)
+    expect(optOut).toContain('Opted out')
+    expect(readJson(projectsFile)).toEqual({ projects: [] })
+  })
+
+  test('list shows opted-in projects', async () => {
+    const a = makeProjectDir()
+    const b = makeProjectDir()
+    await runKairosCommand(`opt-in ${a}`)
+    await runKairosCommand(`opt-in ${b}`)
+
+    const out = await runKairosCommand('list')
+    expect(out).toContain(a)
+    expect(out).toContain(b)
+  })
+
+  test('list reports empty state clearly', async () => {
+    const out = await runKairosCommand('list')
+    expect(out).toBe('No projects opted in.')
+  })
+
+  test('demo writes a durable file-backed one-shot cron task', async () => {
+    const projectDir = makeProjectDir()
+
+    const out = await runKairosCommand(`demo ${projectDir}`)
+    expect(out).toContain('scheduled')
+
+    const tasksPath = join(projectDir, '.claude', 'scheduled_tasks.json')
+    const body = readJson(tasksPath) as {
+      tasks: Array<{ id: string; cron: string; prompt: string; recurring?: boolean }>
+    }
+    expect(body.tasks).toHaveLength(1)
+    const [task] = body.tasks
+    expect(task.recurring).toBeUndefined()
+    expect(task.prompt).toContain('KAIROS dashboard demo')
+    // Cron must be a valid 5-field expression targeting a specific minute.
+    expect(task.cron.split(/\s+/)).toHaveLength(5)
+  })
+
+  test('pause writes pause.json and resume clears it', async () => {
+    const pausePath = join(
+      process.env.CLAUDE_CONFIG_DIR as string,
+      'kairos',
+      'pause.json',
+    )
+
+    await runKairosCommand('pause')
+    expect((readJson(pausePath) as { paused: boolean }).paused).toBe(true)
+
+    await runKairosCommand('resume')
+    expect((readJson(pausePath) as { paused: boolean }).paused).toBe(false)
+  })
+
+  test('status surfaces the daemon-authored re-auth notice verbatim', async () => {
+    const stateDir = join(process.env.CLAUDE_CONFIG_DIR as string, 'kairos')
+    mkdirSync(stateDir, { recursive: true })
+    writeFileSync(
+      join(stateDir, 'pause.json'),
+      JSON.stringify({
+        paused: true,
+        reason: 'auth_failure',
+        scope: 'global',
+        source: 'daemon',
+        setAt: '2026-04-22T12:00:00Z',
+        notice:
+          'KAIROS daemon hit an auth failure. Run `claude` interactively once to re-authorize the Keychain entry, then resume the daemon.',
+      }),
+    )
+
+    const out = await runKairosCommand('status')
+    expect(out).toContain('paused: yes [auth_failure]')
+    expect(out).toContain('notice: KAIROS daemon hit an auth failure')
+    expect(out).toContain('Run `claude` interactively')
+  })
+
+  test('status reports running daemon + pause state', async () => {
+    const stateDir = join(process.env.CLAUDE_CONFIG_DIR as string, 'kairos')
+    mkdirSync(stateDir, { recursive: true })
+    writeFileSync(
+      join(stateDir, 'status.json'),
+      JSON.stringify({
+        kind: 'kairos',
+        state: 'idle',
+        pid: 4242,
+        startedAt: '2026-04-22T12:00:00Z',
+        updatedAt: '2026-04-22T12:01:00Z',
+        projects: 1,
+      }),
+    )
+
+    await runKairosCommand('pause')
+    const out = await runKairosCommand('status')
+    expect(out).toContain('pid 4242')
+    expect(out).toContain('paused: yes')
+  })
+
+  test('dashboard respects KAIROS_DASHBOARD_URL override', async () => {
+    process.env.KAIROS_DASHBOARD_URL = 'http://127.0.0.1:9999/'
+    const out = await runKairosCommand('dashboard')
+    expect(out).toBe('Dashboard: http://127.0.0.1:9999/')
+  })
+
+  test('logs returns the daemon stdout tail', async () => {
+    const stateDir = join(process.env.CLAUDE_CONFIG_DIR as string, 'kairos')
+    mkdirSync(stateDir, { recursive: true })
+    writeFileSync(
+      join(stateDir, 'daemon.out.log'),
+      ['[t] first', '[t] second', '[t] third', ''].join('\n'),
+    )
+
+    const out = await runKairosCommand('logs 2')
+    expect(out).toBe(['[t] second', '[t] third'].join('\n'))
+  })
+
+  test('logs returns project log tail when a project dir is passed', async () => {
+    const projectDir = makeProjectDir()
+    const logPath = join(projectDir, '.claude', 'kairos', 'log.jsonl')
+    mkdirSync(join(projectDir, '.claude', 'kairos'), { recursive: true })
+    writeFileSync(
+      logPath,
+      ['{"a":1}', '{"a":2}', '{"a":3}', ''].join('\n'),
+    )
+
+    const out = await runKairosCommand(`logs ${projectDir} 2`)
+    expect(out).toBe(['{"a":2}', '{"a":3}'].join('\n'))
+  })
+})

--- a/src 2/commands/kairos.test.ts
+++ b/src 2/commands/kairos.test.ts
@@ -120,6 +120,35 @@ describe('/kairos command', () => {
     expect((readJson(pausePath) as { paused: boolean }).paused).toBe(false)
   })
 
+  test('resume warns the user when the prior pause was an auth_failure', async () => {
+    // Users who /kairos resume without actually re-auth'ing would otherwise
+    // silently loop-retry on the next tick. Make the command explicitly
+    // call out the prerequisite.
+    const stateDir = join(process.env.CLAUDE_CONFIG_DIR as string, 'kairos')
+    mkdirSync(stateDir, { recursive: true })
+    writeFileSync(
+      join(stateDir, 'pause.json'),
+      JSON.stringify({
+        paused: true,
+        reason: 'auth_failure',
+        scope: 'global',
+        source: 'daemon',
+        setAt: '2026-04-22T12:00:00Z',
+        notice: 'KAIROS daemon hit an auth failure.',
+      }),
+    )
+
+    const out = await runKairosCommand('resume')
+    expect(out).toContain('auth_failure')
+    expect(out).toContain('`claude` interactively')
+  })
+
+  test('resume is silent on the auth warning when prior pause was not auth_failure', async () => {
+    await runKairosCommand('pause')
+    const out = await runKairosCommand('resume')
+    expect(out).toBe('Resumed KAIROS daemon.')
+  })
+
   test('status surfaces the daemon-authored re-auth notice verbatim', async () => {
     const stateDir = join(process.env.CLAUDE_CONFIG_DIR as string, 'kairos')
     mkdirSync(stateDir, { recursive: true })
@@ -192,5 +221,20 @@ describe('/kairos command', () => {
 
     const out = await runKairosCommand(`logs ${projectDir} 2`)
     expect(out).toBe(['{"a":2}', '{"a":3}'].join('\n'))
+  })
+
+  test('logs treats a bare number as a line count, not a project dir', async () => {
+    // Regression: the earlier heuristic matched any token containing `/`,
+    // `~`, or `.` — so `25.` would have been routed to project logs.
+    // Bare digits must always be a line count.
+    const stateDir = join(process.env.CLAUDE_CONFIG_DIR as string, 'kairos')
+    mkdirSync(stateDir, { recursive: true })
+    writeFileSync(
+      join(stateDir, 'daemon.out.log'),
+      ['a', 'b', 'c', 'd', ''].join('\n'),
+    )
+
+    const out = await runKairosCommand('logs 3')
+    expect(out).toBe(['b', 'c', 'd'].join('\n'))
   })
 })

--- a/src 2/commands/kairos.ts
+++ b/src 2/commands/kairos.ts
@@ -1,0 +1,242 @@
+// /kairos — user-facing control surface for the KAIROS daemon.
+//
+// All file layout lives in daemon/kairos/paths.ts; this command just routes
+// subcommands to the same model functions the dashboard uses, so terminal
+// and browser UIs stay in sync through the on-disk state (not a shared
+// in-memory singleton).
+//
+// Scope — this file intentionally does NOT register itself in commands.ts.
+// Trunk registration is Phase 5B (see epic #11).
+
+import { readFile } from 'fs/promises'
+import { getProjectRoot } from '../bootstrap/state.js'
+import type { Command, LocalCommandCall } from '../types/command.js'
+import {
+  enqueueDemoTask,
+  optInProject,
+  optOutProject,
+  setPauseState,
+} from '../daemon/dashboard/model.js'
+import { createProjectRegistry } from '../daemon/kairos/projectRegistry.js'
+import {
+  getKairosPausePath,
+  getKairosStatusPath,
+  getKairosStdoutLogPath,
+  getProjectKairosLogPath,
+} from '../daemon/kairos/paths.js'
+import { safeParseJSON } from '../utils/json.js'
+import type { GlobalStatus, PauseState } from '../daemon/kairos/stateWriter.js'
+
+const DEFAULT_DASHBOARD_URL = 'http://127.0.0.1:7777/'
+const DEFAULT_LOG_TAIL = 25
+
+const HELP_TEXT = `Usage:
+/kairos status
+/kairos list
+/kairos opt-in [projectDir]
+/kairos opt-out [projectDir]
+/kairos demo [projectDir]
+/kairos pause
+/kairos resume
+/kairos dashboard
+/kairos logs [projectDir] [lines]`
+
+type Subcommand =
+  | 'status'
+  | 'list'
+  | 'opt-in'
+  | 'opt-out'
+  | 'demo'
+  | 'pause'
+  | 'resume'
+  | 'dashboard'
+  | 'logs'
+
+const SUBCOMMANDS = new Set<Subcommand>([
+  'status',
+  'list',
+  'opt-in',
+  'opt-out',
+  'demo',
+  'pause',
+  'resume',
+  'dashboard',
+  'logs',
+])
+
+function parseArgs(args: string): { sub: Subcommand | null; rest: string[] } {
+  const tokens = args.trim().split(/\s+/).filter(Boolean)
+  if (tokens.length === 0) return { sub: null, rest: [] }
+  const [head, ...rest] = tokens
+  if (!SUBCOMMANDS.has(head as Subcommand)) {
+    return { sub: null, rest: tokens }
+  }
+  return { sub: head as Subcommand, rest }
+}
+
+function resolveProjectDir(explicit: string | undefined): string {
+  if (explicit && explicit.trim().length > 0) return explicit
+  return getProjectRoot()
+}
+
+async function readJsonIfExists<T>(path: string): Promise<T | null> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    const parsed = safeParseJSON(raw, false)
+    return parsed === null ? null : (parsed as T)
+  } catch {
+    return null
+  }
+}
+
+async function handleStatus(): Promise<string> {
+  const [status, pause, registry] = await Promise.all([
+    readJsonIfExists<GlobalStatus>(getKairosStatusPath()),
+    readJsonIfExists<PauseState>(getKairosPausePath()),
+    createProjectRegistry(),
+  ])
+  const projects = await registry.read()
+  const lines: string[] = []
+  if (status) {
+    lines.push(`daemon: ${status.state} (pid ${status.pid})`)
+    lines.push(`started: ${status.startedAt}`)
+    lines.push(`updated: ${status.updatedAt}`)
+  } else {
+    lines.push('daemon: not running (no status file)')
+  }
+  if (pause?.paused) {
+    const reason = pause.reason ? ` [${pause.reason}]` : ''
+    const scope = pause.scope ? ` scope=${pause.scope}` : ''
+    lines.push(`paused: yes${reason}${scope}`)
+    if (pause.notice) {
+      lines.push(`notice: ${pause.notice}`)
+    }
+  } else {
+    lines.push('paused: no')
+  }
+  lines.push(`projects: ${projects.length}`)
+  return lines.join('\n')
+}
+
+async function handleList(): Promise<string> {
+  const registry = await createProjectRegistry()
+  const projects = await registry.read()
+  if (projects.length === 0) {
+    return 'No projects opted in.'
+  }
+  return projects.map(p => `- ${p}`).join('\n')
+}
+
+async function handleOptIn(projectDir: string): Promise<string> {
+  await optInProject(projectDir)
+  return `Opted in: ${projectDir}`
+}
+
+async function handleOptOut(projectDir: string): Promise<string> {
+  await optOutProject(projectDir)
+  return `Opted out: ${projectDir}`
+}
+
+async function handleDemo(projectDir: string): Promise<string> {
+  const taskId = await enqueueDemoTask(projectDir)
+  return `Demo task ${taskId} scheduled in ${projectDir}/.claude/scheduled_tasks.json`
+}
+
+async function handlePause(): Promise<string> {
+  await setPauseState(true)
+  return 'Paused KAIROS daemon. Fired tasks will be skipped until resume.'
+}
+
+async function handleResume(): Promise<string> {
+  await setPauseState(false)
+  return 'Resumed KAIROS daemon.'
+}
+
+function handleDashboard(): string {
+  const url = process.env.KAIROS_DASHBOARD_URL ?? DEFAULT_DASHBOARD_URL
+  return `Dashboard: ${url}`
+}
+
+async function tailFile(path: string, n: number): Promise<string[]> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    return raw.trim().split('\n').filter(Boolean).slice(-n)
+  } catch {
+    return []
+  }
+}
+
+async function handleLogs(
+  projectDir: string | undefined,
+  linesArg: string | undefined,
+): Promise<string> {
+  const n = linesArg ? Math.max(1, Math.floor(Number(linesArg))) : DEFAULT_LOG_TAIL
+  const limit = Number.isFinite(n) ? n : DEFAULT_LOG_TAIL
+
+  if (projectDir) {
+    const tail = await tailFile(getProjectKairosLogPath(projectDir), limit)
+    if (tail.length === 0) {
+      return `No project log at ${getProjectKairosLogPath(projectDir)}.`
+    }
+    return tail.join('\n')
+  }
+  const tail = await tailFile(getKairosStdoutLogPath(), limit)
+  if (tail.length === 0) {
+    return `No daemon log at ${getKairosStdoutLogPath()}.`
+  }
+  return tail.join('\n')
+}
+
+export async function runKairosCommand(args: string): Promise<string> {
+  const { sub, rest } = parseArgs(args)
+  if (sub === null) {
+    return HELP_TEXT
+  }
+  switch (sub) {
+    case 'status':
+      return handleStatus()
+    case 'list':
+      return handleList()
+    case 'opt-in':
+      return handleOptIn(resolveProjectDir(rest[0]))
+    case 'opt-out':
+      return handleOptOut(resolveProjectDir(rest[0]))
+    case 'demo':
+      return handleDemo(resolveProjectDir(rest[0]))
+    case 'pause':
+      return handlePause()
+    case 'resume':
+      return handleResume()
+    case 'dashboard':
+      return handleDashboard()
+    case 'logs': {
+      const first = rest[0]
+      const looksLikeDir = first !== undefined && /[/~.]/.test(first)
+      if (looksLikeDir) {
+        return handleLogs(resolveProjectDir(first), rest[1])
+      }
+      return handleLogs(undefined, first)
+    }
+  }
+}
+
+const call: LocalCommandCall = async args => {
+  try {
+    const value = await runKairosCommand(args)
+    return { type: 'text', value }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { type: 'text', value: `kairos: ${message}` }
+  }
+}
+
+const kairos = {
+  type: 'local',
+  name: 'kairos',
+  description: 'Inspect and control the KAIROS background daemon',
+  argumentHint: 'status|list|opt-in|opt-out|demo|pause|resume|dashboard|logs',
+  supportsNonInteractive: true,
+  load: () => Promise.resolve({ call }),
+} satisfies Command
+
+export default kairos

--- a/src 2/commands/kairos.ts
+++ b/src 2/commands/kairos.ts
@@ -148,7 +148,15 @@ async function handlePause(): Promise<string> {
 }
 
 async function handleResume(): Promise<string> {
+  const previous = await readJsonIfExists<PauseState>(getKairosPausePath())
   await setPauseState(false)
+  if (previous?.paused && previous.reason === 'auth_failure') {
+    return (
+      'Resumed KAIROS daemon. NOTE: previous pause was auth_failure — if ' +
+      'you have not run `claude` interactively to re-authorize the ' +
+      'Keychain entry, the next fired task will auth-fail again.'
+    )
+  }
   return 'Resumed KAIROS daemon.'
 }
 
@@ -211,8 +219,11 @@ export async function runKairosCommand(args: string): Promise<string> {
       return handleDashboard()
     case 'logs': {
       const first = rest[0]
-      const looksLikeDir = first !== undefined && /[/~.]/.test(first)
-      if (looksLikeDir) {
+      // A bare number is always a line count; anything else (including
+      // `.`, `./foo`, or a bare project name) is a project dir. Avoids
+      // the earlier heuristic's false-positive on tokens like `25.`.
+      const firstIsLineCount = first !== undefined && /^\d+$/.test(first)
+      if (first !== undefined && !firstIsLineCount) {
         return handleLogs(resolveProjectDir(first), rest[1])
       }
       return handleLogs(undefined, first)

--- a/src 2/daemon/kairos/authFailure.integration.test.ts
+++ b/src 2/daemon/kairos/authFailure.integration.test.ts
@@ -5,8 +5,14 @@ import { tmpdir } from 'os'
 import type { CronTask } from '../../utils/cronTasks.js'
 import type { ChildLauncher } from './childRunner.js'
 import { AUTH_FAILURE_NOTICE } from './childRunner.js'
+import type { PauseState } from './stateWriter.js'
 import { createStateWriter } from './stateWriter.js'
-import { makeAuthFailureHandler, makeCapHitHandler, makeRunFiredTask } from './worker.js'
+import {
+  createAuthFailurePauseGate,
+  makeAuthFailureHandler,
+  makeCapHitHandler,
+  makeRunFiredTask,
+} from './worker.js'
 import {
   getKairosGlobalEventsPath,
   getKairosPausePath,
@@ -125,5 +131,63 @@ describe('auth-failure integration', () => {
         e => e.kind === 'auth_failure',
       ),
     ).toBe(true)
+  })
+})
+
+describe('createAuthFailurePauseGate', () => {
+  // Unit tests for the in-memory latch. Covers the cross-project race
+  // where project A's async writePauseState hasn't landed on disk yet
+  // when project B's checkPaused runs.
+  function makeStubReader(state: PauseState | null) {
+    let current = state
+    return {
+      readPauseState: async () => current,
+      set: (next: PauseState | null) => {
+        current = next
+      },
+    }
+  }
+
+  test('returns on-disk paused state when latch is not set', async () => {
+    const reader = makeStubReader({
+      paused: true,
+      reason: 'cap_hit',
+      scope: 'global',
+      source: 'daemon',
+    })
+    const gate = createAuthFailurePauseGate(reader)
+    expect(await gate.isPaused()).toBe(true)
+    reader.set({ paused: false, source: 'user' })
+    expect(await gate.isPaused()).toBe(false)
+  })
+
+  test('latch flips to paused even when on-disk state is still unpaused', async () => {
+    // Models the race window: A called handleAuthFailure (which flips the
+    // in-memory latch synchronously) but the writePauseState hasn't
+    // landed. B's isPaused() must still return true.
+    const reader = makeStubReader(null)
+    const gate = createAuthFailurePauseGate(reader)
+    expect(await gate.isPaused()).toBe(false)
+
+    gate.latch()
+    expect(await gate.isPaused()).toBe(true)
+
+    reader.set({ paused: false, source: 'daemon' })
+    expect(await gate.isPaused()).toBe(true)
+  })
+
+  test('user-authored resume clears the latch; daemon-authored does not', async () => {
+    const reader = makeStubReader(null)
+    const gate = createAuthFailurePauseGate(reader)
+    gate.latch()
+    expect(await gate.isPaused()).toBe(true)
+
+    // Daemon-authored unpause (shouldn't happen in practice, defensive).
+    reader.set({ paused: false, source: 'daemon' })
+    expect(await gate.isPaused()).toBe(true)
+
+    // User runs /kairos resume → pause.json has {paused:false, source:'user'}.
+    reader.set({ paused: false, source: 'user' })
+    expect(await gate.isPaused()).toBe(false)
   })
 })

--- a/src 2/daemon/kairos/authFailure.integration.test.ts
+++ b/src 2/daemon/kairos/authFailure.integration.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { CronTask } from '../../utils/cronTasks.js'
+import type { ChildLauncher } from './childRunner.js'
+import { AUTH_FAILURE_NOTICE } from './childRunner.js'
+import { createStateWriter } from './stateWriter.js'
+import { makeAuthFailureHandler, makeCapHitHandler, makeRunFiredTask } from './worker.js'
+import {
+  getKairosGlobalEventsPath,
+  getKairosPausePath,
+  getProjectKairosEventsPath,
+} from './paths.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function makeTask(id: string): CronTask {
+  return { id, cron: '* * * * *', prompt: 'do work', createdAt: Date.now() }
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function readJsonLines(path: string): unknown[] {
+  return readFileSync(path, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line))
+}
+
+describe('auth-failure integration', () => {
+  test('auth error from launcher pauses the daemon globally and writes the re-auth notice', async () => {
+    const configDir = makeTempDir('kairos-auth-')
+    const projectDir = makeTempDir('kairos-auth-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+
+    let callCount = 0
+    // Async generator that throws before yielding — models the SDK's `query()`
+    // rejecting on 401. Written as an explicit iterator so lint's
+    // require-yield rule sees a reachable yield-shaped contract.
+    const launcher: ChildLauncher = () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          async next(): Promise<IteratorResult<never>> {
+            callCount += 1
+            throw new Error(
+              'Request failed: 401 Unauthorized (Keychain denied)',
+            )
+          },
+        }
+      },
+    })
+
+    const now = () => new Date('2026-04-22T12:00:00.000Z')
+    const handleCapHit = makeCapHitHandler(stateWriter, now)
+    const handleAuthFailure = makeAuthFailureHandler(stateWriter, now)
+
+    const runFiredTask = makeRunFiredTask({
+      projectDir,
+      stateWriter,
+      costTracker: null,
+      launcher,
+      defaultAllowedTools: ['Read'],
+      maxTurns: 1,
+      timeoutMs: 5_000,
+      handleCapHit,
+      handleAuthFailure,
+      now,
+    })
+
+    const outcome1 = await runFiredTask(makeTask('auth-1'), 'event')
+    expect(outcome1.ok).toBe(false)
+    expect(outcome1.paused).toBe(true)
+    expect(outcome1.result?.exitReason).toBe('auth_failure')
+    expect(callCount).toBe(1)
+
+    const pause = readJson(getKairosPausePath()) as {
+      paused: boolean
+      reason?: string
+      scope?: string
+      source?: string
+      notice?: string
+    }
+    expect(pause.paused).toBe(true)
+    expect(pause.reason).toBe('auth_failure')
+    expect(pause.scope).toBe('global')
+    expect(pause.source).toBe('daemon')
+    expect(pause.notice).toBe(AUTH_FAILURE_NOTICE)
+
+    const globalEvents = readJsonLines(getKairosGlobalEventsPath()) as Array<
+      Record<string, unknown>
+    >
+    const authGlobal = globalEvents.find(e => e.kind === 'auth_failure')
+    expect(authGlobal).toBeDefined()
+    expect(authGlobal).toMatchObject({
+      kind: 'auth_failure',
+      projectDir,
+      taskId: 'auth-1',
+      source: 'daemon',
+      notice: AUTH_FAILURE_NOTICE,
+    })
+
+    const projectEvents = readJsonLines(getProjectKairosEventsPath(projectDir))
+    expect(
+      (projectEvents as Array<Record<string, unknown>>).some(
+        e => e.kind === 'auth_failure',
+      ),
+    ).toBe(true)
+  })
+})

--- a/src 2/daemon/kairos/childRunner.test.ts
+++ b/src 2/daemon/kairos/childRunner.test.ts
@@ -349,6 +349,15 @@ describe('isAuthFailureError', () => {
     'budget exceeded',
     'timeout',
     '',
+    // Adversarial: words that used to match but shouldn't. A bare "keychain"
+    // mention or "no credentials" phrase from an unrelated subsystem must
+    // not globally pause the daemon.
+    'Keychain service temporarily unavailable',
+    'Keychain backup completed',
+    'no credentials needed for this endpoint',
+    'oauth configuration loaded',
+    'Authentication service starting',
+    'HTTP 403 file not found',
   ])('does NOT classify %p as auth failure', message => {
     expect(isAuthFailureError(new Error(message))).toBe(false)
   })

--- a/src 2/daemon/kairos/childRunner.test.ts
+++ b/src 2/daemon/kairos/childRunner.test.ts
@@ -5,7 +5,11 @@ import type {
   ChildLauncherParams,
   ChildStreamMessage,
 } from './childRunner.js'
-import { runChild } from './childRunner.js'
+import {
+  AUTH_FAILURE_NOTICE,
+  isAuthFailureError,
+  runChild,
+} from './childRunner.js'
 
 type RecordedCall = {
   params: ChildLauncherParams
@@ -289,5 +293,69 @@ describe('childRunner.runChild', () => {
     expect(result.exitReason).toBe('max_budget')
     expect(result.costUSD).toBe(1.0)
     expect(result.errorMessage).toBe('budget exceeded')
+  })
+
+  test('auth failure: launcher throws an auth error → exitReason=auth_failure + auth_failure event', async () => {
+    const events: ChildEvent[] = []
+    const { launcher } = makeLauncher([], {
+      throwError: new Error('Request failed: 401 Unauthorized'),
+    })
+
+    const result = await runChild(
+      {
+        taskId: 't-auth',
+        prompt: 'x',
+        projectDir: '/tmp/proj',
+        allowedTools: [],
+        runId: 'run-auth',
+      },
+      {
+        launcher,
+        onEvent: e => {
+          events.push(e)
+        },
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.exitReason).toBe('auth_failure')
+    expect(result.errorMessage).toContain('re-authorize')
+
+    const authEvent = events.find(e => e.kind === 'auth_failure')
+    expect(authEvent).toBeDefined()
+    if (authEvent && authEvent.kind === 'auth_failure') {
+      expect(authEvent.notice).toBe(AUTH_FAILURE_NOTICE)
+      expect(authEvent.taskId).toBe('t-auth')
+      expect(authEvent.projectDir).toBe('/tmp/proj')
+    }
+  })
+})
+
+describe('isAuthFailureError', () => {
+  test.each([
+    '401 Unauthorized',
+    'Authentication failed',
+    'authentication required',
+    'Invalid API key',
+    'Keychain returned errSecAuthFailed',
+    'OAuth token expired',
+    'no credentials available',
+  ])('classifies %p as auth failure', message => {
+    expect(isAuthFailureError(new Error(message))).toBe(true)
+  })
+
+  test.each([
+    'ECONNREFUSED',
+    'budget exceeded',
+    'timeout',
+    '',
+  ])('does NOT classify %p as auth failure', message => {
+    expect(isAuthFailureError(new Error(message))).toBe(false)
+  })
+
+  test('tolerates non-Error values', () => {
+    expect(isAuthFailureError('401 Unauthorized')).toBe(true)
+    expect(isAuthFailureError(null)).toBe(false)
+    expect(isAuthFailureError(undefined)).toBe(false)
   })
 })

--- a/src 2/daemon/kairos/childRunner.ts
+++ b/src 2/daemon/kairos/childRunner.ts
@@ -77,16 +77,23 @@ export type ChildRunExitReason =
 export const AUTH_FAILURE_NOTICE =
   'KAIROS daemon hit an auth failure. Run `claude` interactively once to re-authorize the Keychain entry, then resume the daemon.'
 
+// Deliberately narrow: every pattern must pair an auth noun with an
+// auth-specific failure mode. A bare "keychain" or "no credentials"
+// substring is too easy to hit from unrelated macOS keychain services or
+// HTTP libraries — those would globally pause the daemon on a transient
+// error and force the user to re-auth for no reason.
 const AUTH_FAILURE_PATTERNS: readonly RegExp[] = [
   /\b401\b/,
+  /\b403\b[^\n]*(auth|token|credential|forbidden)/i,
   /unauthori[sz]ed/i,
-  /authentication[^a-z0-9]*(failed|required|error)/i,
+  /authentication[^a-z0-9]*(failed|required|error|denied|rejected)/i,
   /invalid[^a-z0-9]*api[^a-z0-9]*key/i,
   /not[^a-z0-9]*authenticated/i,
-  /keychain/i,
-  /no[^a-z0-9]*credentials/i,
+  /keychain[^\n]{0,80}(denied|errsec|locked|unauthori[sz]ed|auth[^a-z0-9]*failed|access[^a-z0-9]*denied)/i,
+  /errsecauthfailed/i,
+  /no[^a-z0-9]*(valid[^a-z0-9]*)?credentials[^a-z0-9]*(available|found|configured|provided)/i,
   /missing[^a-z0-9]*credentials/i,
-  /oauth[^a-z0-9]*(token[^a-z0-9]*)?(expired|invalid|required)/i,
+  /oauth[^a-z0-9]*(token[^a-z0-9]*)?(expired|invalid|required|revoked)/i,
 ]
 
 /** True when `err` is recognisably an auth-related failure. */

--- a/src 2/daemon/kairos/childRunner.ts
+++ b/src 2/daemon/kairos/childRunner.ts
@@ -67,6 +67,34 @@ export type ChildRunExitReason =
   | 'error'
   | 'max_turns'
   | 'max_budget'
+  | 'auth_failure'
+
+/**
+ * User-facing notice surfaced when the daemon detects an auth failure.
+ * Keep wording stable — the dashboard, pause file, and status command all
+ * quote this string verbatim.
+ */
+export const AUTH_FAILURE_NOTICE =
+  'KAIROS daemon hit an auth failure. Run `claude` interactively once to re-authorize the Keychain entry, then resume the daemon.'
+
+const AUTH_FAILURE_PATTERNS: readonly RegExp[] = [
+  /\b401\b/,
+  /unauthori[sz]ed/i,
+  /authentication[^a-z0-9]*(failed|required|error)/i,
+  /invalid[^a-z0-9]*api[^a-z0-9]*key/i,
+  /not[^a-z0-9]*authenticated/i,
+  /keychain/i,
+  /no[^a-z0-9]*credentials/i,
+  /missing[^a-z0-9]*credentials/i,
+  /oauth[^a-z0-9]*(token[^a-z0-9]*)?(expired|invalid|required)/i,
+]
+
+/** True when `err` is recognisably an auth-related failure. */
+export function isAuthFailureError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err ?? '')
+  if (!message) return false
+  return AUTH_FAILURE_PATTERNS.some(pattern => pattern.test(message))
+}
 
 export type ChildRunResult = {
   runId: string
@@ -120,6 +148,15 @@ export type ChildEvent =
       t: string
       runId: string
       timeoutMs: number
+    }
+  | {
+      kind: 'auth_failure'
+      t: string
+      runId: string
+      taskId: string
+      projectDir: string
+      notice: string
+      errorMessage: string
     }
 
 export type ChildRunDeps = {
@@ -296,6 +333,19 @@ export async function runChild(
   }
 
   if (streamError) {
+    const authFailure = isAuthFailureError(streamError)
+    const exitReason: ChildRunExitReason = authFailure ? 'auth_failure' : 'error'
+    if (authFailure) {
+      await deps.onEvent({
+        kind: 'auth_failure',
+        t: now().toISOString(),
+        runId,
+        taskId: options.taskId,
+        projectDir: options.projectDir,
+        notice: AUTH_FAILURE_NOTICE,
+        errorMessage: streamError.message,
+      })
+    }
     await deps.onEvent({
       kind: 'child_error',
       t: now().toISOString(),
@@ -305,14 +355,16 @@ export async function runChild(
     const result: ChildRunResult = {
       runId,
       ok: false,
-      exitReason: 'error',
+      exitReason,
       sessionId,
       costUSD: resultMessage?.total_cost_usd ?? 0,
       numTurns: resultMessage?.num_turns ?? 0,
       durationMs,
       allowedTools,
       lastAssistantText,
-      errorMessage: streamError.message,
+      errorMessage: authFailure
+        ? `${AUTH_FAILURE_NOTICE} (${streamError.message})`
+        : streamError.message,
     }
     await deps.onEvent({
       kind: 'child_finished',

--- a/src 2/daemon/kairos/install/install.test.ts
+++ b/src 2/daemon/kairos/install/install.test.ts
@@ -90,6 +90,37 @@ describe('installKairosLaunchAgent', () => {
     expect(calls.map(c => c[0])).toEqual(['bootout', 'bootstrap', 'enable'])
     expect(existsSync(plistPath)).toBe(true)
   })
+
+  test('bootstrap failure leaves plist on disk (converges on retry)', async () => {
+    // If the sequence is bootout → write → bootstrap and bootstrap throws,
+    // the plist written to disk should reflect the NEW intent so that a
+    // subsequent install retry picks up where we left off without the
+    // caller having to re-specify the arguments.
+    const dir = makeTempDir()
+    const plistPath = join(dir, `${KAIROS_LAUNCH_AGENT_LABEL}.plist`)
+
+    await expect(
+      installKairosLaunchAgent({
+        plistPath,
+        uid: 501,
+        plistInputs: {
+          program: '/usr/local/bin/claude',
+          args: ['daemon', 'kairos'],
+        },
+        launchctl: async args => {
+          if (args[0] === 'bootstrap') {
+            throw new Error('bootstrap: permission denied')
+          }
+          return { stdout: '', stderr: '' }
+        },
+      }),
+    ).rejects.toThrow(/bootstrap/)
+
+    // Plist MUST be on disk with the new config so a retry works.
+    expect(existsSync(plistPath)).toBe(true)
+    const xml = readFileSync(plistPath, 'utf8')
+    expect(xml).toContain('<string>/usr/local/bin/claude</string>')
+  })
 })
 
 describe('uninstallKairosLaunchAgent', () => {

--- a/src 2/daemon/kairos/install/install.test.ts
+++ b/src 2/daemon/kairos/install/install.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+} from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { installKairosLaunchAgent } from './install.js'
+import { uninstallKairosLaunchAgent } from './uninstall.js'
+import {
+  KAIROS_LAUNCH_AGENT_LABEL,
+  getLaunchctlServiceTarget,
+} from './plist.js'
+
+const TEMP_DIRS: string[] = []
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-install-test-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('installKairosLaunchAgent', () => {
+  test('writes a plist and invokes bootstrap + enable', async () => {
+    const dir = makeTempDir()
+    const plistPath = join(dir, `${KAIROS_LAUNCH_AGENT_LABEL}.plist`)
+    const calls: string[][] = []
+
+    const result = await installKairosLaunchAgent({
+      plistPath,
+      uid: 501,
+      plistInputs: {
+        program: '/usr/local/bin/claude',
+        args: ['daemon', 'kairos'],
+      },
+      launchctl: async args => {
+        calls.push([...args])
+        return { stdout: '', stderr: '' }
+      },
+    })
+
+    expect(result.plistPath).toBe(plistPath)
+    expect(result.target).toBe(getLaunchctlServiceTarget(501))
+    expect(existsSync(plistPath)).toBe(true)
+
+    const xml = readFileSync(plistPath, 'utf8')
+    expect(xml).toContain(`<string>${KAIROS_LAUNCH_AGENT_LABEL}</string>`)
+    expect(xml).toContain('<string>/usr/local/bin/claude</string>')
+
+    expect(calls[0]).toEqual(['bootout', `gui/501/${KAIROS_LAUNCH_AGENT_LABEL}`])
+    expect(calls[1]).toEqual([
+      'bootstrap',
+      'gui/501',
+      plistPath,
+    ])
+    expect(calls[2]).toEqual(['enable', `gui/501/${KAIROS_LAUNCH_AGENT_LABEL}`])
+  })
+
+  test('ignores bootout errors on first install (idempotent re-install)', async () => {
+    const dir = makeTempDir()
+    const plistPath = join(dir, `${KAIROS_LAUNCH_AGENT_LABEL}.plist`)
+    const calls: string[][] = []
+
+    await installKairosLaunchAgent({
+      plistPath,
+      uid: 501,
+      plistInputs: {
+        program: '/usr/local/bin/claude',
+        args: ['daemon', 'kairos'],
+      },
+      launchctl: async args => {
+        calls.push([...args])
+        if (args[0] === 'bootout') {
+          throw new Error('Service not loaded')
+        }
+        return { stdout: '', stderr: '' }
+      },
+    })
+
+    expect(calls.map(c => c[0])).toEqual(['bootout', 'bootstrap', 'enable'])
+    expect(existsSync(plistPath)).toBe(true)
+  })
+})
+
+describe('uninstallKairosLaunchAgent', () => {
+  test('boots out and removes the plist', async () => {
+    const dir = makeTempDir()
+    const plistPath = join(dir, `${KAIROS_LAUNCH_AGENT_LABEL}.plist`)
+    writeFileSync(plistPath, '<plist/>')
+    const calls: string[][] = []
+
+    const result = await uninstallKairosLaunchAgent({
+      plistPath,
+      uid: 501,
+      launchctl: async args => {
+        calls.push([...args])
+        return { stdout: '', stderr: '' }
+      },
+    })
+
+    expect(result.removed).toBe(true)
+    expect(existsSync(plistPath)).toBe(false)
+    expect(calls[0]).toEqual(['bootout', `gui/501/${KAIROS_LAUNCH_AGENT_LABEL}`])
+  })
+
+  test('is safe to run when plist does not exist', async () => {
+    const dir = makeTempDir()
+    const plistPath = join(dir, `${KAIROS_LAUNCH_AGENT_LABEL}.plist`)
+
+    const result = await uninstallKairosLaunchAgent({
+      plistPath,
+      uid: 501,
+      launchctl: async () => ({ stdout: '', stderr: '' }),
+    })
+
+    expect(result.removed).toBe(false)
+    expect(existsSync(plistPath)).toBe(false)
+  })
+
+  test('ignores bootout failures', async () => {
+    const dir = makeTempDir()
+    const plistPath = join(dir, `${KAIROS_LAUNCH_AGENT_LABEL}.plist`)
+    writeFileSync(plistPath, '<plist/>')
+
+    const result = await uninstallKairosLaunchAgent({
+      plistPath,
+      uid: 501,
+      launchctl: async () => {
+        throw new Error('Service not loaded')
+      },
+    })
+
+    expect(result.removed).toBe(true)
+    expect(existsSync(plistPath)).toBe(false)
+  })
+})
+
+describe('install + uninstall round trip', () => {
+  test('install, then uninstall leaves no plist behind', async () => {
+    const dir = makeTempDir()
+    const plistPath = join(dir, `${KAIROS_LAUNCH_AGENT_LABEL}.plist`)
+    mkdirSync(dir, { recursive: true })
+    const runner = async () => ({ stdout: '', stderr: '' })
+
+    await installKairosLaunchAgent({
+      plistPath,
+      uid: 501,
+      plistInputs: {
+        program: '/usr/local/bin/claude',
+        args: ['daemon', 'kairos'],
+      },
+      launchctl: runner,
+    })
+    expect(existsSync(plistPath)).toBe(true)
+
+    const result = await uninstallKairosLaunchAgent({
+      plistPath,
+      uid: 501,
+      launchctl: runner,
+    })
+    expect(result.removed).toBe(true)
+    expect(existsSync(plistPath)).toBe(false)
+  })
+})

--- a/src 2/daemon/kairos/install/install.ts
+++ b/src 2/daemon/kairos/install/install.ts
@@ -1,0 +1,168 @@
+// Install the KAIROS LaunchAgent plist and bootstrap it via launchctl.
+//
+// Resolves the claude binary by walking up from the currently-running script:
+//   - If we're running through `bun` (dev mode), the program is `bun` and the
+//     first arg is the absolute path to the cli entrypoint.
+//   - If we're running the bundled `./dist/cli.js`, program is the node/bun
+//     runtime and the arg is the bundled file.
+// Either way, we capture process.execPath + argv[1] (the entrypoint) so the
+// LaunchAgent starts the same binary the user invoked, even without a
+// globally-installed `claude`.
+//
+// Usage from the workspace root:
+//   bun run ./daemon/kairos/install/install.ts
+// or programmatically: `await installKairosLaunchAgent()`.
+
+import { mkdir, writeFile } from 'fs/promises'
+import { dirname } from 'path'
+import { promisify } from 'util'
+import { execFile as execFileCb } from 'child_process'
+import { userInfo } from 'os'
+import {
+  buildKairosPlist,
+  getKairosPlistPath,
+  getLaunchctlServiceTarget,
+  KAIROS_LAUNCH_AGENT_LABEL,
+  type KairosPlistInputs,
+} from './plist.js'
+
+const execFile = promisify(execFileCb)
+
+/**
+ * Find the canonical `claude` CLI binary — the same one the user runs
+ * interactively, so launchd uses a Keychain ACL path we know is authorized.
+ * Resolution order:
+ *   1. CLAUDE_BIN env override (explicit user intent).
+ *   2. `which claude` from PATH (the normal install case).
+ *   3. process.execPath + argv[1] (dev fallback: whatever is running this
+ *      script right now, e.g. `bun ./entrypoints/cli.tsx`).
+ */
+export async function resolveCanonicalClaude(
+  overrides: {
+    env?: NodeJS.ProcessEnv
+    which?: (name: string) => Promise<string | null>
+  } = {},
+): Promise<{ program: string; args: string[] }> {
+  const env = overrides.env ?? process.env
+  const envOverride = env.CLAUDE_BIN?.trim()
+  if (envOverride) {
+    return { program: envOverride, args: ['daemon', 'kairos'] }
+  }
+  const whichFn = overrides.which ?? defaultWhich
+  const fromPath = await whichFn('claude')
+  if (fromPath) {
+    return { program: fromPath, args: ['daemon', 'kairos'] }
+  }
+  // Last-resort dev fallback: whatever runtime/entrypoint is currently
+  // executing the installer. When the user invoked `claude daemon install`
+  // through a bundled binary, this is the same canonical binary.
+  const program = process.execPath
+  const entry = process.argv[1]
+  return {
+    program,
+    args: entry ? [entry, 'daemon', 'kairos'] : ['daemon', 'kairos'],
+  }
+}
+
+async function defaultWhich(name: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFile('/usr/bin/which', [name])
+    const trimmed = stdout.trim()
+    return trimmed.length > 0 ? trimmed : null
+  } catch {
+    return null
+  }
+}
+
+export type LaunchctlRunner = (
+  args: readonly string[],
+) => Promise<{ stdout: string; stderr: string }>
+
+const defaultRunner: LaunchctlRunner = async args => {
+  const { stdout, stderr } = await execFile('launchctl', [...args])
+  return { stdout, stderr }
+}
+
+export type InstallKairosOptions = {
+  /** Path where the plist should be written. Defaults to the user LaunchAgents dir. */
+  plistPath?: string
+  /** Override the program arguments written into the plist. */
+  plistInputs?: Partial<KairosPlistInputs>
+  /** Uid for the gui domain target. Defaults to the current user. */
+  uid?: number
+  /** Swap out the real launchctl for tests. */
+  launchctl?: LaunchctlRunner
+}
+
+export async function installKairosLaunchAgent(
+  options: InstallKairosOptions = {},
+): Promise<{ plistPath: string; target: string; program: string }> {
+  const plistPath = options.plistPath ?? getKairosPlistPath()
+  const uid = options.uid ?? userInfo().uid
+  const runner = options.launchctl ?? defaultRunner
+  const target = getLaunchctlServiceTarget(uid)
+
+  const defaults = await resolveCanonicalClaude()
+  const inputs: KairosPlistInputs = {
+    program: options.plistInputs?.program ?? defaults.program,
+    args: options.plistInputs?.args ?? defaults.args,
+    env: options.plistInputs?.env,
+    workingDirectory: options.plistInputs?.workingDirectory,
+    stdoutPath: options.plistInputs?.stdoutPath,
+    stderrPath: options.plistInputs?.stderrPath,
+    throttleIntervalSec: options.plistInputs?.throttleIntervalSec,
+    runAtLoad: options.plistInputs?.runAtLoad,
+  }
+
+  await mkdir(dirname(plistPath), { recursive: true })
+  await writeFile(plistPath, buildKairosPlist(inputs), 'utf8')
+
+  // Bootout any existing instance first so re-installs are idempotent.
+  // launchctl returns non-zero when the service isn't loaded yet — swallow
+  // that single class of error and propagate anything else.
+  try {
+    await runner(['bootout', target])
+  } catch {
+    // expected on first install
+  }
+  await runner(['bootstrap', `gui/${uid}`, plistPath])
+  await runner(['enable', target])
+
+  return { plistPath, target, program: inputs.program }
+}
+
+// CLI entrypoint — only run when this file is executed directly.
+const isMainModule =
+  typeof process !== 'undefined' &&
+  typeof import.meta !== 'undefined' &&
+  typeof import.meta.url === 'string' &&
+  process.argv[1] !== undefined &&
+  import.meta.url === `file://${process.argv[1]}`
+
+if (isMainModule) {
+  installKairosLaunchAgent()
+    .then(({ plistPath, target, program }) => {
+      console.log(`Installed ${KAIROS_LAUNCH_AGENT_LABEL}`)
+      console.log(`  plist:   ${plistPath}`)
+      console.log(`  target:  ${target}`)
+      console.log(`  program: ${program}`)
+      console.log('')
+      console.log(
+        'Note: KAIROS runs as a LaunchAgent. The daemon only ticks while',
+      )
+      console.log(
+        'you are logged into your Mac (locked screen is fine, logout is not).',
+      )
+      console.log(
+        'If macOS later re-prompts for Keychain access after a Claude Code',
+      )
+      console.log(
+        'update, run `claude` interactively once to re-authorize the binary.',
+      )
+    })
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`kairos install failed: ${message}`)
+      process.exit(1)
+    })
+}

--- a/src 2/daemon/kairos/install/install.ts
+++ b/src 2/daemon/kairos/install/install.ts
@@ -13,7 +13,8 @@
 //   bun run ./daemon/kairos/install/install.ts
 // or programmatically: `await installKairosLaunchAgent()`.
 
-import { mkdir, writeFile } from 'fs/promises'
+import { access, mkdir, writeFile } from 'fs/promises'
+import { constants as fsConstants } from 'fs'
 import { dirname } from 'path'
 import { promisify } from 'util'
 import { execFile as execFileCb } from 'child_process'
@@ -41,11 +42,19 @@ export async function resolveCanonicalClaude(
   overrides: {
     env?: NodeJS.ProcessEnv
     which?: (name: string) => Promise<string | null>
+    /**
+     * Validate that a resolved absolute path is executable. Default checks
+     * `X_OK` via fs.access. Tests can pass a no-op to skip the filesystem
+     * probe.
+     */
+    assertExecutable?: (path: string) => Promise<void>
   } = {},
 ): Promise<{ program: string; args: string[] }> {
   const env = overrides.env ?? process.env
+  const assertExec = overrides.assertExecutable ?? defaultAssertExecutable
   const envOverride = env.CLAUDE_BIN?.trim()
   if (envOverride) {
+    await assertExec(envOverride)
     return { program: envOverride, args: ['daemon', 'kairos'] }
   }
   const whichFn = overrides.which ?? defaultWhich
@@ -71,6 +80,18 @@ async function defaultWhich(name: string): Promise<string | null> {
     return trimmed.length > 0 ? trimmed : null
   } catch {
     return null
+  }
+}
+
+async function defaultAssertExecutable(path: string): Promise<void> {
+  try {
+    await access(path, fsConstants.X_OK)
+  } catch {
+    throw new Error(
+      `CLAUDE_BIN=${path} is not an executable file. Point it at an ` +
+        'absolute path to the claude CLI, or unset it to fall back to ' +
+        '`which claude`.',
+    )
   }
 }
 
@@ -102,7 +123,14 @@ export async function installKairosLaunchAgent(
   const runner = options.launchctl ?? defaultRunner
   const target = getLaunchctlServiceTarget(uid)
 
-  const defaults = await resolveCanonicalClaude()
+  // Skip the canonical-claude probe when the caller has already pinned
+  // program + args. Avoids touching CLAUDE_BIN / PATH during test runs
+  // that inject an explicit program path.
+  const needsResolution =
+    !options.plistInputs?.program || !options.plistInputs?.args
+  const defaults = needsResolution
+    ? await resolveCanonicalClaude()
+    : { program: '', args: [] as string[] }
   const inputs: KairosPlistInputs = {
     program: options.plistInputs?.program ?? defaults.program,
     args: options.plistInputs?.args ?? defaults.args,
@@ -114,17 +142,21 @@ export async function installKairosLaunchAgent(
     runAtLoad: options.plistInputs?.runAtLoad,
   }
 
-  await mkdir(dirname(plistPath), { recursive: true })
-  await writeFile(plistPath, buildKairosPlist(inputs), 'utf8')
-
-  // Bootout any existing instance first so re-installs are idempotent.
-  // launchctl returns non-zero when the service isn't loaded yet — swallow
-  // that single class of error and propagate anything else.
+  // Order matters: bootout the OLD service before writing the NEW plist.
+  // That way any mid-install failure leaves the on-disk plist matching the
+  // (now-unloaded) intent, so a retry converges cleanly. Writing first
+  // would briefly advertise new config for a service still running with
+  // old config. launchctl returns non-zero when the service isn't loaded
+  // yet — swallow that single class of error and propagate anything else.
   try {
     await runner(['bootout', target])
   } catch {
     // expected on first install
   }
+
+  await mkdir(dirname(plistPath), { recursive: true })
+  await writeFile(plistPath, buildKairosPlist(inputs), 'utf8')
+
   await runner(['bootstrap', `gui/${uid}`, plistPath])
   await runner(['enable', target])
 

--- a/src 2/daemon/kairos/install/plist.test.ts
+++ b/src 2/daemon/kairos/install/plist.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildKairosPlist,
+  FORBIDDEN_PLIST_ENV_KEYS,
+  getKairosPlistPath,
+  getLaunchctlServiceTarget,
+  KAIROS_LAUNCH_AGENT_LABEL,
+  sanitizePlistEnv,
+} from './plist.js'
+
+describe('buildKairosPlist', () => {
+  test('emits a valid plist header + required keys', () => {
+    const xml = buildKairosPlist({
+      program: '/usr/local/bin/claude',
+      args: ['daemon', 'kairos'],
+      stdoutPath: '/tmp/kairos.out',
+      stderrPath: '/tmp/kairos.err',
+      workingDirectory: '/Users/tester',
+    })
+    expect(xml.startsWith('<?xml version="1.0"')).toBe(true)
+    expect(xml).toContain('<!DOCTYPE plist PUBLIC')
+    expect(xml).toContain('<plist version="1.0">')
+    expect(xml).toContain(
+      `<string>${KAIROS_LAUNCH_AGENT_LABEL}</string>`,
+    )
+    expect(xml).toContain('<string>/usr/local/bin/claude</string>')
+    expect(xml).toContain('<string>daemon</string>')
+    expect(xml).toContain('<string>kairos</string>')
+    expect(xml).toContain('<key>RunAtLoad</key>')
+    expect(xml).toContain('<key>KeepAlive</key>')
+    expect(xml).toContain('<true/>')
+    expect(xml).toContain('<key>ThrottleInterval</key>')
+  })
+
+  test('escapes XML metacharacters in program arguments', () => {
+    const xml = buildKairosPlist({
+      program: '/bin/echo',
+      args: ['<script>', 'a&b', 'q"x'],
+    })
+    expect(xml).toContain('&lt;script&gt;')
+    expect(xml).toContain('a&amp;b')
+    expect(xml).toContain('q&quot;x')
+    expect(xml).not.toContain('<script>')
+  })
+
+  test('always includes HOME and USER so child claude reads user Keychain', () => {
+    const xml = buildKairosPlist({ program: '/bin/claude', args: [] })
+    expect(xml).toContain('<key>EnvironmentVariables</key>')
+    expect(xml).toContain('<key>HOME</key>')
+    expect(xml).toContain('<key>USER</key>')
+  })
+
+  test('merges user-supplied env on top of HOME/USER defaults', () => {
+    const xml = buildKairosPlist({
+      program: '/bin/claude',
+      args: [],
+      env: { KAIROS_DEBUG: '1' },
+    })
+    expect(xml).toContain('<key>HOME</key>')
+    expect(xml).toContain('<key>KAIROS_DEBUG</key>')
+    expect(xml).toContain('<string>1</string>')
+  })
+
+  test('refuses to inline ANTHROPIC_API_KEY even when caller passes one', () => {
+    const xml = buildKairosPlist({
+      program: '/bin/claude',
+      args: [],
+      env: { ANTHROPIC_API_KEY: 'sk-leak-me', KAIROS_DEBUG: '1' },
+    })
+    expect(xml).not.toContain('ANTHROPIC_API_KEY')
+    expect(xml).not.toContain('sk-leak-me')
+    // Unrelated user env still lands in the plist.
+    expect(xml).toContain('<key>KAIROS_DEBUG</key>')
+  })
+
+  test('runAtLoad=false emits <false/>', () => {
+    const xml = buildKairosPlist({
+      program: '/bin/claude',
+      args: [],
+      runAtLoad: false,
+    })
+    expect(xml).toContain('<key>RunAtLoad</key>\n    <false/>')
+  })
+})
+
+describe('sanitizePlistEnv', () => {
+  test('drops every forbidden auth key', () => {
+    const input: Record<string, string> = { KEEP: 'ok' }
+    for (const key of FORBIDDEN_PLIST_ENV_KEYS) {
+      input[key] = 'SHOULD_BE_DROPPED'
+    }
+    const out = sanitizePlistEnv(input)
+    for (const key of FORBIDDEN_PLIST_ENV_KEYS) {
+      expect(out[key]).toBeUndefined()
+    }
+    expect(out.KEEP).toBe('ok')
+  })
+})
+
+describe('paths', () => {
+  test('getKairosPlistPath lives under ~/Library/LaunchAgents', () => {
+    const plistPath = getKairosPlistPath('/Users/tester')
+    expect(plistPath).toBe(
+      `/Users/tester/Library/LaunchAgents/${KAIROS_LAUNCH_AGENT_LABEL}.plist`,
+    )
+  })
+
+  test('getLaunchctlServiceTarget follows gui/<uid>/<label>', () => {
+    expect(getLaunchctlServiceTarget(501)).toBe(
+      `gui/501/${KAIROS_LAUNCH_AGENT_LABEL}`,
+    )
+  })
+})

--- a/src 2/daemon/kairos/install/plist.test.ts
+++ b/src 2/daemon/kairos/install/plist.test.ts
@@ -30,6 +30,11 @@ describe('buildKairosPlist', () => {
     expect(xml).toContain('<key>KeepAlive</key>')
     expect(xml).toContain('<true/>')
     expect(xml).toContain('<key>ThrottleInterval</key>')
+    // Keychain access requires a graphical (Aqua) session — pin it so
+    // launchd won't start the agent in a background/ssh context where the
+    // Keychain is locked.
+    expect(xml).toContain('<key>LimitLoadToSessionType</key>')
+    expect(xml).toContain('<string>Aqua</string>')
   })
 
   test('escapes XML metacharacters in program arguments', () => {

--- a/src 2/daemon/kairos/install/plist.ts
+++ b/src 2/daemon/kairos/install/plist.ts
@@ -1,0 +1,187 @@
+// LaunchAgent plist layout for the KAIROS daemon.
+//
+// We bootstrap the plist into the user's gui domain (not global) so the
+// daemon runs under the same uid as the REPL and has access to
+// ~/.claude/kairos state out of the box. KeepAlive=true plus a small
+// ThrottleInterval means the daemon restarts on crash but not in a tight
+// loop.
+
+import { homedir, userInfo } from 'os'
+import { join } from 'path'
+import {
+  getKairosStateDir,
+  getKairosStdoutLogPath,
+} from '../paths.js'
+
+export const KAIROS_LAUNCH_AGENT_LABEL = 'com.anthropic.claude.kairos'
+
+/**
+ * Env vars we refuse to inline into the plist. The claude CLI's auth is
+ * Keychain-scoped to the binary; passing ANTHROPIC_API_KEY here would route
+ * the daemon around that and leave a secret on disk in cleartext.
+ */
+export const FORBIDDEN_PLIST_ENV_KEYS: readonly string[] = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+]
+
+export type KairosPlistInputs = {
+  /** Absolute path to the binary that will be executed (e.g. `claude`). */
+  program: string
+  /** Arguments following the binary path. */
+  args: readonly string[]
+  /** Extra environment variables to set on the daemon process. */
+  env?: Record<string, string>
+  /** Working directory for the daemon. Defaults to the user's home. */
+  workingDirectory?: string
+  /** Stdout log path. Defaults to the kairos state dir daemon log. */
+  stdoutPath?: string
+  /** Stderr log path. Defaults to kairos state dir. */
+  stderrPath?: string
+  /** Restart throttle in seconds. Defaults to 10 (matches launchd floor). */
+  throttleIntervalSec?: number
+  /** Run at load (default true). Set to false for tests. */
+  runAtLoad?: boolean
+}
+
+/** Path to the user LaunchAgents plist directory. */
+export function getLaunchAgentsDir(home: string = homedir()): string {
+  return join(home, 'Library', 'LaunchAgents')
+}
+
+/** Full path to the kairos LaunchAgent plist file. */
+export function getKairosPlistPath(home: string = homedir()): string {
+  return join(getLaunchAgentsDir(home), `${KAIROS_LAUNCH_AGENT_LABEL}.plist`)
+}
+
+/** `gui/<uid>/<label>` domain target used by launchctl. */
+export function getLaunchctlServiceTarget(
+  uid: number = userInfo().uid,
+): string {
+  return `gui/${uid}/${KAIROS_LAUNCH_AGENT_LABEL}`
+}
+
+// The plist format is a small, well-defined subset — escape text nodes and
+// emit XML ourselves so the installer has no runtime plist dependency.
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function stringElement(value: string, indent: string): string {
+  return `${indent}<string>${escapeXml(value)}</string>`
+}
+
+function arrayElement(values: readonly string[], indent: string): string {
+  const inner = values
+    .map(v => stringElement(v, `${indent}  `))
+    .join('\n')
+  return `${indent}<array>\n${inner}\n${indent}</array>`
+}
+
+function dictElement(
+  entries: Array<[string, string]>,
+  indent: string,
+): string {
+  if (entries.length === 0) return `${indent}<dict/>`
+  const inner = entries
+    .flatMap(([k, v]) => [
+      `${indent}  <key>${escapeXml(k)}</key>`,
+      stringElement(v, `${indent}  `),
+    ])
+    .join('\n')
+  return `${indent}<dict>\n${inner}\n${indent}</dict>`
+}
+
+/**
+ * Default environment the daemon must inherit when launchd starts it.
+ * HOME + USER matter for macOS Keychain: the claude CLI's ACL is scoped to
+ * the user's Keychain, and SDK code downstream of `query()` resolves config
+ * under `$HOME/.claude`. launchd strips most of the parent env when a
+ * LaunchAgent boots, so we pin these here.
+ */
+export function buildDefaultPlistEnv(
+  overrides: Partial<{ home: string; user: string; path: string }> = {},
+): Record<string, string> {
+  const info = userInfo()
+  const home = overrides.home ?? info.homedir
+  const user = overrides.user ?? info.username
+  const path =
+    overrides.path ??
+    process.env.PATH ??
+    '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+  return { HOME: home, USER: user, PATH: path }
+}
+
+/**
+ * Merge a default env with user overrides, filtering out forbidden keys
+ * (like ANTHROPIC_API_KEY) so they can never leak onto disk via the plist.
+ */
+export function sanitizePlistEnv(
+  env: Record<string, string>,
+): Record<string, string> {
+  const forbidden = new Set(FORBIDDEN_PLIST_ENV_KEYS)
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(env)) {
+    if (forbidden.has(key)) continue
+    out[key] = value
+  }
+  return out
+}
+
+export function buildKairosPlist(inputs: KairosPlistInputs): string {
+  const runAtLoad = inputs.runAtLoad ?? true
+  const throttle = inputs.throttleIntervalSec ?? 10
+  const workingDir = inputs.workingDirectory ?? homedir()
+  const stdoutPath = inputs.stdoutPath ?? getKairosStdoutLogPath()
+  const stderrPath =
+    inputs.stderrPath ?? join(getKairosStateDir(), 'daemon.err.log')
+  const programArgs = [inputs.program, ...inputs.args]
+  const mergedEnv = sanitizePlistEnv({
+    ...buildDefaultPlistEnv(),
+    ...(inputs.env ?? {}),
+  })
+  const envEntries = Object.entries(mergedEnv)
+
+  const body: string[] = [
+    '    <key>Label</key>',
+    stringElement(KAIROS_LAUNCH_AGENT_LABEL, '    '),
+    '    <key>ProgramArguments</key>',
+    arrayElement(programArgs, '    '),
+    '    <key>RunAtLoad</key>',
+    runAtLoad ? '    <true/>' : '    <false/>',
+    '    <key>KeepAlive</key>',
+    '    <true/>',
+    '    <key>ThrottleInterval</key>',
+    `    <integer>${Math.max(1, Math.floor(throttle))}</integer>`,
+    '    <key>WorkingDirectory</key>',
+    stringElement(workingDir, '    '),
+    '    <key>StandardOutPath</key>',
+    stringElement(stdoutPath, '    '),
+    '    <key>StandardErrorPath</key>',
+    stringElement(stderrPath, '    '),
+  ]
+  // envEntries always has HOME/USER/PATH from the default merge above, so
+  // this block is effectively always emitted — the conditional is defense
+  // in depth for future callers who opt out explicitly.
+  if (envEntries.length > 0) {
+    body.push('    <key>EnvironmentVariables</key>')
+    body.push(dictElement(envEntries, '    '))
+  }
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" ' +
+      '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    '  <dict>',
+    ...body,
+    '  </dict>',
+    '</plist>',
+    '',
+  ].join('\n')
+}

--- a/src 2/daemon/kairos/install/plist.ts
+++ b/src 2/daemon/kairos/install/plist.ts
@@ -164,6 +164,11 @@ export function buildKairosPlist(inputs: KairosPlistInputs): string {
     stringElement(stdoutPath, '    '),
     '    <key>StandardErrorPath</key>',
     stringElement(stderrPath, '    '),
+    // Keychain ACLs are scoped to the Aqua (GUI) session — pin this so
+    // launchd doesn't try to start the agent in a background/ssh session
+    // where the Keychain is locked.
+    '    <key>LimitLoadToSessionType</key>',
+    stringElement('Aqua', '    '),
   ]
   // envEntries always has HOME/USER/PATH from the default merge above, so
   // this block is effectively always emitted — the conditional is defense

--- a/src 2/daemon/kairos/install/resolveClaude.test.ts
+++ b/src 2/daemon/kairos/install/resolveClaude.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from 'bun:test'
 import { resolveCanonicalClaude } from './install.js'
 
+const noopAssert = async () => {}
+
 describe('resolveCanonicalClaude', () => {
   test('prefers CLAUDE_BIN env override', async () => {
     const result = await resolveCanonicalClaude({
       env: { CLAUDE_BIN: '/opt/claude/bin/claude' },
       which: async () => '/usr/local/bin/claude',
+      assertExecutable: noopAssert,
     })
     expect(result.program).toBe('/opt/claude/bin/claude')
     expect(result.args).toEqual(['daemon', 'kairos'])
@@ -15,6 +18,7 @@ describe('resolveCanonicalClaude', () => {
     const result = await resolveCanonicalClaude({
       env: {},
       which: async name => (name === 'claude' ? '/usr/local/bin/claude' : null),
+      assertExecutable: noopAssert,
     })
     expect(result.program).toBe('/usr/local/bin/claude')
     expect(result.args).toEqual(['daemon', 'kairos'])
@@ -24,10 +28,40 @@ describe('resolveCanonicalClaude', () => {
     const result = await resolveCanonicalClaude({
       env: {},
       which: async () => null,
+      assertExecutable: noopAssert,
     })
     expect(result.program).toBe(process.execPath)
     // args[0] should be the currently-running entrypoint (or empty shape).
     expect(result.args[result.args.length - 2]).toBe('daemon')
     expect(result.args[result.args.length - 1]).toBe('kairos')
+  })
+
+  test('throws a clear error when CLAUDE_BIN points at a non-executable path', async () => {
+    // Fails fast before the launchd agent crash-loops through
+    // ThrottleInterval on a typo'd CLAUDE_BIN.
+    await expect(
+      resolveCanonicalClaude({
+        env: { CLAUDE_BIN: '/opt/does/not/exist/claude' },
+        which: async () => '/usr/local/bin/claude',
+        assertExecutable: async path => {
+          throw new Error(`not executable: ${path}`)
+        },
+      }),
+    ).rejects.toThrow(/not executable/)
+  })
+
+  test('does NOT validate the which(claude) result (trusts PATH)', async () => {
+    // Only CLAUDE_BIN is validated — paths from `which` are already an
+    // OS-level existence signal.
+    const calls: string[] = []
+    const result = await resolveCanonicalClaude({
+      env: {},
+      which: async () => '/usr/local/bin/claude',
+      assertExecutable: async path => {
+        calls.push(path)
+      },
+    })
+    expect(result.program).toBe('/usr/local/bin/claude')
+    expect(calls).toEqual([])
   })
 })

--- a/src 2/daemon/kairos/install/resolveClaude.test.ts
+++ b/src 2/daemon/kairos/install/resolveClaude.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveCanonicalClaude } from './install.js'
+
+describe('resolveCanonicalClaude', () => {
+  test('prefers CLAUDE_BIN env override', async () => {
+    const result = await resolveCanonicalClaude({
+      env: { CLAUDE_BIN: '/opt/claude/bin/claude' },
+      which: async () => '/usr/local/bin/claude',
+    })
+    expect(result.program).toBe('/opt/claude/bin/claude')
+    expect(result.args).toEqual(['daemon', 'kairos'])
+  })
+
+  test('falls back to which(claude) when no env override', async () => {
+    const result = await resolveCanonicalClaude({
+      env: {},
+      which: async name => (name === 'claude' ? '/usr/local/bin/claude' : null),
+    })
+    expect(result.program).toBe('/usr/local/bin/claude')
+    expect(result.args).toEqual(['daemon', 'kairos'])
+  })
+
+  test('falls back to current runtime when claude is not on PATH', async () => {
+    const result = await resolveCanonicalClaude({
+      env: {},
+      which: async () => null,
+    })
+    expect(result.program).toBe(process.execPath)
+    // args[0] should be the currently-running entrypoint (or empty shape).
+    expect(result.args[result.args.length - 2]).toBe('daemon')
+    expect(result.args[result.args.length - 1]).toBe('kairos')
+  })
+})

--- a/src 2/daemon/kairos/install/uninstall.ts
+++ b/src 2/daemon/kairos/install/uninstall.ts
@@ -1,0 +1,81 @@
+// Uninstall the KAIROS LaunchAgent — bootout from launchd, then remove the
+// plist. Safe to call when the agent isn't currently loaded.
+//
+// Usage from the workspace root:
+//   bun run ./daemon/kairos/install/uninstall.ts
+
+import { rm } from 'fs/promises'
+import { promisify } from 'util'
+import { execFile as execFileCb } from 'child_process'
+import { userInfo } from 'os'
+import {
+  getKairosPlistPath,
+  getLaunchctlServiceTarget,
+  KAIROS_LAUNCH_AGENT_LABEL,
+} from './plist.js'
+import type { LaunchctlRunner } from './install.js'
+
+const execFile = promisify(execFileCb)
+
+const defaultRunner: LaunchctlRunner = async args => {
+  const { stdout, stderr } = await execFile('launchctl', [...args])
+  return { stdout, stderr }
+}
+
+export type UninstallKairosOptions = {
+  plistPath?: string
+  uid?: number
+  launchctl?: LaunchctlRunner
+}
+
+export async function uninstallKairosLaunchAgent(
+  options: UninstallKairosOptions = {},
+): Promise<{ plistPath: string; target: string; removed: boolean }> {
+  const plistPath = options.plistPath ?? getKairosPlistPath()
+  const uid = options.uid ?? userInfo().uid
+  const runner = options.launchctl ?? defaultRunner
+  const target = getLaunchctlServiceTarget(uid)
+
+  // bootout is idempotent enough in practice, but still throws when the
+  // service isn't loaded. Swallow that and fall through to file removal
+  // so a half-installed state (plist on disk, service never loaded) also
+  // cleans up cleanly.
+  try {
+    await runner(['bootout', target])
+  } catch {
+    // ignore — service may not be loaded
+  }
+
+  let removed = false
+  try {
+    await rm(plistPath, { force: false })
+    removed = true
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | null)?.code
+    if (code !== 'ENOENT') throw err
+    // plist already gone — still treat as successful cleanup
+  }
+
+  return { plistPath, target, removed }
+}
+
+const isMainModule =
+  typeof process !== 'undefined' &&
+  typeof import.meta !== 'undefined' &&
+  typeof import.meta.url === 'string' &&
+  process.argv[1] !== undefined &&
+  import.meta.url === `file://${process.argv[1]}`
+
+if (isMainModule) {
+  uninstallKairosLaunchAgent()
+    .then(({ plistPath, target, removed }) => {
+      console.log(`Uninstalled ${KAIROS_LAUNCH_AGENT_LABEL}`)
+      console.log(`  target:  ${target}`)
+      console.log(`  plist:   ${plistPath}${removed ? '' : ' (already absent)'}`)
+    })
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`kairos uninstall failed: ${message}`)
+      process.exit(1)
+    })
+}

--- a/src 2/daemon/kairos/stateWriter.ts
+++ b/src 2/daemon/kairos/stateWriter.ts
@@ -72,6 +72,16 @@ export type ProjectLogEvent =
       message: string
       source: 'daemon'
     }
+  | {
+      kind: 'auth_failure'
+      t: string
+      projectDir: string
+      taskId: string
+      runId: string
+      notice: string
+      errorMessage: string
+      source: 'daemon'
+    }
 
 export type GlobalStatus = {
   kind: 'kairos'
@@ -95,12 +105,14 @@ export type CostsFile = {
 
 export type PauseState = {
   paused: boolean
-  reason?: 'cap_hit'
+  reason?: 'cap_hit' | 'auth_failure'
   scope?: 'project' | 'global'
   cap?: number
   current?: number
   setAt?: string
   source: 'daemon' | 'user'
+  /** Human-readable notice shown to the user when the daemon pauses itself. */
+  notice?: string
 }
 
 const writeQueues = new Map<string, Promise<void>>()

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -220,6 +220,39 @@ export function makeAuthFailureHandler(
   }
 }
 
+/**
+ * In-memory latch that closes the race between project A detecting an auth
+ * failure and project B's next tick. `handleAuthFailure` starts with an
+ * async `writePauseState`, so without this flag B can read an unpaused
+ * file and fire a second child that burns another Keychain re-prompt.
+ *
+ * - `latch()` flips the in-memory flag synchronously.
+ * - `isPaused()` returns true if the on-disk pause is set OR the latch
+ *   is held. The latch clears when the user explicitly resumes
+ *   (pause.json written with `source: 'user'`).
+ */
+export function createAuthFailurePauseGate(
+  stateWriter: Pick<StateWriter, 'readPauseState'>,
+): { latch: () => void; isPaused: () => Promise<boolean> } {
+  let authFailureLatched = false
+  return {
+    latch() {
+      authFailureLatched = true
+    },
+    async isPaused() {
+      const state = await stateWriter.readPauseState()
+      if (state?.paused === false && state.source === 'user') {
+        // User has acknowledged the auth failure and resumed — clear the
+        // latch so the next tick can attempt a spawn. If auth is still
+        // broken, the next child run will re-latch.
+        authFailureLatched = false
+      }
+      if (state?.paused === true) return true
+      return authFailureLatched
+    },
+  }
+}
+
 export type RunFiredTaskOptions = {
   projectDir: string
   stateWriter: StateWriter
@@ -350,11 +383,13 @@ export async function runKairosWorker(
     2 * 60 * 1000
 
   const handleCapHit = makeCapHitHandler(stateWriter, now)
-  const handleAuthFailure = makeAuthFailureHandler(stateWriter, now)
-  const checkPaused = async (): Promise<boolean> => {
-    const state = await stateWriter.readPauseState()
-    return !!state?.paused
+  const authGate = createAuthFailurePauseGate(stateWriter)
+  const baseAuthFailureHandler = makeAuthFailureHandler(stateWriter, now)
+  const handleAuthFailure: AuthFailureHandler = async params => {
+    authGate.latch()
+    await baseAuthFailureHandler(params)
   }
+  const checkPaused = authGate.isPaused
 
   const syncGlobalStatus = async (state: 'starting' | 'idle' | 'stopped') => {
     await stateWriter.writeGlobalStatus({

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -4,7 +4,11 @@ import type {
   ChildLauncher,
   ChildRunResult,
 } from './childRunner.js'
-import { createSdkChildLauncher, runChild } from './childRunner.js'
+import {
+  AUTH_FAILURE_NOTICE,
+  createSdkChildLauncher,
+  runChild,
+} from './childRunner.js'
 import {
   createCostTracker,
   type CapHit,
@@ -167,6 +171,55 @@ export function makeCapHitHandler(
   }
 }
 
+type AuthFailureHandler = (params: {
+  projectDir: string
+  task: CronTask
+  result: ChildRunResult
+}) => Promise<void>
+
+/**
+ * Auth failures come from the user's Keychain no longer letting the daemon
+ * use the claude binary — usually after an auto-update. Retrying inside the
+ * daemon can't possibly help (the ACL re-prompt needs an interactive UI),
+ * so we flip global pause state with a descriptive reason. The `/kairos
+ * status` command reads pause.json and surfaces the notice verbatim.
+ */
+export function makeAuthFailureHandler(
+  stateWriter: StateWriter,
+  now: () => Date,
+): AuthFailureHandler {
+  return async ({ projectDir, task, result }) => {
+    const t = now().toISOString()
+    await stateWriter.writePauseState({
+      paused: true,
+      reason: 'auth_failure',
+      scope: 'global',
+      setAt: t,
+      source: 'daemon',
+      notice: AUTH_FAILURE_NOTICE,
+    })
+    await stateWriter.appendGlobalEvent({
+      kind: 'auth_failure',
+      t,
+      projectDir,
+      taskId: task.id,
+      runId: result.runId,
+      notice: AUTH_FAILURE_NOTICE,
+      errorMessage: result.errorMessage ?? 'unknown',
+      source: 'daemon',
+    })
+    await stateWriter.appendProjectEvent(projectDir, {
+      kind: 'auth_failure',
+      t,
+      taskId: task.id,
+      runId: result.runId,
+      notice: AUTH_FAILURE_NOTICE,
+      errorMessage: result.errorMessage ?? 'unknown',
+      source: 'daemon',
+    })
+  }
+}
+
 export type RunFiredTaskOptions = {
   projectDir: string
   stateWriter: StateWriter
@@ -176,6 +229,7 @@ export type RunFiredTaskOptions = {
   maxTurns: number
   timeoutMs: number
   handleCapHit: CapHitHandler
+  handleAuthFailure?: AuthFailureHandler
   now: () => Date
 }
 
@@ -189,6 +243,7 @@ export function makeRunFiredTask(options: RunFiredTaskOptions) {
     maxTurns,
     timeoutMs,
     handleCapHit,
+    handleAuthFailure,
     now,
   } = options
 
@@ -224,6 +279,16 @@ export function makeRunFiredTask(options: RunFiredTaskOptions) {
     )
 
     let paused = false
+
+    // Auth failures take precedence over cost accounting: the run didn't
+    // actually consume a cap, and the daemon must stop spawning new children
+    // immediately so every queued task doesn't burn a fresh Keychain
+    // re-prompt on a sleeping user's machine.
+    if (result.exitReason === 'auth_failure' && handleAuthFailure) {
+      await handleAuthFailure({ projectDir, task, result })
+      return { ok: false, paused: true, result }
+    }
+
     if (costTracker) {
       const { capHit } = await costTracker.record({
         projectDir,
@@ -285,6 +350,7 @@ export async function runKairosWorker(
     2 * 60 * 1000
 
   const handleCapHit = makeCapHitHandler(stateWriter, now)
+  const handleAuthFailure = makeAuthFailureHandler(stateWriter, now)
   const checkPaused = async (): Promise<boolean> => {
     const state = await stateWriter.readPauseState()
     return !!state?.paused
@@ -315,6 +381,7 @@ export async function runKairosWorker(
       maxTurns,
       timeoutMs,
       handleCapHit,
+      handleAuthFailure,
       now,
     })
     const worker = createProjectWorker(projectDir, {


### PR DESCRIPTION
Implements issue #16 Phase 5A: the `/kairos` local command plus the LaunchAgent install/uninstall flow, and the auth-failure handling that both the command and dashboard surface. Trunk-safe — no edits to `commands.ts`, `Tool.ts`, `types/`, `schemas/`, `state/`, `entrypoints/`, or `migrations/` (registration is Phase 5B).

## Changes
- **`/kairos` subcommands** (`status | list | opt-in | opt-out | demo | pause | resume | dashboard | logs`) in `commands/kairos.ts`, reusing `daemon/dashboard/model.ts` so terminal and web UI share on-disk state.
- **LaunchAgent install** at `~/Library/LaunchAgents/com.anthropic.claude.kairos.plist` (user scope, not LaunchDaemon, so child `claude` reads the user Keychain). Plist always sets `HOME`/`USER`/`PATH`; `sanitizePlistEnv` strips `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` even if callers pass them. `resolveCanonicalClaude` picks the same binary the user runs interactively (`CLAUDE_BIN` → `which claude` → `process.execPath`).
- **Auth-failure path**: `isAuthFailureError` classifier + `AUTH_FAILURE_NOTICE` in `childRunner.ts`; worker's `makeAuthFailureHandler` writes a **global** pause with the notice (no per-task loop-retry), and `/kairos status` surfaces it verbatim.

## Test plan
- [x] `bun test` against the six Phase 5A files → 50 pass / 0 fail / 144 expect()
- [x] `bun run lint` clean
- [x] Manual `/kairos status` with a daemon-authored auth-failure pause prints `paused: yes [auth_failure] scope=global` + the re-auth `notice:` line
- [x] Generated plist inspected: label `com.anthropic.claude.kairos`, `RunAtLoad=true`, `KeepAlive=true`, contains `HOME`/`USER`/`PATH`, zero `ANTHROPIC_*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)