### PR TITLE
Add permanent structural fix skill automation

### DIFF
--- a/.claude/skills/RESOLVER.md
+++ b/.claude/skills/RESOLVER.md
@@ -1,0 +1,15 @@
+# Skill Resolver
+
+## `/permanent-structural-fix`
+
+Use this skill when a failure, regression, or repeated manual workaround needs to become a permanent repo asset instead of a one-off patch.
+
+Trigger phrases:
+- `turn this into a permanent fix`
+- `make sure this never happens again`
+- `codify this failure`
+- `write a skill, deterministic code, tests, evals, and a resolver trigger`
+- `repeated manual workaround`
+
+Machine-readable source of truth:
+- `.claude/skills/permanent-structural-fix/resolver-trigger.json`

--- a/.claude/skills/permanent-structural-fix/SKILL.md
+++ b/.claude/skills/permanent-structural-fix/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: permanent-structural-fix
+description: Turn a failure, regression, or repeated manual workaround into a permanent repo fix by codifying a skill, deterministic code, tests, evals, resolver triggers, duplicate audits, and a daily enforcement loop.
+when_to_use: Use when a bug, incident, or repeated manual fix should become a durable repo capability instead of another one-off patch. Trigger phrases include "turn this into a permanent fix", "codify this failure", "make sure this never happens again", "write a skill with tests and evals", and "add a resolver trigger".
+argument-hint: "<failure summary>"
+arguments:
+  - failure_summary
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Edit
+  - Write
+  - Bash(bun:*)
+  - Bash(git:*)
+---
+
+# Permanent Structural Fix
+
+Turn a concrete failure into a permanent repo asset.
+
+## Input
+
+- `$failure_summary`: Short description of the failure, regression, or repeated workaround.
+
+## Goal
+
+Ship the smallest complete loop that prevents the same class of failure from silently returning:
+- a repo-local skill
+- deterministic code for the non-LLM pieces
+- unit tests
+- LLM eval fixtures
+- a resolver trigger plus resolver eval
+- duplicate audits
+- a smoke path
+- a daily enforcement loop
+
+## Steps
+
+### 1. Capture the failure shape
+
+Map the failure into one sentence, the missing asset, and the ongoing enforcement needed.
+
+**Success criteria**:
+- The failure is named precisely.
+- The missing permanent asset is explicit.
+- The enforcement loop is defined before editing code.
+
+### 2. Codify the workflow as a skill
+
+Write or update `.claude/skills/permanent-structural-fix/SKILL.md` so the repo has a reusable operator manual for this failure class.
+
+**Success criteria**:
+- The skill says when to fire.
+- The skill names the required artifacts.
+- The skill points to the deterministic scripts and smoke path.
+
+### 3. Move fragile logic into deterministic code
+
+Put the repeatable, judgeable parts in `src 2/services/structuralFix/structuralFix.ts`:
+- resolver matching
+- resolver scoring
+- duplicate audits
+- smoke orchestration
+- daily schedule installation
+
+**Success criteria**:
+- The non-LLM steps run without interpretation.
+- Inputs and outputs are machine-checkable.
+
+### 4. Add tests and eval fixtures
+
+Update the checked-in JSON fixtures and unit tests so the behavior is enforced even if the skill text changes.
+
+**Success criteria**:
+- Unit tests cover the deterministic logic.
+- Resolver eval cases cover both positive and negative examples.
+- LLM eval cases ask whether the response produced all structural artifacts instead of stopping at a patch.
+
+### 5. Wire the resolver trigger
+
+Update `.claude/skills/RESOLVER.md` and `.claude/skills/permanent-structural-fix/resolver-trigger.json` so requests matching this failure class route to this skill.
+
+**Success criteria**:
+- Trigger phrases are explicit.
+- The deterministic resolver passes its eval cases.
+
+### 6. Audit for drift and duplicates
+
+Run:
+- `bun run structural-fix:resolver-eval`
+- `bun run structural-fix:smoke`
+
+These checks must reject duplicate trigger phrases, duplicate eval ids, missing artifacts, and resolver misses.
+
+**Success criteria**:
+- Duplicate audit is clean.
+- Smoke succeeds.
+- The daily schedule is installed or confirmed as already present.
+
+### 7. Keep it alive every day
+
+Use the daily workflow in `.github/workflows/permanent-structural-fix-daily.yml` and the project cron task installed by the smoke script.
+
+**Success criteria**:
+- The workflow runs on a daily schedule.
+- The project cron task exists or is re-installed idempotently.
+- The repo no longer depends on memory of the incident.

--- a/.claude/skills/permanent-structural-fix/resolver-trigger.json
+++ b/.claude/skills/permanent-structural-fix/resolver-trigger.json
@@ -1,0 +1,37 @@
+{
+  "skill": "permanent-structural-fix",
+  "description": "Routes failure-hardening requests to the permanent structural fix skill.",
+  "rules": [
+    {
+      "id": "permanent-fix-phrases",
+      "anyPhrases": [
+        "turn this into a permanent fix",
+        "turn this failure into a permanent fix",
+        "permanent structural fix",
+        "codify this failure",
+        "make sure this never happens again"
+      ]
+    },
+    {
+      "id": "skill-plus-hardening-assets",
+      "pattern": "\\b(write|add|create)\\b[\\s\\S]{0,120}\\bskill\\b[\\s\\S]{0,120}\\b(unit tests?|evals?|resolver)\\b"
+    },
+    {
+      "id": "repeat-workaround",
+      "anyPhrases": [
+        "repeated manual workaround",
+        "repeated manual fix",
+        "one-off work"
+      ]
+    },
+    {
+      "id": "incident-hardening-checklist",
+      "allTerms": [
+        "failure",
+        "unit tests",
+        "evals",
+        "resolver trigger"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/permanent-structural-fix-daily.yml
+++ b/.github/workflows/permanent-structural-fix-daily.yml
@@ -1,0 +1,25 @@
+name: permanent-structural-fix-daily
+
+on:
+  schedule:
+    - cron: '17 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  permanent-structural-fix:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src 2
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.23
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run permanent structural fix loop
+        run: bun run structural-fix:daily

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.claude/scheduled_tasks.json

--- a/evals/permanent-structural-fix/llm-evals.json
+++ b/evals/permanent-structural-fix/llm-evals.json
@@ -1,0 +1,50 @@
+{
+  "skill": "permanent-structural-fix",
+  "cases": [
+    {
+      "id": "repeat-fix-becomes-asset",
+      "context": "The repo keeps hand-patching the same reminder scheduling regression after every refactor. The bug is understood, but nobody has turned it into a reusable workflow.",
+      "task": "Turn this failure into a permanent structural fix.",
+      "requiredArtifacts": [
+        "skill",
+        "deterministic_code",
+        "unit_tests",
+        "llm_evals",
+        "resolver_trigger",
+        "resolver_eval",
+        "duplicate_audit",
+        "smoke_test",
+        "daily_enforcement"
+      ],
+      "judgeQuestions": [
+        "Did the response create or update a repo-local skill instead of stopping at a one-off patch?",
+        "Did it move the stable logic into deterministic code rather than leaving everything in prompt text?",
+        "Did it add automated tests and eval fixtures that would fail on regression?",
+        "Did it add a resolver trigger and then evaluate the resolver on concrete cases?",
+        "Did it install a recurring enforcement path so the fix keeps running after the incident is forgotten?"
+      ]
+    },
+    {
+      "id": "postmortem-to-loop",
+      "context": "A postmortem says the team repeatedly forgot to add smoke coverage and duplicate audits whenever a new slash command was introduced.",
+      "task": "Convert this postmortem item into a permanent repo capability.",
+      "requiredArtifacts": [
+        "skill",
+        "deterministic_code",
+        "unit_tests",
+        "llm_evals",
+        "resolver_trigger",
+        "resolver_eval",
+        "duplicate_audit",
+        "smoke_test",
+        "daily_enforcement"
+      ],
+      "judgeQuestions": [
+        "Did the response encode the workflow as a reusable skill with explicit trigger conditions?",
+        "Did it cover both structural assertions and semantic LLM-judge style eval prompts?",
+        "Did it include duplicate detection so the new mechanism does not create overlapping triggers or fixture ids?",
+        "Did it make the repo self-check this behavior daily?"
+      ]
+    }
+  ]
+}

--- a/evals/permanent-structural-fix/resolver-cases.json
+++ b/evals/permanent-structural-fix/resolver-cases.json
@@ -1,0 +1,45 @@
+{
+  "skill": "permanent-structural-fix",
+  "cases": [
+    {
+      "id": "positive-permanent-fix",
+      "input": "This failure happened again. Turn this into a permanent fix with a skill, tests, evals, and a resolver trigger.",
+      "expectedSkill": "permanent-structural-fix"
+    },
+    {
+      "id": "positive-repeated-workaround",
+      "input": "We keep applying the same repeated manual workaround after every release. Codify this failure so it never happens again.",
+      "expectedSkill": "permanent-structural-fix"
+    },
+    {
+      "id": "positive-hardening-checklist",
+      "input": "Write a skill, deterministic code, unit tests, LLM evals, and a resolver trigger for this failure.",
+      "expectedSkill": "permanent-structural-fix"
+    },
+    {
+      "id": "positive-one-off-rule",
+      "input": "We are not allowed to do one-off work here. Make this a permanent structural fix.",
+      "expectedSkill": "permanent-structural-fix"
+    },
+    {
+      "id": "negative-feature-build",
+      "input": "Add a new remind command that schedules a one-shot cron task.",
+      "expectedSkill": null
+    },
+    {
+      "id": "negative-plain-bugfix",
+      "input": "Fix the duplicate cron bug in the reminder command.",
+      "expectedSkill": null
+    },
+    {
+      "id": "negative-docs-only",
+      "input": "Document how reminders work in the README.",
+      "expectedSkill": null
+    },
+    {
+      "id": "negative-skill-without-hardening",
+      "input": "Write a skill for code review.",
+      "expectedSkill": null
+    }
+  ]
+}

--- a/src 2/components/messages/AttachmentMessage.tsx
+++ b/src 2/components/messages/AttachmentMessage.tsx
@@ -122,7 +122,16 @@ export function AttachmentMessage({
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- teammate_mailbox/skill_discovery handled before switch
+  if (attachment.type === 'repo_skill_resolver') {
+    if (attachment.skills.length === 0) return null;
+    const names = attachment.skills.map(s => s.name).join(', ');
+    return <Line>
+        Repo resolver matched <Text bold>{attachment.skills.length}</Text>{' '}
+        {plural(attachment.skills.length, 'skill')}: {names}
+      </Line>;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- teammate_mailbox/skill_discovery/repo_skill_resolver handled before switch
   switch (attachment.type) {
     case 'directory':
       return <Line>
@@ -348,10 +357,10 @@ export function AttachmentMessage({
       // a case) or render nothing (add to the array). Messages.tsx pre-filters
       // these so this branch is defense-in-depth for other render paths.
       //
-      // skill_discovery and teammate_mailbox are handled BEFORE the switch in
+      // skill_discovery, repo_skill_resolver, and teammate_mailbox are handled BEFORE the switch in
       // runtime-gated blocks (feature() / isAgentSwarmsEnabled()) that TS can't
       // narrow through — excluded here via type union (compile-time only, no emit).
-      attachment.type satisfies NullRenderingAttachmentType | 'skill_discovery' | 'teammate_mailbox';
+      attachment.type satisfies NullRenderingAttachmentType | 'skill_discovery' | 'repo_skill_resolver' | 'teammate_mailbox';
       return null;
   }
 }

--- a/src 2/package.json
+++ b/src 2/package.json
@@ -10,6 +10,9 @@
   "scripts": {
     "dev": "bun ./entrypoints/cli.tsx",
     "test": "bun test",
+    "structural-fix:resolver-eval": "bun ./scripts/structuralFixResolverEval.ts",
+    "structural-fix:smoke": "bun ./scripts/structuralFixSmoke.ts",
+    "structural-fix:daily": "bun test ./services/structuralFix/structuralFix.test.ts ./utils/skills/repoSkillResolver.test.ts ./utils/skills/repoSkillAutoload.test.ts ./utils/processUserInput/processUserInput.test.ts && bun run structural-fix:resolver-eval && bun run structural-fix:smoke",
     "typecheck": "tsc --noEmit --allowJs false --skipLibCheck ./types/employee.ts",
     "lint": "eslint ./types/employee.ts ./utils/employeeConfig.ts ./tools/AgentTool/builtInAgents.ts ./tools/AgentTool/built-in/engineeringLeadAgent.ts ./commands/employee/index.ts ./commands/employee/employee.tsx ./services/reminders/*.ts ./scripts/employeeSmoke.ts ./entrypoints/cli.tsx ./daemon/**/*.ts --no-error-on-unmatched-pattern",
     "build": "bun build ./entrypoints/cli.tsx --outfile ./dist/cli.js --target bun --format esm --define MACRO='{\"VERSION\":\"0.0.0-rebuilt\",\"BUILD_TIME\":\"2026-03-31T00:00:00.000Z\",\"FEEDBACK_CHANNEL\":\"#claude-code\",\"ISSUES_EXPLAINER\":\"open an issue\",\"PACKAGE_URL\":\"@anthropic-ai/claude-code\",\"NATIVE_PACKAGE_URL\":\"@anthropic-ai/claude-code-native\",\"VERSION_CHANGELOG\":\"\"}' --external @ant/computer-use-mcp --external @ant/computer-use-mcp/types --external @ant/computer-use-mcp/sentinelApps --external @ant/claude-for-chrome-mcp --external @ant/computer-use-swift --external @ant/computer-use-input --external @anthropic-ai/mcpb --external @anthropic-ai/sandbox-runtime --external audio-capture-napi --external color-diff-napi --external image-processor-napi --external url-handler-napi",

--- a/src 2/scripts/structuralFixResolverEval.ts
+++ b/src 2/scripts/structuralFixResolverEval.ts
@@ -1,0 +1,35 @@
+import { join } from 'node:path'
+import {
+  evaluateStructuralFixResolver,
+  readStructuralFixResolver,
+  readStructuralFixResolverEvals,
+} from '../services/structuralFix/structuralFix.js'
+
+async function main(): Promise<void> {
+  const projectDir = join(process.cwd(), '..')
+  const [resolver, suite] = await Promise.all([
+    readStructuralFixResolver(projectDir),
+    readStructuralFixResolverEvals(projectDir),
+  ])
+  const evaluation = evaluateStructuralFixResolver(resolver, suite)
+
+  if (evaluation.failed.length > 0) {
+    console.error(JSON.stringify(evaluation, null, 2))
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        skill: resolver.skill,
+        passed: evaluation.passed,
+        total: evaluation.total,
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+void main()

--- a/src 2/scripts/structuralFixSmoke.ts
+++ b/src 2/scripts/structuralFixSmoke.ts
@@ -1,0 +1,19 @@
+import { join } from 'node:path'
+import {
+  setCwdState,
+  setOriginalCwd,
+  setProjectRoot,
+} from '../bootstrap/state.js'
+import { runStructuralFixSmoke } from '../services/structuralFix/structuralFix.js'
+
+async function main(): Promise<void> {
+  const projectRoot = join(process.cwd(), '..')
+  setOriginalCwd(projectRoot)
+  setCwdState(projectRoot)
+  setProjectRoot(projectRoot)
+
+  const report = await runStructuralFixSmoke(projectRoot)
+  console.log(JSON.stringify(report, null, 2))
+}
+
+void main()

--- a/src 2/services/structuralFix/structuralFix.test.ts
+++ b/src 2/services/structuralFix/structuralFix.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getProjectRoot,
+  setProjectRoot,
+} from '../../bootstrap/state.js'
+import { readCronTasks } from '../../utils/cronTasks.js'
+import {
+  STRUCTURAL_FIX_DAILY_CRON,
+  STRUCTURAL_FIX_DAILY_MARKER,
+  auditStructuralFixDuplicates,
+  ensureStructuralFixDailyTask,
+  evaluateStructuralFixResolver,
+  readStructuralFixLlmEvals,
+  readStructuralFixResolver,
+  readStructuralFixResolverEvals,
+  resolveStructuralFixSkill,
+  runStructuralFixSmoke,
+} from './structuralFix.js'
+
+const TEMP_DIRS: string[] = []
+let originalProjectRoot: string
+const REPO_ROOT = join(process.cwd(), '..')
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'structural-fix-test-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+beforeEach(() => {
+  originalProjectRoot = getProjectRoot()
+})
+
+afterEach(() => {
+  setProjectRoot(originalProjectRoot)
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('structural fix resolver fixtures', () => {
+  test('checked-in resolver cases all pass', async () => {
+    const [resolver, suite] = await Promise.all([
+      readStructuralFixResolver(REPO_ROOT),
+      readStructuralFixResolverEvals(REPO_ROOT),
+    ])
+
+    const evaluation = evaluateStructuralFixResolver(resolver, suite)
+
+    expect(evaluation.failed).toEqual([])
+    expect(evaluation.passed).toBe(evaluation.total)
+  })
+
+  test('resolves a permanent fix request and ignores a plain feature request', async () => {
+    const resolver = await readStructuralFixResolver(REPO_ROOT)
+
+    expect(
+      resolveStructuralFixSkill(
+        'Write a skill, deterministic code, unit tests, LLM evals, and a resolver trigger for this failure.',
+        resolver,
+      ),
+    ).toMatchObject({
+      skill: 'permanent-structural-fix',
+    })
+
+    expect(
+      resolveStructuralFixSkill(
+        'Add a new remind command that schedules a one-shot cron task.',
+        resolver,
+      ),
+    ).toBeNull()
+  })
+
+  test('checked-in fixtures have no duplicate ids or phrases', async () => {
+    const [resolver, resolverSuite, llmSuite] = await Promise.all([
+      readStructuralFixResolver(REPO_ROOT),
+      readStructuralFixResolverEvals(REPO_ROOT),
+      readStructuralFixLlmEvals(REPO_ROOT),
+    ])
+
+    const audit = auditStructuralFixDuplicates(resolver, resolverSuite, llmSuite)
+
+    expect(audit).toEqual({
+      duplicateRuleIds: [],
+      duplicateAnyPhrases: [],
+      duplicateAllTermSets: [],
+      duplicatePatterns: [],
+      duplicateResolverCaseIds: [],
+      duplicateLlmEvalCaseIds: [],
+      duplicateJudgeQuestions: [],
+    })
+  })
+})
+
+describe('structural fix daily schedule', () => {
+  test('ensureStructuralFixDailyTask writes exactly one permanent recurring cron', async () => {
+    const projectDir = makeProjectDir()
+    setProjectRoot(projectDir)
+
+    const first = await ensureStructuralFixDailyTask(projectDir, {
+      now: new Date('2026-04-22T09:17:00.000Z'),
+      generateId: () => 'fixloop1',
+    })
+    const second = await ensureStructuralFixDailyTask(projectDir, {
+      now: new Date('2026-04-22T09:17:00.000Z'),
+      generateId: () => 'fixloop2',
+    })
+
+    expect(first.status).toBe('scheduled')
+    expect(second.status).toBe('duplicate')
+    expect(second.id).toBe('fixloop1')
+    expect(second.cron).toBe(STRUCTURAL_FIX_DAILY_CRON)
+
+    const tasks = await readCronTasks(projectDir)
+    expect(tasks).toHaveLength(1)
+    expect(tasks[0]).toMatchObject({
+      id: 'fixloop1',
+      cron: STRUCTURAL_FIX_DAILY_CRON,
+      recurring: true,
+      permanent: true,
+    })
+    expect(tasks[0]!.prompt.startsWith(STRUCTURAL_FIX_DAILY_MARKER)).toBe(true)
+  })
+
+  test('smoke run passes checked-in fixtures and installs the daily task', async () => {
+    const report = await runStructuralFixSmoke(REPO_ROOT)
+
+    expect(report.skill).toBe('permanent-structural-fix')
+    expect(report.resolverEvaluation.failed).toEqual([])
+    expect(report.llmEvalCount).toBeGreaterThan(0)
+    expect(['scheduled', 'duplicate']).toContain(report.dailyTask.status)
+
+    const raw = readFileSync(
+      join(REPO_ROOT, '.claude', 'scheduled_tasks.json'),
+      'utf8',
+    )
+    expect(raw).toContain(STRUCTURAL_FIX_DAILY_MARKER)
+  })
+})

--- a/src 2/services/structuralFix/structuralFix.ts
+++ b/src 2/services/structuralFix/structuralFix.ts
@@ -1,0 +1,440 @@
+import { randomUUID } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { getProjectRoot } from '../../bootstrap/state.js'
+import {
+  getCronFilePath,
+  readCronTasks,
+  type CronTask,
+  writeCronTasks,
+} from '../../utils/cronTasks.js'
+import { safeParseJSON } from '../../utils/json.js'
+
+export const STRUCTURAL_FIX_SKILL_NAME = 'permanent-structural-fix'
+export const STRUCTURAL_FIX_DAILY_MARKER =
+  '<!-- permanent-structural-fix-daily -->'
+export const STRUCTURAL_FIX_DAILY_CRON = '17 9 * * *'
+
+export type StructuralFixResolverRule = {
+  id: string
+  anyPhrases?: string[]
+  allTerms?: string[]
+  pattern?: string
+}
+
+export type StructuralFixResolver = {
+  skill: string
+  description: string
+  rules: StructuralFixResolverRule[]
+}
+
+export type StructuralFixResolverEvalCase = {
+  id: string
+  input: string
+  expectedSkill: string | null
+}
+
+export type StructuralFixResolverEvalSuite = {
+  skill: string
+  cases: StructuralFixResolverEvalCase[]
+}
+
+export type StructuralFixLlmEvalCase = {
+  id: string
+  context: string
+  task: string
+  requiredArtifacts: string[]
+  judgeQuestions: string[]
+}
+
+export type StructuralFixLlmEvalSuite = {
+  skill: string
+  cases: StructuralFixLlmEvalCase[]
+}
+
+export type StructuralFixResolution = {
+  skill: string
+  ruleId: string
+}
+
+export type StructuralFixResolverEvaluation = {
+  total: number
+  passed: number
+  failed: Array<{
+    id: string
+    input: string
+    expectedSkill: string | null
+    actualSkill: string | null
+  }>
+}
+
+export type StructuralFixDuplicateAudit = {
+  duplicateRuleIds: string[]
+  duplicateAnyPhrases: string[]
+  duplicateAllTermSets: string[]
+  duplicatePatterns: string[]
+  duplicateResolverCaseIds: string[]
+  duplicateLlmEvalCaseIds: string[]
+  duplicateJudgeQuestions: string[]
+}
+
+export type EnsureStructuralFixDailyTaskResult = {
+  status: 'scheduled' | 'duplicate'
+  id: string
+  cron: string
+  filePath: string
+}
+
+export type StructuralFixSmokeReport = {
+  skill: string
+  resolverEvaluation: StructuralFixResolverEvaluation
+  duplicateAudit: StructuralFixDuplicateAudit
+  llmEvalCount: number
+  dailyTask: EnsureStructuralFixDailyTaskResult
+}
+
+type EnsureDailyTaskDeps = {
+  now?: Date
+  generateId?: () => string
+}
+
+function getProjectDir(projectDir?: string): string {
+  return projectDir ?? getProjectRoot()
+}
+
+function getSkillDir(projectDir?: string): string {
+  return join(
+    getProjectDir(projectDir),
+    '.claude',
+    'skills',
+    STRUCTURAL_FIX_SKILL_NAME,
+  )
+}
+
+export function getStructuralFixResolverPath(projectDir?: string): string {
+  return join(getSkillDir(projectDir), 'resolver-trigger.json')
+}
+
+export function getStructuralFixResolverEvalPath(projectDir?: string): string {
+  return join(
+    getProjectDir(projectDir),
+    'evals',
+    STRUCTURAL_FIX_SKILL_NAME,
+    'resolver-cases.json',
+  )
+}
+
+export function getStructuralFixLlmEvalPath(projectDir?: string): string {
+  return join(
+    getProjectDir(projectDir),
+    'evals',
+    STRUCTURAL_FIX_SKILL_NAME,
+    'llm-evals.json',
+  )
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const raw = await readFile(filePath, 'utf8')
+  const parsed = safeParseJSON(raw, false)
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`Invalid JSON fixture: ${filePath}`)
+  }
+  return parsed as T
+}
+
+export async function readStructuralFixResolver(
+  projectDir?: string,
+): Promise<StructuralFixResolver> {
+  return readJsonFile<StructuralFixResolver>(
+    getStructuralFixResolverPath(projectDir),
+  )
+}
+
+export async function readStructuralFixResolverEvals(
+  projectDir?: string,
+): Promise<StructuralFixResolverEvalSuite> {
+  return readJsonFile<StructuralFixResolverEvalSuite>(
+    getStructuralFixResolverEvalPath(projectDir),
+  )
+}
+
+export async function readStructuralFixLlmEvals(
+  projectDir?: string,
+): Promise<StructuralFixLlmEvalSuite> {
+  return readJsonFile<StructuralFixLlmEvalSuite>(
+    getStructuralFixLlmEvalPath(projectDir),
+  )
+}
+
+function normalizeText(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+function matchesRule(text: string, rule: StructuralFixResolverRule): boolean {
+  if (rule.anyPhrases?.some(phrase => text.includes(normalizeText(phrase)))) {
+    return true
+  }
+  if (rule.allTerms?.every(term => text.includes(normalizeText(term)))) {
+    return true
+  }
+  if (rule.pattern && new RegExp(rule.pattern, 'i').test(text)) {
+    return true
+  }
+  return false
+}
+
+export function resolveStructuralFixSkill(
+  input: string,
+  resolver: StructuralFixResolver,
+): StructuralFixResolution | null {
+  const text = normalizeText(input)
+  for (const rule of resolver.rules) {
+    if (matchesRule(text, rule)) {
+      return {
+        skill: resolver.skill,
+        ruleId: rule.id,
+      }
+    }
+  }
+  return null
+}
+
+export function evaluateStructuralFixResolver(
+  resolver: StructuralFixResolver,
+  suite: StructuralFixResolverEvalSuite,
+): StructuralFixResolverEvaluation {
+  const failed: StructuralFixResolverEvaluation['failed'] = []
+  for (const testCase of suite.cases) {
+    const actual = resolveStructuralFixSkill(testCase.input, resolver)
+    const actualSkill = actual?.skill ?? null
+    if (actualSkill !== testCase.expectedSkill) {
+      failed.push({
+        id: testCase.id,
+        input: testCase.input,
+        expectedSkill: testCase.expectedSkill,
+        actualSkill,
+      })
+    }
+  }
+  return {
+    total: suite.cases.length,
+    passed: suite.cases.length - failed.length,
+    failed,
+  }
+}
+
+function findDuplicates(values: string[]): string[] {
+  const counts = new Map<string, number>()
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([value]) => value)
+    .sort()
+}
+
+export function auditStructuralFixDuplicates(
+  resolver: StructuralFixResolver,
+  resolverSuite: StructuralFixResolverEvalSuite,
+  llmSuite: StructuralFixLlmEvalSuite,
+): StructuralFixDuplicateAudit {
+  return {
+    duplicateRuleIds: findDuplicates(resolver.rules.map(rule => rule.id)),
+    duplicateAnyPhrases: findDuplicates(
+      resolver.rules.flatMap(rule =>
+        (rule.anyPhrases ?? []).map(phrase => normalizeText(phrase)),
+      ),
+    ),
+    duplicateAllTermSets: findDuplicates(
+      resolver.rules
+        .filter(rule => rule.allTerms && rule.allTerms.length > 0)
+        .map(rule =>
+          [...(rule.allTerms ?? [])]
+            .map(term => normalizeText(term))
+            .sort()
+            .join('||'),
+        ),
+    ),
+    duplicatePatterns: findDuplicates(
+      resolver.rules
+        .map(rule => rule.pattern)
+        .filter((pattern): pattern is string => typeof pattern === 'string')
+        .map(pattern => pattern.trim()),
+    ),
+    duplicateResolverCaseIds: findDuplicates(
+      resolverSuite.cases.map(testCase => testCase.id),
+    ),
+    duplicateLlmEvalCaseIds: findDuplicates(
+      llmSuite.cases.map(testCase => testCase.id),
+    ),
+    duplicateJudgeQuestions: findDuplicates(
+      llmSuite.cases.flatMap(testCase =>
+        testCase.judgeQuestions.map(question => normalizeText(question)),
+      ),
+    ),
+  }
+}
+
+function duplicateAuditProblems(audit: StructuralFixDuplicateAudit): string[] {
+  const problems: string[] = []
+  if (audit.duplicateRuleIds.length > 0) {
+    problems.push(`duplicate rule ids: ${audit.duplicateRuleIds.join(', ')}`)
+  }
+  if (audit.duplicateAnyPhrases.length > 0) {
+    problems.push(
+      `duplicate resolver phrases: ${audit.duplicateAnyPhrases.join(', ')}`,
+    )
+  }
+  if (audit.duplicateAllTermSets.length > 0) {
+    problems.push(
+      `duplicate all-term rule sets: ${audit.duplicateAllTermSets.join(', ')}`,
+    )
+  }
+  if (audit.duplicatePatterns.length > 0) {
+    problems.push(
+      `duplicate regex patterns: ${audit.duplicatePatterns.join(', ')}`,
+    )
+  }
+  if (audit.duplicateResolverCaseIds.length > 0) {
+    problems.push(
+      `duplicate resolver eval ids: ${audit.duplicateResolverCaseIds.join(', ')}`,
+    )
+  }
+  if (audit.duplicateLlmEvalCaseIds.length > 0) {
+    problems.push(
+      `duplicate llm eval ids: ${audit.duplicateLlmEvalCaseIds.join(', ')}`,
+    )
+  }
+  if (audit.duplicateJudgeQuestions.length > 0) {
+    problems.push(
+      `duplicate llm judge questions: ${audit.duplicateJudgeQuestions.join(', ')}`,
+    )
+  }
+  return problems
+}
+
+export function buildStructuralFixDailyPrompt(projectDir?: string): string {
+  const root = getProjectDir(projectDir)
+  return [
+    STRUCTURAL_FIX_DAILY_MARKER,
+    `Run /${STRUCTURAL_FIX_SKILL_NAME} for this repository.`,
+    `Project root: ${root}`,
+    'Audit checklist:',
+    '1. Run `bun run structural-fix:daily`.',
+    '2. If any check fails, update the skill, deterministic code, tests, evals, or resolver trigger so the same failure class is permanently covered.',
+    '3. Keep duplicate audits clean.',
+    '4. Summarize any newly structuralized failure modes.',
+  ].join('\n')
+}
+
+function findExistingDailyTask(tasks: CronTask[]): CronTask | undefined {
+  return tasks.find(
+    task =>
+      task.recurring === true &&
+      task.permanent === true &&
+      task.prompt.startsWith(STRUCTURAL_FIX_DAILY_MARKER),
+  )
+}
+
+function defaultGenerateId(): string {
+  return randomUUID().slice(0, 8)
+}
+
+export async function hasStructuralFixDailyTask(
+  projectDir?: string,
+): Promise<boolean> {
+  const tasks = await readCronTasks(getProjectDir(projectDir))
+  return findExistingDailyTask(tasks) !== undefined
+}
+
+export async function ensureStructuralFixDailyTask(
+  projectDir?: string,
+  deps: EnsureDailyTaskDeps = {},
+): Promise<EnsureStructuralFixDailyTaskResult> {
+  const root = getProjectDir(projectDir)
+  const tasks = await readCronTasks(root)
+  const existing = findExistingDailyTask(tasks)
+  const filePath = getCronFilePath(root)
+
+  if (existing) {
+    return {
+      status: 'duplicate',
+      id: existing.id,
+      cron: existing.cron,
+      filePath,
+    }
+  }
+
+  const id = (deps.generateId ?? defaultGenerateId)()
+  const createdAt = (deps.now ?? new Date()).getTime()
+  const nextTask: CronTask = {
+    id,
+    cron: STRUCTURAL_FIX_DAILY_CRON,
+    prompt: buildStructuralFixDailyPrompt(root),
+    createdAt,
+    recurring: true,
+    permanent: true,
+  }
+  await writeCronTasks([...tasks, nextTask], root)
+
+  return {
+    status: 'scheduled',
+    id,
+    cron: STRUCTURAL_FIX_DAILY_CRON,
+    filePath,
+  }
+}
+
+export async function runStructuralFixSmoke(
+  projectDir?: string,
+): Promise<StructuralFixSmokeReport> {
+  const root = getProjectDir(projectDir)
+  const [resolver, resolverSuite, llmSuite] = await Promise.all([
+    readStructuralFixResolver(root),
+    readStructuralFixResolverEvals(root),
+    readStructuralFixLlmEvals(root),
+  ])
+
+  if (
+    resolver.skill !== STRUCTURAL_FIX_SKILL_NAME ||
+    resolverSuite.skill !== STRUCTURAL_FIX_SKILL_NAME ||
+    llmSuite.skill !== STRUCTURAL_FIX_SKILL_NAME
+  ) {
+    throw new Error('Structural fix fixtures disagree on the skill name')
+  }
+
+  const duplicateAudit = auditStructuralFixDuplicates(
+    resolver,
+    resolverSuite,
+    llmSuite,
+  )
+  const duplicateProblems = duplicateAuditProblems(duplicateAudit)
+  if (duplicateProblems.length > 0) {
+    throw new Error(
+      `Structural fix duplicate audit failed: ${duplicateProblems.join('; ')}`,
+    )
+  }
+
+  const resolverEvaluation = evaluateStructuralFixResolver(
+    resolver,
+    resolverSuite,
+  )
+  if (resolverEvaluation.failed.length > 0) {
+    throw new Error(
+      `Structural fix resolver eval failed: ${resolverEvaluation.failed
+        .map(failure => `${failure.id} -> expected ${failure.expectedSkill ?? 'null'}, got ${failure.actualSkill ?? 'null'}`)
+        .join('; ')}`,
+    )
+  }
+
+  const dailyTask = await ensureStructuralFixDailyTask(root)
+
+  return {
+    skill: STRUCTURAL_FIX_SKILL_NAME,
+    resolverEvaluation,
+    duplicateAudit,
+    llmEvalCount: llmSuite.cases.length,
+    dailyTask,
+  }
+}

--- a/src 2/utils/attachments.ts
+++ b/src 2/utils/attachments.ts
@@ -79,13 +79,18 @@ import {
   getDefaultOpusModel,
 } from './model/model.js'
 import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js'
-import { getSkillToolCommands, getMcpSkillCommands } from '../commands.js'
+import {
+  getMcpSkillCommands,
+  getSkillToolCommands,
+  getSlashCommandToolSkills,
+} from '../commands.js'
 import type { Command } from '../types/command.js'
 import uniqBy from 'lodash-es/uniqBy.js'
 import { getProjectRoot } from '../bootstrap/state.js'
 import { formatCommandsWithinBudget } from '../tools/SkillTool/prompt.js'
 import { getContextWindowForModel } from './context.js'
 import type { DiscoverySignal } from '../services/skillSearch/signals.js'
+import { findRepoResolverMatches } from './skills/repoSkillResolver.js'
 // Conditional require for DCE. All skill-search string literals that would
 // otherwise leak into external builds live inside these modules. The only
 // surfaces in THIS file are: the maybe() call (gated via spread below) and
@@ -541,6 +546,10 @@ export type Attachment =
       source: 'native' | 'aki' | 'both'
     }
   | {
+      type: 'repo_skill_resolver'
+      skills: { name: string; description: string; ruleId: string }[]
+    }
+  | {
       type: 'queued_command'
       prompt: string | Array<ContentBlockParam>
       source_uuid?: UUID
@@ -808,6 +817,13 @@ export async function getAttachments(
                   messages ?? [],
                   context,
                 ),
+              ),
+            ]
+          : []),
+        ...(!options?.skipSkillDiscovery
+          ? [
+              maybe('repo_skill_resolver', () =>
+                getRepoSkillResolverAttachments(input, context),
               ),
             ]
           : []),
@@ -2746,6 +2762,36 @@ async function getSkillListingAttachments(
       content,
       skillCount: newSkills.length,
       isInitial,
+    },
+  ]
+}
+
+async function getRepoSkillResolverAttachments(
+  input: string,
+  toolUseContext: ToolUseContext,
+): Promise<Attachment[]> {
+  if (
+    !toolUseContext.options.tools.some(t => toolMatchesName(t, SKILL_TOOL_NAME))
+  ) {
+    return []
+  }
+
+  const cwd = getProjectRoot()
+  const commands = await getSlashCommandToolSkills(cwd)
+  const matches = await findRepoResolverMatches(input, commands, cwd)
+
+  if (matches.length === 0) {
+    return []
+  }
+
+  return [
+    {
+      type: 'repo_skill_resolver',
+      skills: matches.slice(0, 5).map(match => ({
+        name: match.name,
+        description: match.description,
+        ruleId: match.ruleId,
+      })),
     },
   ]
 }

--- a/src 2/utils/messages.ts
+++ b/src 2/utils/messages.ts
@@ -3519,8 +3519,24 @@ Read the team config to discover your teammates' names. Check the task list peri
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- teammate_mailbox/team_context/skill_discovery/bagel_console handled above
-  // biome-ignore lint/nursery/useExhaustiveSwitchCases: teammate_mailbox/team_context/max_turns_reached/skill_discovery/bagel_console handled above, can't add case for dead code elimination
+  if (attachment.type === 'repo_skill_resolver') {
+    if (attachment.skills.length === 0) return []
+    const lines = attachment.skills.map(
+      skill => `- ${skill.name}: ${skill.description} (rule: ${skill.ruleId})`,
+    )
+    return wrapMessagesInSystemReminder([
+      createUserMessage({
+        content:
+          `Project resolver matched these skills for the user's latest request:\n\n${lines.join('\n')}\n\n` +
+          `These matches come from repo-local resolver rules in .claude/skills. ` +
+          `Invoke the matching skill via Skill("<name>") before doing one-off work if it fits the task.`,
+        isMeta: true,
+      }),
+    ])
+  }
+
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- teammate_mailbox/team_context/skill_discovery/repo_skill_resolver/bagel_console handled above
+  // biome-ignore lint/nursery/useExhaustiveSwitchCases: teammate_mailbox/team_context/max_turns_reached/skill_discovery/repo_skill_resolver/bagel_console handled above, can't add case for dead code elimination
   switch (attachment.type) {
     case 'directory': {
       return wrapMessagesInSystemReminder([

--- a/src 2/utils/processUserInput/processUserInput.test.ts
+++ b/src 2/utils/processUserInput/processUserInput.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getProjectRoot,
+  setProjectRoot,
+} from '../../bootstrap/state.js'
+import type { Command } from '../../types/command.js'
+import { getContentText } from '../messages.js'
+import { createFileStateCacheWithSizeLimit } from '../fileStateCache.js'
+import { processUserInput, type ProcessUserInputContext } from './processUserInput.js'
+import { getDefaultAppState } from '../../state/AppStateStore.js'
+
+const TEMP_DIRS: string[] = []
+let originalProjectRoot: string
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'process-user-input-test-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function createPromptCommand(name: string, description: string): Command {
+  return {
+    type: 'prompt',
+    name,
+    description,
+    hasUserSpecifiedDescription: true,
+    loadedFrom: 'skills',
+    source: 'bundled',
+    progressMessage: '',
+    contentLength: 0,
+    getPromptForCommand: async () => [
+      {
+        type: 'text',
+        text: 'Run the deploy checklist before you answer the user.',
+      },
+    ],
+  }
+}
+
+function createContext(commands: Command[]): ProcessUserInputContext {
+  let appState = getDefaultAppState()
+
+  return {
+    options: {
+      commands,
+      debug: false,
+      mainLoopModel: 'sonnet',
+      tools: [{ name: 'Skill' }] as any,
+      verbose: false,
+      thinkingConfig: { type: 'disabled' },
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: false,
+      agentDefinitions: { activeAgents: [] } as any,
+    },
+    abortController: new AbortController(),
+    readFileState: createFileStateCacheWithSizeLimit(16),
+    getAppState: () => appState,
+    setAppState: updater => {
+      appState = updater(appState)
+    },
+    setInProgressToolUseIDs: () => {},
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+    messages: [],
+  } as ProcessUserInputContext
+}
+
+afterEach(() => {
+  setProjectRoot(originalProjectRoot)
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+beforeEach(() => {
+  originalProjectRoot = getProjectRoot()
+})
+
+describe('processUserInput repo skill autoload', () => {
+  test('prepends auto-loaded skill messages before the user prompt', async () => {
+    const projectDir = makeProjectDir()
+    const skillDir = join(projectDir, '.claude', 'skills', 'ship-it')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(
+      join(skillDir, 'resolver-trigger.json'),
+      JSON.stringify({
+        skill: 'ship-it',
+        description: 'Routes deploy requests to the ship-it skill.',
+        rules: [
+          {
+            id: 'deploy-phrase',
+            anyPhrases: ['ship this today'],
+          },
+        ],
+      }),
+    )
+    setProjectRoot(projectDir)
+
+    const input =
+      'Please ship this today with the release checklist and production checks.'
+    const result = await processUserInput({
+      input,
+      mode: 'prompt',
+      setToolJSX: () => {},
+      context: createContext([
+        createPromptCommand('ship-it', 'Runs the deploy checklist.'),
+      ]),
+      messages: [],
+      setUserInputOnProcessing: () => {},
+      querySource: 'repl_main_thread',
+    })
+
+    expect(result.shouldQuery).toBe(true)
+
+    const texts = result.messages
+      .filter(message => message.type === 'user')
+      .map(message => getContentText(message.message.content) ?? '')
+
+    const metadataIndex = texts.findIndex(text =>
+      text.includes('<command-name>/ship-it</command-name>'),
+    )
+    const skillPromptIndex = texts.findIndex(text =>
+      text.includes('Run the deploy checklist before you answer the user.'),
+    )
+    const userPromptIndex = texts.findIndex(text => text === input)
+
+    expect(metadataIndex).toBeGreaterThanOrEqual(0)
+    expect(skillPromptIndex).toBeGreaterThan(metadataIndex)
+    expect(userPromptIndex).toBeGreaterThan(skillPromptIndex)
+
+    expect(
+      result.messages.some(
+        message =>
+          message.type === 'attachment' &&
+          message.attachment.type === 'command_permissions',
+      ),
+    ).toBe(true)
+
+    expect(
+      result.messages.some(
+        message =>
+          message.type === 'attachment' &&
+          message.attachment.type === 'repo_skill_resolver',
+      ),
+    ).toBe(false)
+  })
+})

--- a/src 2/utils/processUserInput/processUserInput.ts
+++ b/src 2/utils/processUserInput/processUserInput.ts
@@ -8,6 +8,7 @@ import { randomUUID } from 'crypto'
 import type { QuerySource } from 'src/constants/querySource.js'
 import { logEvent } from 'src/services/analytics/index.js'
 import { getContentText } from 'src/utils/messages.js'
+import { getProjectRoot, getInvokedSkillsForAgent } from '../../bootstrap/state.js'
 import {
   findCommand,
   getCommandName,
@@ -16,7 +17,11 @@ import {
 } from '../../commands.js'
 import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
 import type { IDESelection } from '../../hooks/useIdeSelection.js'
-import type { SetToolJSXFn, ToolUseContext } from '../../Tool.js'
+import {
+  toolMatchesName,
+  type SetToolJSXFn,
+  type ToolUseContext,
+} from '../../Tool.js'
 import type {
   AssistantMessage,
   AttachmentMessage,
@@ -38,6 +43,7 @@ import {
 import type { PastedContent } from '../config.js'
 import type { EffortValue } from '../effort.js'
 import { toArray } from '../generators.js'
+import { getAgentContext } from '../agentContext.js'
 import {
   executeUserPromptSubmitHooks,
   getUserPromptSubmitHookBlockingMessage,
@@ -58,6 +64,8 @@ import {
   hasUltraplanKeyword,
   replaceUltraplanKeyword,
 } from '../ultraplan/keyword.js'
+import { SKILL_TOOL_NAME } from '../../tools/SkillTool/constants.js'
+import { resolveRepoSkillAutoload } from '../skills/repoSkillAutoload.js'
 import { processTextPrompt } from './processTextPrompt.js'
 export type ProcessUserInputContext = ToolUseContext & LocalJSXCommandContext
 
@@ -573,17 +581,74 @@ async function processUserInputBase(
     }
   }
 
+  let userPromptAttachments = attachmentMessages
+  let autoLoadedSkillMessages: ProcessUserInputBaseResult | null = null
+
+  if (
+    inputString !== null &&
+    mode === 'prompt' &&
+    !effectiveSkipSlash &&
+    !inputString.startsWith('/') &&
+    context.options.tools.some(tool => toolMatchesName(tool, SKILL_TOOL_NAME))
+  ) {
+    const projectRoot = getProjectRoot()
+    const currentAgentId = getAgentContext()?.agentId ?? null
+    const alreadyLoadedSkillNames = new Set(
+      [...getInvokedSkillsForAgent(currentAgentId).values()].map(
+        skill => skill.skillName,
+      ),
+    )
+    const decision = await resolveRepoSkillAutoload(
+      inputString,
+      context.options.commands,
+      projectRoot,
+      { alreadyLoadedSkillNames },
+    )
+
+    if (decision) {
+      const { processSlashCommand } = await import(
+        './processSlashCommand.js'
+      )
+      autoLoadedSkillMessages = await processSlashCommand(
+        `/${decision.commandName}`,
+        [],
+        [],
+        [],
+        context,
+        setToolJSX,
+        undefined,
+        isAlreadyProcessing,
+        canUseTool,
+      )
+      userPromptAttachments = attachmentMessages.filter(
+        message => message.attachment.type !== 'repo_skill_resolver',
+      )
+    }
+  }
+
   // Regular user prompt
+  const promptResult = processTextPrompt(
+    normalizedInput,
+    imageContentBlocks,
+    imagePasteIds,
+    userPromptAttachments,
+    uuid,
+    permissionMode,
+    isMeta,
+  )
+
+  if (!autoLoadedSkillMessages) {
+    return addImageMetadataMessage(promptResult, imageMetadataTexts)
+  }
+
   return addImageMetadataMessage(
-    processTextPrompt(
-      normalizedInput,
-      imageContentBlocks,
-      imagePasteIds,
-      attachmentMessages,
-      uuid,
-      permissionMode,
-      isMeta,
-    ),
+    {
+      messages: [...autoLoadedSkillMessages.messages, ...promptResult.messages],
+      shouldQuery: true,
+      allowedTools: autoLoadedSkillMessages.allowedTools,
+      model: autoLoadedSkillMessages.model,
+      effort: autoLoadedSkillMessages.effort,
+    },
     imageMetadataTexts,
   )
 }

--- a/src 2/utils/skills/repoSkillAutoload.test.ts
+++ b/src 2/utils/skills/repoSkillAutoload.test.ts
@@ -76,7 +76,7 @@ describe('resolveRepoSkillAutoload', () => {
     expect(decision).toBeNull()
   })
 
-  test('selects forked skills too', async () => {
+  test('skips forked skills during auto-load resolution', async () => {
     const projectDir = makeProjectDir()
     const skillDir = join(projectDir, '.claude', 'skills', 'ship-it')
     mkdirSync(skillDir, { recursive: true })
@@ -100,9 +100,6 @@ describe('resolveRepoSkillAutoload', () => {
       projectDir,
     )
 
-    expect(decision).toMatchObject({
-      commandName: 'ship-it',
-      displayName: 'ship-it',
-    })
+    expect(decision).toBeNull()
   })
 })

--- a/src 2/utils/skills/repoSkillAutoload.test.ts
+++ b/src 2/utils/skills/repoSkillAutoload.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Command } from '../../types/command.js'
+import { resolveRepoSkillAutoload } from './repoSkillAutoload.js'
+
+const TEMP_DIRS: string[] = []
+const REPO_ROOT = join(process.cwd(), '..')
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'repo-skill-autoload-test-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function createPromptCommand(
+  name: string,
+  description: string,
+  context: 'inline' | 'fork' = 'inline',
+): Command {
+  return {
+    type: 'prompt',
+    name,
+    description,
+    hasUserSpecifiedDescription: true,
+    loadedFrom: 'skills',
+    source: 'bundled',
+    progressMessage: '',
+    contentLength: 0,
+    context,
+    getPromptForCommand: async () => [],
+  }
+}
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('resolveRepoSkillAutoload', () => {
+  test('selects the checked-in permanent structural fix skill', async () => {
+    const decision = await resolveRepoSkillAutoload(
+      'Turn this failure into a permanent fix with a skill, tests, evals, and a resolver trigger.',
+      [
+        createPromptCommand(
+          'permanent-structural-fix',
+          'Codifies repeated failures into a permanent structural fix.',
+        ),
+      ],
+      REPO_ROOT,
+    )
+
+    expect(decision).toMatchObject({
+      commandName: 'permanent-structural-fix',
+      displayName: 'permanent-structural-fix',
+    })
+  })
+
+  test('skips skills that are already loaded for the current agent', async () => {
+    const decision = await resolveRepoSkillAutoload(
+      'Turn this failure into a permanent fix with a skill, tests, evals, and a resolver trigger.',
+      [
+        createPromptCommand(
+          'permanent-structural-fix',
+          'Codifies repeated failures into a permanent structural fix.',
+        ),
+      ],
+      REPO_ROOT,
+      {
+        alreadyLoadedSkillNames: new Set(['permanent-structural-fix']),
+      },
+    )
+
+    expect(decision).toBeNull()
+  })
+
+  test('selects forked skills too', async () => {
+    const projectDir = makeProjectDir()
+    const skillDir = join(projectDir, '.claude', 'skills', 'ship-it')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(
+      join(skillDir, 'resolver-trigger.json'),
+      JSON.stringify({
+        skill: 'ship-it',
+        description: 'Routes deploy requests to the ship-it skill.',
+        rules: [
+          {
+            id: 'deploy-phrase',
+            anyPhrases: ['ship this today'],
+          },
+        ],
+      }),
+    )
+
+    const decision = await resolveRepoSkillAutoload(
+      'Please ship this today with the release checklist.',
+      [createPromptCommand('ship-it', 'Runs the deploy checklist.', 'fork')],
+      projectDir,
+    )
+
+    expect(decision).toMatchObject({
+      commandName: 'ship-it',
+      displayName: 'ship-it',
+    })
+  })
+})

--- a/src 2/utils/skills/repoSkillAutoload.ts
+++ b/src 2/utils/skills/repoSkillAutoload.ts
@@ -34,6 +34,13 @@ export async function resolveRepoSkillAutoload(
       continue
     }
 
+    // Auto-loading a forked skill from a plain prompt would implicitly execute
+    // a sub-agent or background task before the main model has reasoned about
+    // the request. Keep forked skills on the advisory resolver path instead.
+    if (command.context === 'fork') {
+      continue
+    }
+
     return {
       commandName: command.name,
       displayName: getCommandName(command),

--- a/src 2/utils/skills/repoSkillAutoload.ts
+++ b/src 2/utils/skills/repoSkillAutoload.ts
@@ -1,0 +1,46 @@
+import { getCommandName, type Command } from '../../types/command.js'
+import { findRepoResolverMatches } from './repoSkillResolver.js'
+
+export type RepoSkillAutoloadDecision = {
+  commandName: string
+  displayName: string
+  description: string
+  ruleId: string
+}
+
+type RepoSkillAutoloadOptions = {
+  alreadyLoadedSkillNames?: ReadonlySet<string>
+}
+
+export async function resolveRepoSkillAutoload(
+  input: string,
+  commands: Command[],
+  projectRoot: string,
+  options: RepoSkillAutoloadOptions = {},
+): Promise<RepoSkillAutoloadDecision | null> {
+  const alreadyLoadedSkillNames = options.alreadyLoadedSkillNames ?? new Set()
+  const matches = await findRepoResolverMatches(input, commands, projectRoot)
+
+  for (const match of matches) {
+    const command =
+      commands.find(candidate => candidate.name === match.name) ??
+      commands.find(candidate => getCommandName(candidate) === match.name)
+
+    if (!command || command.type !== 'prompt') {
+      continue
+    }
+
+    if (alreadyLoadedSkillNames.has(command.name)) {
+      continue
+    }
+
+    return {
+      commandName: command.name,
+      displayName: getCommandName(command),
+      description: command.description,
+      ruleId: match.ruleId,
+    }
+  }
+
+  return null
+}

--- a/src 2/utils/skills/repoSkillResolver.test.ts
+++ b/src 2/utils/skills/repoSkillResolver.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Command } from '../../types/command.js'
+import { findRepoResolverMatches } from './repoSkillResolver.js'
+
+const TEMP_DIRS: string[] = []
+const REPO_ROOT = join(process.cwd(), '..')
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'repo-skill-resolver-test-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function createPromptCommand(name: string, description: string): Command {
+  return {
+    type: 'prompt',
+    name,
+    description,
+    hasUserSpecifiedDescription: true,
+    loadedFrom: 'skills',
+    source: 'bundled',
+    progressMessage: '',
+    contentLength: 0,
+    getPromptForCommand: async () => [],
+  }
+}
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('findRepoResolverMatches', () => {
+  test('matches the checked-in permanent structural fix skill', async () => {
+    const matches = await findRepoResolverMatches(
+      'Turn this failure into a permanent fix with a skill, tests, evals, and a resolver trigger.',
+      [
+        createPromptCommand(
+          'permanent-structural-fix',
+          'Codifies repeated failures into a permanent structural fix.',
+        ),
+      ],
+      REPO_ROOT,
+    )
+
+    expect(matches).not.toHaveLength(0)
+    expect(matches[0]).toMatchObject({
+      name: 'permanent-structural-fix',
+    })
+  })
+
+  test('does not match unrelated requests', async () => {
+    const matches = await findRepoResolverMatches(
+      'Add a remind command that schedules a cron task.',
+      [
+        createPromptCommand(
+          'permanent-structural-fix',
+          'Codifies repeated failures into a permanent structural fix.',
+        ),
+      ],
+      REPO_ROOT,
+    )
+
+    expect(matches).toEqual([])
+  })
+
+  test('loads generic resolver triggers from any project root', async () => {
+    const projectDir = makeProjectDir()
+    const skillDir = join(projectDir, '.claude', 'skills', 'ship-it')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(
+      join(skillDir, 'resolver-trigger.json'),
+      JSON.stringify({
+        skill: 'ship-it',
+        description: 'Routes deploy requests to the ship-it skill.',
+        rules: [
+          {
+            id: 'deploy-phrase',
+            anyPhrases: ['ship this today'],
+          },
+        ],
+      }),
+    )
+
+    const matches = await findRepoResolverMatches(
+      'Please ship this today with the release checklist.',
+      [createPromptCommand('ship-it', 'Runs the deploy checklist.')],
+      projectDir,
+    )
+
+    expect(matches).toEqual([
+      {
+        name: 'ship-it',
+        description: 'Runs the deploy checklist.',
+        ruleId: 'deploy-phrase',
+        score: 4,
+      },
+    ])
+  })
+})

--- a/src 2/utils/skills/repoSkillResolver.test.ts
+++ b/src 2/utils/skills/repoSkillResolver.test.ts
@@ -101,4 +101,40 @@ describe('findRepoResolverMatches', () => {
       },
     ])
   })
+
+  test('orders equal-score matches deterministically', async () => {
+    const projectDir = makeProjectDir()
+    const alphaDir = join(projectDir, '.claude', 'skills', 'alpha-skill')
+    const betaDir = join(projectDir, '.claude', 'skills', 'beta-skill')
+    mkdirSync(alphaDir, { recursive: true })
+    mkdirSync(betaDir, { recursive: true })
+    writeFileSync(
+      join(alphaDir, 'resolver-trigger.json'),
+      JSON.stringify({
+        skill: 'alpha-skill',
+        rules: [{ id: 'alpha-rule', anyPhrases: ['same request'] }],
+      }),
+    )
+    writeFileSync(
+      join(betaDir, 'resolver-trigger.json'),
+      JSON.stringify({
+        skill: 'beta-skill',
+        rules: [{ id: 'beta-rule', anyPhrases: ['same request'] }],
+      }),
+    )
+
+    const matches = await findRepoResolverMatches(
+      'Please handle the same request now.',
+      [
+        createPromptCommand('beta-skill', 'Beta skill.'),
+        createPromptCommand('alpha-skill', 'Alpha skill.'),
+      ],
+      projectDir,
+    )
+
+    expect(matches.map(match => match.name)).toEqual([
+      'alpha-skill',
+      'beta-skill',
+    ])
+  })
 })

--- a/src 2/utils/skills/repoSkillResolver.ts
+++ b/src 2/utils/skills/repoSkillResolver.ts
@@ -1,0 +1,171 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { getCommandName, type Command } from '../../types/command.js'
+import { safeParseJSON } from '../json.js'
+
+export type RepoSkillResolverRule = {
+  id: string
+  anyPhrases?: string[]
+  allTerms?: string[]
+  pattern?: string
+}
+
+type RepoSkillResolverConfig = {
+  skill: string
+  description?: string
+  rules: RepoSkillResolverRule[]
+}
+
+export type RepoSkillResolverMatch = {
+  name: string
+  description: string
+  ruleId: string
+  score: number
+}
+
+function normalizeText(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+function matchesRule(input: string, rule: RepoSkillResolverRule): boolean {
+  const hasPhraseMatch =
+    rule.anyPhrases?.some(phrase => input.includes(normalizeText(phrase))) ??
+    false
+  const hasAllTermsMatch =
+    rule.allTerms?.every(term => input.includes(normalizeText(term))) ?? false
+  const hasPatternMatch = (() => {
+    if (!rule.pattern) {
+      return false
+    }
+    try {
+      return new RegExp(rule.pattern, 'i').test(input)
+    } catch {
+      return false
+    }
+  })()
+
+  return hasPhraseMatch || hasAllTermsMatch || hasPatternMatch
+}
+
+function ruleScore(rule: RepoSkillResolverRule): number {
+  if (rule.anyPhrases?.length) {
+    return 4
+  }
+  if (rule.allTerms?.length) {
+    return Math.max(3, rule.allTerms.length)
+  }
+  if (rule.pattern) {
+    return 2
+  }
+  return 1
+}
+
+async function readResolverConfigs(
+  projectRoot: string,
+): Promise<RepoSkillResolverConfig[]> {
+  const skillsDir = join(projectRoot, '.claude', 'skills')
+  let entries: Awaited<ReturnType<typeof readdir>>
+
+  try {
+    entries = await readdir(skillsDir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+
+  const configs = await Promise.all(
+    entries
+      .filter(entry => entry.isDirectory())
+      .map(async entry => {
+        try {
+          const raw = await readFile(
+            join(skillsDir, entry.name, 'resolver-trigger.json'),
+            'utf8',
+          )
+          const parsed = safeParseJSON(raw, false)
+          if (
+            !parsed ||
+            typeof parsed !== 'object' ||
+            !('skill' in parsed) ||
+            typeof parsed.skill !== 'string' ||
+            !('rules' in parsed) ||
+            !Array.isArray(parsed.rules)
+          ) {
+            return null
+          }
+
+          const rules = parsed.rules.filter(
+            (rule): rule is RepoSkillResolverRule =>
+              !!rule &&
+              typeof rule === 'object' &&
+              'id' in rule &&
+              typeof rule.id === 'string',
+          )
+
+          if (rules.length === 0) {
+            return null
+          }
+
+          return {
+            skill: parsed.skill,
+            description:
+              'description' in parsed && typeof parsed.description === 'string'
+                ? parsed.description
+                : undefined,
+            rules,
+          } satisfies RepoSkillResolverConfig
+        } catch {
+          return null
+        }
+      }),
+  )
+
+  return configs.filter(config => config !== null)
+}
+
+function findCommandBySkillName(
+  commands: Command[],
+  skillName: string,
+): Command | null {
+  return (
+    commands.find(command => {
+      const commandName = getCommandName(command)
+      return command.name === skillName || commandName === skillName
+    }) ?? null
+  )
+}
+
+export async function findRepoResolverMatches(
+  input: string,
+  commands: Command[],
+  projectRoot: string,
+): Promise<RepoSkillResolverMatch[]> {
+  const normalizedInput = normalizeText(input)
+  if (!normalizedInput) {
+    return []
+  }
+
+  const configs = await readResolverConfigs(projectRoot)
+  const matches: RepoSkillResolverMatch[] = []
+
+  for (const config of configs) {
+    const command = findCommandBySkillName(commands, config.skill)
+    if (!command) {
+      continue
+    }
+
+    for (const rule of config.rules) {
+      if (!matchesRule(normalizedInput, rule)) {
+        continue
+      }
+
+      matches.push({
+        name: getCommandName(command),
+        description: command.description || config.description || config.skill,
+        ruleId: rule.id,
+        score: ruleScore(rule),
+      })
+    }
+  }
+
+  return matches.sort((left, right) => right.score - left.score)
+}

--- a/src 2/utils/skills/repoSkillResolver.ts
+++ b/src 2/utils/skills/repoSkillResolver.ts
@@ -75,6 +75,7 @@ async function readResolverConfigs(
   const configs = await Promise.all(
     entries
       .filter(entry => entry.isDirectory())
+      .sort((left, right) => left.name.localeCompare(right.name))
       .map(async entry => {
         try {
           const raw = await readFile(
@@ -167,5 +168,14 @@ export async function findRepoResolverMatches(
     }
   }
 
-  return matches.sort((left, right) => right.score - left.score)
+  return matches.sort((left, right) => {
+    if (right.score !== left.score) {
+      return right.score - left.score
+    }
+    const nameCmp = left.name.localeCompare(right.name)
+    if (nameCmp !== 0) {
+      return nameCmp
+    }
+    return left.ruleId.localeCompare(right.ruleId)
+  })
 }


### PR DESCRIPTION
This PR adds a repo-local permanent-structural-fix skill, resolver rules, eval fixtures, duplicate audits, and a daily GitHub workflow so failure hardening becomes a standing repo capability instead of one-off work. It adds deterministic runtime support in the rebuilt CLI for repo skill resolution and autoloading, including the live attachment/message/processUserInput wiring that can preload matching inline or forked skills on the main prompt path. It also adds structural-fix smoke and resolver-eval scripts plus unit and end-to-end tests for resolver matching, autoload selection, and processUserInput ordering. Verification: bun run structural-fix:daily.