### PR TITLE
Add KAIROS session memory and recall

### DIFF
--- a/src 2/commands/kairos-memory-proposals.ts
+++ b/src 2/commands/kairos-memory-proposals.ts
@@ -1,0 +1,69 @@
+import {
+  acceptMemoryProposal,
+  listPendingMemoryProposals,
+  rejectMemoryProposal,
+  renderMemoryProposalDiff,
+  wipeAllKairosMemoryArtifacts,
+} from '../services/memory/proposalQueue.js'
+
+const MEMORY_PROPOSALS_HELP = `Usage:
+/kairos memory-proposals list
+/kairos memory-proposals diff <id>
+/kairos memory-proposals accept <id>
+/kairos memory-proposals reject <id>`
+
+const MEMORY_HELP = `Usage:
+/kairos memory wipe --confirm`
+
+export async function runKairosMemoryProposalsCommand(
+  rest: string[],
+): Promise<string> {
+  const [subcommand, id] = rest
+
+  switch (subcommand) {
+    case 'list': {
+      const proposals = listPendingMemoryProposals()
+      if (proposals.length === 0) {
+        return 'No pending memory proposals.'
+      }
+      return proposals
+        .map(
+          proposal =>
+            `- ${proposal.id} [${proposal.kind}] ${proposal.content} (session ${proposal.evidence_session_id})`,
+        )
+        .join('\n')
+    }
+    case 'diff': {
+      if (!id) return MEMORY_PROPOSALS_HELP
+      return renderMemoryProposalDiff(id)
+    }
+    case 'accept': {
+      if (!id) return MEMORY_PROPOSALS_HELP
+      const accepted = acceptMemoryProposal(id)
+      return [
+        `Accepted proposal ${accepted.proposal.id}.`,
+        `Updated: ${accepted.targetPath}`,
+        `Backup: ${accepted.backupPath}`,
+      ].join('\n')
+    }
+    case 'reject': {
+      if (!id) return MEMORY_PROPOSALS_HELP
+      const rejected = rejectMemoryProposal(id)
+      return `Rejected proposal ${rejected.id}.`
+    }
+    default:
+      return MEMORY_PROPOSALS_HELP
+  }
+}
+
+export async function runKairosMemoryCommand(rest: string[]): Promise<string> {
+  const [subcommand, confirm] = rest
+  if (subcommand !== 'wipe') {
+    return MEMORY_HELP
+  }
+  if (confirm !== '--confirm') {
+    return 'Refusing to wipe memory without --confirm.'
+  }
+  wipeAllKairosMemoryArtifacts()
+  return 'Wiped KAIROS session index, summaries, and proposal queue.'
+}

--- a/src 2/commands/kairos.test.ts
+++ b/src 2/commands/kairos.test.ts
@@ -237,4 +237,76 @@ describe('/kairos command', () => {
     const out = await runKairosCommand('logs 3')
     expect(out).toBe(['b', 'c', 'd'].join('\n'))
   })
+
+  test('memory-proposals list shows pending proposals', async () => {
+    const { queueMemoryProposal } = await import(
+      '../services/memory/proposalQueue.js'
+    )
+    queueMemoryProposal(
+      {
+        kind: 'fact',
+        content: 'The daemon uses FTS5-backed recall.',
+        evidence_session_id: 'sess-1',
+      },
+      { generateId: () => 'prop001' },
+    )
+
+    const out = await runKairosCommand('memory-proposals list')
+    expect(out).toContain('prop001')
+    expect(out).toContain('[fact]')
+  })
+
+  test('memory-proposals accept updates memory files', async () => {
+    const { queueMemoryProposal } = await import(
+      '../services/memory/proposalQueue.js'
+    )
+    queueMemoryProposal(
+      {
+        kind: 'preference',
+        content: 'The user prefers concise recall summaries.',
+        evidence_session_id: 'sess-2',
+      },
+      { generateId: () => 'prop002' },
+    )
+
+    const out = await runKairosCommand('memory-proposals accept prop002')
+    expect(out).toContain('Accepted proposal prop002')
+    expect(
+      readFileSync(
+        join(process.env.CLAUDE_CONFIG_DIR as string, 'USER.md'),
+        'utf8',
+      ),
+    ).toContain('concise recall summaries')
+  })
+
+  test('memory wipe requires confirmation and removes artifacts', async () => {
+    const { queueMemoryProposal } = await import(
+      '../services/memory/proposalQueue.js'
+    )
+    queueMemoryProposal(
+      {
+        kind: 'fact',
+        content: 'Session memory summaries are stored under ~/.claude/sessions/.summaries.',
+        evidence_session_id: 'sess-3',
+      },
+      { generateId: () => 'prop003' },
+    )
+
+    const refused = await runKairosCommand('memory wipe')
+    expect(refused).toContain('--confirm')
+
+    const wiped = await runKairosCommand('memory wipe --confirm')
+    expect(wiped).toContain('Wiped KAIROS session index')
+    expect(() =>
+      readFileSync(
+        join(
+          process.env.CLAUDE_CONFIG_DIR as string,
+          'memory',
+          '.pending-proposals',
+          'prop003.json',
+        ),
+        'utf8',
+      ),
+    ).toThrow()
+  })
 })

--- a/src 2/commands/kairos.ts
+++ b/src 2/commands/kairos.ts
@@ -12,6 +12,10 @@ import { readFile } from 'fs/promises'
 import { getProjectRoot } from '../bootstrap/state.js'
 import type { Command, LocalCommandCall } from '../types/command.js'
 import {
+  runKairosMemoryCommand,
+  runKairosMemoryProposalsCommand,
+} from './kairos-memory-proposals.js'
+import {
   enqueueDemoTask,
   optInProject,
   optOutProject,
@@ -39,7 +43,9 @@ const HELP_TEXT = `Usage:
 /kairos pause
 /kairos resume
 /kairos dashboard
-/kairos logs [projectDir] [lines]`
+/kairos logs [projectDir] [lines]
+/kairos memory-proposals list|diff|accept|reject
+/kairos memory wipe --confirm`
 
 type Subcommand =
   | 'status'
@@ -51,6 +57,8 @@ type Subcommand =
   | 'resume'
   | 'dashboard'
   | 'logs'
+  | 'memory-proposals'
+  | 'memory'
 
 const SUBCOMMANDS = new Set<Subcommand>([
   'status',
@@ -62,6 +70,8 @@ const SUBCOMMANDS = new Set<Subcommand>([
   'resume',
   'dashboard',
   'logs',
+  'memory-proposals',
+  'memory',
 ])
 
 function parseArgs(args: string): { sub: Subcommand | null; rest: string[] } {
@@ -228,6 +238,10 @@ export async function runKairosCommand(args: string): Promise<string> {
       }
       return handleLogs(undefined, first)
     }
+    case 'memory-proposals':
+      return runKairosMemoryProposalsCommand(rest)
+    case 'memory':
+      return runKairosMemoryCommand(rest)
   }
 }
 
@@ -245,7 +259,8 @@ const kairos = {
   type: 'local',
   name: 'kairos',
   description: 'Inspect and control the KAIROS background daemon',
-  argumentHint: 'status|list|opt-in|opt-out|demo|pause|resume|dashboard|logs',
+  argumentHint:
+    'status|list|opt-in|opt-out|demo|pause|resume|dashboard|logs|memory-proposals|memory',
   supportsNonInteractive: true,
   load: () => Promise.resolve({ call }),
 } satisfies Command

--- a/src 2/services/autoDream/autoDream.ts
+++ b/src 2/services/autoDream/autoDream.ts
@@ -43,6 +43,7 @@ import {
   recordConsolidation,
 } from './consolidationLock.js'
 import { scheduleKairosDreamTask } from './kairosDreamTask.js'
+import { scheduleKairosSessionMemoryTask } from '../memory/sessionSummaryTask.js'
 import {
   registerDreamTask,
   addDreamTurn,
@@ -180,11 +181,20 @@ export function initAutoDream(): void {
     // scheduleKairosDreamTask handles the inner loop; the lock stamp
     // handles restart cases after the daemon has fired + deleted the task.
     if (getKairosActive()) {
+      const sessionMemoryResult = await scheduleKairosSessionMemoryTask({
+        transcriptDir: getProjectDir(getOriginalCwd()),
+        sessionIds,
+      })
       const result = await scheduleKairosDreamTask({
         memoryRoot: getAutoMemPath(),
         transcriptDir: getProjectDir(getOriginalCwd()),
         sessionIds,
       })
+      if (sessionMemoryResult.scheduled) {
+        logEvent('tengu_session_memory_scheduled_kairos', {
+          sessions_since: sessionIds.length,
+        })
+      }
       if (result.scheduled) {
         logEvent('tengu_auto_dream_scheduled_kairos', {
           sessions_since: sessionIds.length,

--- a/src 2/services/memory/config.ts
+++ b/src 2/services/memory/config.ts
@@ -1,0 +1,41 @@
+import { getInitialSettings } from '../../utils/settings/settings.js'
+import { DEFAULT_SESSION_MEMORY_RETENTION_DAYS } from './paths.js'
+
+type KairosMemorySettings = {
+  kairos?: {
+    memory?: {
+      index?: {
+        enabled?: boolean
+      }
+      curation?: {
+        enabled?: boolean
+      }
+      retentionDays?: number
+      scoreFloor?: number
+    }
+  }
+}
+
+function getKairosMemorySettings(): KairosMemorySettings['kairos']['memory'] {
+  return (getInitialSettings() as KairosMemorySettings).kairos?.memory
+}
+
+export function isKairosMemoryIndexEnabled(): boolean {
+  return getKairosMemorySettings()?.index?.enabled ?? true
+}
+
+export function isKairosMemoryCurationEnabled(): boolean {
+  return getKairosMemorySettings()?.curation?.enabled ?? false
+}
+
+export function getKairosMemoryRetentionDays(): number {
+  const raw = getKairosMemorySettings()?.retentionDays
+  return typeof raw === 'number' && raw > 0
+    ? Math.floor(raw)
+    : DEFAULT_SESSION_MEMORY_RETENTION_DAYS
+}
+
+export function getKairosMemoryScoreFloor(): number {
+  const raw = getKairosMemorySettings()?.scoreFloor
+  return typeof raw === 'number' && raw >= 0 && raw <= 1 ? raw : 0.18
+}

--- a/src 2/services/memory/curationProposer.ts
+++ b/src 2/services/memory/curationProposer.ts
@@ -1,0 +1,108 @@
+export type MemoryProposalKind = 'fact' | 'preference' | 'pattern'
+
+export type MemoryProposalInput = {
+  kind: MemoryProposalKind
+  content: string
+  evidence_session_id: string
+}
+
+export type SessionSummary = {
+  session_id: string
+  project: string
+  when: string
+  one_liner: string
+  topics: string[]
+  decisions: string[]
+  open_loops: string[]
+}
+
+const MAX_PROPOSAL_CONTENT = 280
+
+function compactWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+export function validateMemoryProposal(
+  proposal: MemoryProposalInput,
+): MemoryProposalInput {
+  const content = compactWhitespace(proposal.content)
+  if (!content) {
+    throw new Error('Memory proposal content must be non-empty.')
+  }
+  if (content.length > MAX_PROPOSAL_CONTENT) {
+    throw new Error(
+      `Memory proposal content must be <= ${MAX_PROPOSAL_CONTENT} characters.`,
+    )
+  }
+  return {
+    kind: proposal.kind,
+    content,
+    evidence_session_id: compactWhitespace(proposal.evidence_session_id),
+  }
+}
+
+export function chooseMemoryTargetFile(kind: MemoryProposalKind): 'MEMORY.md' | 'USER.md' {
+  return kind === 'fact' ? 'MEMORY.md' : 'USER.md'
+}
+
+function detectKind(content: string): MemoryProposalKind | null {
+  const lower = content.toLowerCase()
+  if (
+    lower.includes('prefer ') ||
+    lower.includes('preference') ||
+    lower.includes('likes ')
+  ) {
+    return 'preference'
+  }
+  if (
+    lower.includes('always ') ||
+    lower.includes('workflow') ||
+    lower.includes('pattern') ||
+    lower.includes('usually ')
+  ) {
+    return 'pattern'
+  }
+  if (
+    lower.includes('use ') ||
+    lower.includes('uses ') ||
+    lower.includes('stores ') ||
+    lower.includes('lives ') ||
+    lower.includes('is ')
+  ) {
+    return 'fact'
+  }
+  return null
+}
+
+function pickCandidates(summary: SessionSummary): string[] {
+  return [...summary.decisions, ...summary.open_loops].map(compactWhitespace)
+}
+
+export function deriveMemoryProposalsFromSummary(
+  summary: SessionSummary,
+): MemoryProposalInput[] {
+  const seen = new Set<string>()
+  const proposals: MemoryProposalInput[] = []
+
+  for (const candidate of pickCandidates(summary)) {
+    if (!candidate) continue
+    const kind = detectKind(candidate)
+    if (kind === null) continue
+    const content = candidate.endsWith('.') ? candidate : `${candidate}.`
+    const key = `${kind}:${content.toLowerCase()}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    proposals.push(
+      validateMemoryProposal({
+        kind,
+        content,
+        evidence_session_id: summary.session_id,
+      }),
+    )
+    if (proposals.length >= 3) {
+      break
+    }
+  }
+
+  return proposals
+}

--- a/src 2/services/memory/paths.ts
+++ b/src 2/services/memory/paths.ts
@@ -1,0 +1,48 @@
+import { mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+
+export const DEFAULT_SESSION_MEMORY_RETENTION_DAYS = 90
+
+export function getKairosMemoryRoot(): string {
+  return join(getClaudeConfigHomeDir(), 'memory')
+}
+
+export function getSessionIndexPath(): string {
+  return join(getKairosMemoryRoot(), 'sessions.db')
+}
+
+export function getSessionSummariesDir(): string {
+  return join(getClaudeConfigHomeDir(), 'sessions', '.summaries')
+}
+
+export function getSessionSummaryPath(sessionId: string): string {
+  return join(getSessionSummariesDir(), `${sessionId}.json`)
+}
+
+export function getPendingProposalDir(): string {
+  return join(getKairosMemoryRoot(), '.pending-proposals')
+}
+
+export function getArchivedProposalDir(): string {
+  return join(getKairosMemoryRoot(), '.archived-proposals')
+}
+
+export function getMemoryBackupDir(): string {
+  return join(getKairosMemoryRoot(), 'backups')
+}
+
+export function ensureKairosMemoryDirs(): void {
+  mkdirSync(getKairosMemoryRoot(), { recursive: true, mode: 0o700 })
+  mkdirSync(getSessionSummariesDir(), { recursive: true, mode: 0o700 })
+  mkdirSync(getPendingProposalDir(), { recursive: true, mode: 0o700 })
+  mkdirSync(getArchivedProposalDir(), { recursive: true, mode: 0o700 })
+  mkdirSync(getMemoryBackupDir(), { recursive: true, mode: 0o700 })
+}
+
+export function wipeKairosMemoryArtifacts(): void {
+  rmSync(getSessionIndexPath(), { force: true })
+  rmSync(getSessionSummariesDir(), { recursive: true, force: true })
+  rmSync(getPendingProposalDir(), { recursive: true, force: true })
+  rmSync(getArchivedProposalDir(), { recursive: true, force: true })
+}

--- a/src 2/services/memory/proposalQueue.test.ts
+++ b/src 2/services/memory/proposalQueue.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import {
+  acceptMemoryProposal,
+  listPendingMemoryProposals,
+  queueMemoryProposal,
+  rejectMemoryProposal,
+  wipeAllKairosMemoryArtifacts,
+} from './proposalQueue.js'
+import { getArchivedProposalDir } from './paths.js'
+
+const TEMP_DIRS: string[] = []
+
+function makeConfigDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-proposal-test-'))
+  TEMP_DIRS.push(dir)
+  writeFileSync(join(dir, 'settings.json'), JSON.stringify({}))
+  return dir
+}
+
+beforeEach(() => {
+  process.env.CLAUDE_CONFIG_DIR = makeConfigDir()
+  resetSettingsCache()
+})
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  resetSettingsCache()
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('proposalQueue', () => {
+  test('accept writes to MEMORY.md with a backup', () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string
+    writeFileSync(join(configDir, 'MEMORY.md'), '- existing item\n')
+    const proposal = queueMemoryProposal(
+      {
+        kind: 'fact',
+        content: 'The system stores session recall in SQLite FTS5.',
+        evidence_session_id: 'sess-a',
+      },
+      { generateId: () => 'accept01' },
+    )
+
+    const accepted = acceptMemoryProposal(proposal.id)
+
+    expect(readFileSync(accepted.targetPath, 'utf8')).toContain(
+      'SQLite FTS5',
+    )
+    expect(readFileSync(accepted.backupPath, 'utf8')).toContain('existing item')
+    expect(listPendingMemoryProposals()).toEqual([])
+  })
+
+  test('reject archives the proposal without touching memory files', () => {
+    const proposal = queueMemoryProposal(
+      {
+        kind: 'pattern',
+        content: 'Always review the proposal queue before promoting memory.',
+        evidence_session_id: 'sess-b',
+      },
+      { generateId: () => 'reject01' },
+    )
+
+    const rejected = rejectMemoryProposal(proposal.id)
+
+    expect(rejected.id).toBe('reject01')
+    expect(readdirSync(getArchivedProposalDir())).toContain('reject01.json')
+  })
+
+  test('wipe removes queued artifacts', () => {
+    queueMemoryProposal(
+      {
+        kind: 'preference',
+        content: 'The user prefers concise summaries.',
+        evidence_session_id: 'sess-c',
+      },
+      { generateId: () => 'wipe01' },
+    )
+
+    wipeAllKairosMemoryArtifacts()
+
+    expect(() => readdirSync(getArchivedProposalDir())).toThrow()
+  })
+})

--- a/src 2/services/memory/proposalQueue.ts
+++ b/src 2/services/memory/proposalQueue.ts
@@ -1,0 +1,188 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { basename, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import {
+  chooseMemoryTargetFile,
+  type MemoryProposalInput,
+  validateMemoryProposal,
+} from './curationProposer.js'
+import {
+  ensureKairosMemoryDirs,
+  getArchivedProposalDir,
+  getMemoryBackupDir,
+  getPendingProposalDir,
+  wipeKairosMemoryArtifacts,
+} from './paths.js'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+
+export type StoredMemoryProposal = MemoryProposalInput & {
+  id: string
+  createdAt: string
+}
+
+type ArchivedProposal = StoredMemoryProposal & {
+  archivedAt: string
+  disposition: 'accepted' | 'rejected'
+}
+
+function getPendingProposalPath(id: string): string {
+  return join(getPendingProposalDir(), `${id}.json`)
+}
+
+function getArchivedProposalPath(id: string): string {
+  return join(getArchivedProposalDir(), `${id}.json`)
+}
+
+function sortByMtimeDesc(paths: string[]): string[] {
+  return [...paths].sort(
+    (left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs,
+  )
+}
+
+function readProposalFile(path: string): StoredMemoryProposal {
+  return JSON.parse(readFileSync(path, 'utf8')) as StoredMemoryProposal
+}
+
+function writeJsonFile(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  })
+}
+
+function ensureTargetMemoryFile(fileName: 'MEMORY.md' | 'USER.md'): string {
+  const targetPath = join(getClaudeConfigHomeDir(), fileName)
+  mkdirSync(getClaudeConfigHomeDir(), { recursive: true, mode: 0o700 })
+  if (!existsSync(targetPath)) {
+    writeFileSync(targetPath, '', { encoding: 'utf8', mode: 0o600 })
+  }
+  return targetPath
+}
+
+function backupMemoryFile(targetPath: string): string {
+  ensureKairosMemoryDirs()
+  const backupPath = join(
+    getMemoryBackupDir(),
+    `${basename(targetPath)}.${Date.now()}.bak`,
+  )
+  copyFileSync(targetPath, backupPath)
+  return backupPath
+}
+
+export function queueMemoryProposal(
+  proposal: MemoryProposalInput,
+  deps: { generateId?: () => string; now?: Date } = {},
+): StoredMemoryProposal {
+  ensureKairosMemoryDirs()
+  const validated = validateMemoryProposal(proposal)
+  const id = deps.generateId?.() ?? randomUUID().slice(0, 8)
+  const stored: StoredMemoryProposal = {
+    ...validated,
+    id,
+    createdAt: (deps.now ?? new Date()).toISOString(),
+  }
+  writeJsonFile(getPendingProposalPath(id), stored)
+  return stored
+}
+
+export function listPendingMemoryProposals(): StoredMemoryProposal[] {
+  ensureKairosMemoryDirs()
+  const files = readdirSync(getPendingProposalDir())
+    .filter(file => file.endsWith('.json'))
+    .map(file => join(getPendingProposalDir(), file))
+  return sortByMtimeDesc(files).map(readProposalFile)
+}
+
+export function getPendingMemoryProposal(
+  id: string,
+): StoredMemoryProposal | null {
+  const path = getPendingProposalPath(id)
+  if (!existsSync(path)) return null
+  return readProposalFile(path)
+}
+
+function archiveProposal(
+  proposal: StoredMemoryProposal,
+  disposition: ArchivedProposal['disposition'],
+): ArchivedProposal {
+  ensureKairosMemoryDirs()
+  const archived: ArchivedProposal = {
+    ...proposal,
+    archivedAt: new Date().toISOString(),
+    disposition,
+  }
+  writeJsonFile(getArchivedProposalPath(proposal.id), archived)
+  return archived
+}
+
+export function renderMemoryProposalDiff(id: string): string {
+  const proposal = getPendingMemoryProposal(id)
+  if (!proposal) {
+    throw new Error(`No pending proposal with id ${id}.`)
+  }
+  const targetName = chooseMemoryTargetFile(proposal.kind)
+  const targetPath = ensureTargetMemoryFile(targetName)
+  const existing = readFileSync(targetPath, 'utf8')
+  const line = `- ${proposal.content}`
+  const before = existing.trimEnd()
+  const after = before ? `${before}\n${line}` : line
+  return [
+    `Proposal ${proposal.id}`,
+    `Target: ${targetPath}`,
+    '',
+    '--- before',
+    before || '(empty)',
+    '+++ after',
+    after,
+  ].join('\n')
+}
+
+export function acceptMemoryProposal(id: string): {
+  proposal: StoredMemoryProposal
+  targetPath: string
+  backupPath: string
+} {
+  const proposal = getPendingMemoryProposal(id)
+  if (!proposal) {
+    throw new Error(`No pending proposal with id ${id}.`)
+  }
+  const targetName = chooseMemoryTargetFile(proposal.kind)
+  const targetPath = ensureTargetMemoryFile(targetName)
+  const backupPath = backupMemoryFile(targetPath)
+  const existing = readFileSync(targetPath, 'utf8').trimEnd()
+  const nextLine = `- ${proposal.content}`
+  const next = existing ? `${existing}\n${nextLine}\n` : `${nextLine}\n`
+  writeFileSync(targetPath, next, { encoding: 'utf8', mode: 0o600 })
+  archiveProposal(proposal, 'accepted')
+  unlinkSync(getPendingProposalPath(id))
+  return { proposal, targetPath, backupPath }
+}
+
+export function rejectMemoryProposal(id: string): StoredMemoryProposal {
+  const proposal = getPendingMemoryProposal(id)
+  if (!proposal) {
+    throw new Error(`No pending proposal with id ${id}.`)
+  }
+  archiveProposal(proposal, 'rejected')
+  unlinkSync(getPendingProposalPath(id))
+  return proposal
+}
+
+export function wipeMemoryProposalQueue(): void {
+  rmSync(getPendingProposalDir(), { recursive: true, force: true })
+  rmSync(getArchivedProposalDir(), { recursive: true, force: true })
+}
+
+export function wipeAllKairosMemoryArtifacts(): void {
+  wipeKairosMemoryArtifacts()
+}

--- a/src 2/services/memory/sessionIndex.test.ts
+++ b/src 2/services/memory/sessionIndex.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import {
+  getIndexedSessionCount,
+  pruneExpiredSessionSummaries,
+  searchSessionSummaries,
+  setSessionPinState,
+  upsertSessionSummary,
+  wipeSessionIndex,
+} from './sessionIndex.js'
+
+const TEMP_DIRS: string[] = []
+
+function makeConfigDir(settings: unknown = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-memory-index-'))
+  TEMP_DIRS.push(dir)
+  writeFileSync(join(dir, 'settings.json'), JSON.stringify(settings))
+  return dir
+}
+
+beforeEach(() => {
+  process.env.CLAUDE_CONFIG_DIR = makeConfigDir()
+  resetSettingsCache()
+})
+
+afterEach(() => {
+  wipeSessionIndex()
+  delete process.env.CLAUDE_CONFIG_DIR
+  resetSettingsCache()
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('sessionIndex', () => {
+  test('upsert is idempotent and FTS query returns the matching session', () => {
+    upsertSessionSummary({
+      session_id: 'sess-auth',
+      project: 'brasilia',
+      when: '2026-04-20T00:00:00.000Z',
+      one_liner: 'Decided how auth refresh should work.',
+      topics: ['auth', 'refresh', 'tokens'],
+      decisions: ['We decided to use refresh tokens for daemon auth.'],
+      open_loops: ['Need to document auth expiry handling.'],
+    })
+    upsertSessionSummary({
+      session_id: 'sess-auth',
+      project: 'brasilia',
+      when: '2026-04-20T00:00:00.000Z',
+      one_liner: 'Decided how auth refresh should work.',
+      topics: ['auth', 'refresh', 'tokens'],
+      decisions: ['We decided to use refresh tokens for daemon auth.'],
+      open_loops: ['Need to document auth expiry handling.'],
+    })
+    upsertSessionSummary({
+      session_id: 'sess-ui',
+      project: 'atlas',
+      when: '2026-04-21T00:00:00.000Z',
+      one_liner: 'Reviewed dashboard styling.',
+      topics: ['dashboard', 'styling'],
+      decisions: ['We will keep the current dashboard layout.'],
+      open_loops: [],
+    })
+
+    expect(getIndexedSessionCount()).toBe(2)
+
+    const result = searchSessionSummaries({
+      query: 'what did we decide about daemon auth refresh',
+      top_k: 3,
+    })
+
+    expect(result.matches).toHaveLength(1)
+    expect(result.matches[0]).toMatchObject({
+      session_id: 'sess-auth',
+    })
+  })
+
+  test('score floor prevents unrelated matches', () => {
+    upsertSessionSummary({
+      session_id: 'sess-db',
+      project: 'brasilia',
+      when: '2026-04-20T00:00:00.000Z',
+      one_liner: 'Indexed FTS5 session summaries.',
+      topics: ['fts5', 'sqlite', 'memory'],
+      decisions: ['We chose SQLite FTS5 for recall search.'],
+      open_loops: [],
+    })
+
+    const result = searchSessionSummaries({
+      query: 'gardening plans',
+      top_k: 3,
+      scoreFloor: 0.2,
+    })
+
+    expect(result.matches).toEqual([])
+  })
+
+  test('excluded sessions never appear and pinned sessions survive pruning', () => {
+    upsertSessionSummary({
+      session_id: 'old-pinned',
+      project: 'brasilia',
+      when: '2025-12-01T00:00:00.000Z',
+      one_liner: 'Pinned planning session.',
+      topics: ['planning'],
+      decisions: ['We will keep this historical plan pinned.'],
+      open_loops: [],
+    })
+    upsertSessionSummary({
+      session_id: 'old-default',
+      project: 'brasilia',
+      when: '2025-12-01T00:00:00.000Z',
+      one_liner: 'Old transient session.',
+      topics: ['transient'],
+      decisions: ['We tested a short-lived migration path.'],
+      open_loops: [],
+    })
+    upsertSessionSummary({
+      session_id: 'excluded-session',
+      project: 'brasilia',
+      when: '2026-04-20T00:00:00.000Z',
+      one_liner: 'Private session.',
+      topics: ['private'],
+      decisions: ['We discussed something excluded.'],
+      open_loops: [],
+    })
+
+    setSessionPinState('old-pinned', 'pinned')
+    setSessionPinState('excluded-session', 'excluded')
+
+    const deleted = pruneExpiredSessionSummaries(
+      new Date('2026-04-22T00:00:00.000Z'),
+    )
+    expect(deleted).toBe(1)
+
+    const result = searchSessionSummaries({
+      query: 'private excluded discussed',
+      top_k: 5,
+      scoreFloor: 0,
+    })
+    expect(result.matches).toEqual([])
+
+    const pinnedResult = searchSessionSummaries({
+      query: 'historical plan pinned',
+      top_k: 5,
+      scoreFloor: 0,
+    })
+    expect(pinnedResult.matches[0]?.session_id).toBe('old-pinned')
+  })
+})

--- a/src 2/services/memory/sessionIndex.ts
+++ b/src 2/services/memory/sessionIndex.ts
@@ -1,0 +1,325 @@
+import { Database } from 'bun:sqlite'
+import { chmodSync, closeSync, existsSync, openSync } from 'node:fs'
+import { rmSync } from 'node:fs'
+import { ensureKairosMemoryDirs, getSessionIndexPath } from './paths.js'
+import {
+  getKairosMemoryRetentionDays,
+  getKairosMemoryScoreFloor,
+  isKairosMemoryIndexEnabled,
+} from './config.js'
+import type { SessionSummary } from './curationProposer.js'
+
+export type SessionPinState = 'default' | 'pinned' | 'excluded'
+
+export type RecallMatch = {
+  session_id: string
+  one_liner: string
+  relevant_decisions: string[]
+  score: number
+}
+
+type SearchRow = {
+  session_id: string
+  project: string
+  when_iso: string
+  one_liner: string
+  topics_json: string
+  decisions_json: string
+  open_loops_json: string
+}
+
+const SEARCH_LIMIT_MULTIPLIER = 5
+
+function tokenize(value: string): string[] {
+  return Array.from(
+    new Set(
+      (value.toLowerCase().match(/[a-z0-9]+/g) ?? []).filter(
+        token => token.length >= 2,
+      ),
+    ),
+  )
+}
+
+function joinSearchable(values: string[]): string {
+  return values.join(' ').trim()
+}
+
+function buildMatchQuery(query: string): string {
+  const tokens = tokenize(query)
+  if (tokens.length === 0) {
+    return '""'
+  }
+  return tokens.map(token => `"${token}"`).join(' OR ')
+}
+
+function scoreSummary(query: string, summary: SessionSummary): number {
+  const tokens = tokenize(query)
+  if (tokens.length === 0) return 0
+
+  let score = 0
+  for (const token of tokens) {
+    if (summary.one_liner.toLowerCase().includes(token)) score += 4
+    if (summary.project.toLowerCase().includes(token)) score += 2
+    if (summary.topics.some(topic => topic.toLowerCase().includes(token)))
+      score += 3
+    if (
+      summary.decisions.some(decision => decision.toLowerCase().includes(token))
+    ) {
+      score += 3
+    }
+    if (
+      summary.open_loops.some(loop => loop.toLowerCase().includes(token))
+    ) {
+      score += 2
+    }
+  }
+
+  const max = tokens.length * 14
+  return max === 0 ? 0 : Number((score / max).toFixed(3))
+}
+
+function pickRelevantDecisions(
+  query: string,
+  summary: SessionSummary,
+): string[] {
+  const tokens = tokenize(query)
+  const matching = summary.decisions.filter(decision =>
+    tokens.some(token => decision.toLowerCase().includes(token)),
+  )
+  if (matching.length > 0) {
+    return matching.slice(0, 3)
+  }
+  return summary.decisions.slice(0, 2)
+}
+
+function createSummaryFromRow(row: SearchRow): SessionSummary {
+  return {
+    session_id: row.session_id,
+    project: row.project,
+    when: row.when_iso,
+    one_liner: row.one_liner,
+    topics: JSON.parse(row.topics_json) as string[],
+    decisions: JSON.parse(row.decisions_json) as string[],
+    open_loops: JSON.parse(row.open_loops_json) as string[],
+  }
+}
+
+function ensureIndexFile(): string {
+  ensureKairosMemoryDirs()
+  const dbPath = getSessionIndexPath()
+  if (!existsSync(dbPath)) {
+    const fd = openSync(dbPath, 'a', 0o600)
+    closeSync(fd)
+  }
+  chmodSync(dbPath, 0o600)
+  return dbPath
+}
+
+function openSessionIndex(): Database {
+  const dbPath = ensureIndexFile()
+  const db = new Database(dbPath, { create: true, strict: true })
+  db.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE IF NOT EXISTS session_summaries (
+      session_id TEXT PRIMARY KEY,
+      project TEXT NOT NULL,
+      when_iso TEXT NOT NULL,
+      one_liner TEXT NOT NULL,
+      topics_json TEXT NOT NULL,
+      decisions_json TEXT NOT NULL,
+      open_loops_json TEXT NOT NULL,
+      pin_state TEXT NOT NULL DEFAULT 'default'
+        CHECK (pin_state IN ('default', 'pinned', 'excluded'))
+    );
+    CREATE VIRTUAL TABLE IF NOT EXISTS session_search USING fts5(
+      session_id UNINDEXED,
+      project,
+      one_liner,
+      topics,
+      decisions,
+      open_loops
+    );
+  `)
+  return db
+}
+
+export function upsertSessionSummary(summary: SessionSummary): void {
+  if (!isKairosMemoryIndexEnabled()) return
+  const db = openSessionIndex()
+  try {
+    db.transaction(() => {
+      db.prepare(
+        `
+          INSERT INTO session_summaries (
+            session_id, project, when_iso, one_liner, topics_json, decisions_json, open_loops_json
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(session_id) DO UPDATE SET
+            project = excluded.project,
+            when_iso = excluded.when_iso,
+            one_liner = excluded.one_liner,
+            topics_json = excluded.topics_json,
+            decisions_json = excluded.decisions_json,
+            open_loops_json = excluded.open_loops_json
+        `,
+      ).run(
+        summary.session_id,
+        summary.project,
+        summary.when,
+        summary.one_liner,
+        JSON.stringify(summary.topics),
+        JSON.stringify(summary.decisions),
+        JSON.stringify(summary.open_loops),
+      )
+
+      db.prepare(`DELETE FROM session_search WHERE session_id = ?`).run(
+        summary.session_id,
+      )
+      db.prepare(
+        `
+          INSERT INTO session_search (
+            session_id, project, one_liner, topics, decisions, open_loops
+          ) VALUES (?, ?, ?, ?, ?, ?)
+        `,
+      ).run(
+        summary.session_id,
+        summary.project,
+        summary.one_liner,
+        joinSearchable(summary.topics),
+        joinSearchable(summary.decisions),
+        joinSearchable(summary.open_loops),
+      )
+    })()
+  } finally {
+    db.close()
+  }
+}
+
+export function searchSessionSummaries(args: {
+  query: string
+  project?: string
+  since?: string
+  top_k?: number
+  scoreFloor?: number
+}): { matches: RecallMatch[] } {
+  if (!isKairosMemoryIndexEnabled()) {
+    return { matches: [] }
+  }
+
+  const db = openSessionIndex()
+  try {
+    const topK = Math.max(1, Math.min(args.top_k ?? 5, 25))
+    const matchQuery = buildMatchQuery(args.query)
+    if (matchQuery === '""') {
+      return { matches: [] }
+    }
+    const rows = db
+      .query<SearchRow, [string, string | null, string | null, string | null, string | null]>(
+        `
+          SELECT
+            s.session_id,
+            s.project,
+            s.when_iso,
+            s.one_liner,
+            s.topics_json,
+            s.decisions_json,
+            s.open_loops_json
+          FROM session_search f
+          JOIN session_summaries s ON s.session_id = f.session_id
+          WHERE session_search MATCH ?
+            AND s.pin_state != 'excluded'
+            AND (? IS NULL OR s.project = ?)
+            AND (? IS NULL OR s.when_iso >= ?)
+          LIMIT ${topK * SEARCH_LIMIT_MULTIPLIER}
+        `,
+      )
+      .all(
+        matchQuery,
+        args.project ?? null,
+        args.project ?? null,
+        args.since ?? null,
+        args.since ?? null,
+      )
+
+    const floor = args.scoreFloor ?? getKairosMemoryScoreFloor()
+    const matches = rows
+      .map(row => {
+        const summary = createSummaryFromRow(row)
+        const score = scoreSummary(args.query, summary)
+        return {
+          session_id: summary.session_id,
+          one_liner: summary.one_liner,
+          relevant_decisions: pickRelevantDecisions(args.query, summary),
+          score,
+        } satisfies RecallMatch
+      })
+      .filter(match => match.score >= floor)
+      .sort((left, right) => right.score - left.score)
+      .slice(0, topK)
+
+    return { matches }
+  } finally {
+    db.close()
+  }
+}
+
+export function setSessionPinState(
+  sessionId: string,
+  pinState: SessionPinState,
+): void {
+  const db = openSessionIndex()
+  try {
+    db.prepare(
+      `UPDATE session_summaries SET pin_state = ? WHERE session_id = ?`,
+    ).run(pinState, sessionId)
+  } finally {
+    db.close()
+  }
+}
+
+export function pruneExpiredSessionSummaries(now = new Date()): number {
+  const db = openSessionIndex()
+  const cutoff = new Date(now)
+  cutoff.setUTCDate(cutoff.getUTCDate() - getKairosMemoryRetentionDays())
+  const cutoffIso = cutoff.toISOString()
+  try {
+    const deleted = db
+      .prepare(
+        `
+          DELETE FROM session_summaries
+          WHERE pin_state != 'pinned'
+            AND when_iso < ?
+        `,
+      )
+      .run(cutoffIso)
+    db.prepare(
+      `
+        DELETE FROM session_search
+        WHERE session_id NOT IN (
+          SELECT session_id FROM session_summaries
+        )
+      `,
+    ).run()
+    return Number(deleted.changes)
+  } finally {
+    db.close()
+  }
+}
+
+export function getIndexedSessionCount(): number {
+  const db = openSessionIndex()
+  try {
+    const row = db
+      .query<{ count: number }, []>(
+        `SELECT COUNT(*) AS count FROM session_summaries`,
+      )
+      .get()
+    return row?.count ?? 0
+  } finally {
+    db.close()
+  }
+}
+
+export function wipeSessionIndex(): void {
+  rmSync(getSessionIndexPath(), { force: true })
+}

--- a/src 2/services/memory/sessionSummaryTask.test.ts
+++ b/src 2/services/memory/sessionSummaryTask.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getProjectRoot, setProjectRoot } from '../../bootstrap/state.js'
+import {
+  buildKairosSessionMemoryPrompt,
+  hasPendingKairosSessionMemoryTask,
+  KAIROS_SESSION_MEMORY_MARKER,
+  scheduleKairosSessionMemoryTask,
+} from './sessionSummaryTask.js'
+
+const TEMP_DIRS: string[] = []
+let originalProjectRoot: string
+
+function makeProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-memory-task-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+beforeEach(() => {
+  originalProjectRoot = getProjectRoot()
+})
+
+afterEach(() => {
+  setProjectRoot(originalProjectRoot)
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('sessionSummaryTask', () => {
+  test('builds a prompt tagged with the session-memory marker', () => {
+    const prompt = buildKairosSessionMemoryPrompt({
+      transcriptDir: '/tmp/project',
+      sessionIds: ['sess-1', 'sess-2'],
+    })
+    expect(prompt.startsWith(KAIROS_SESSION_MEMORY_MARKER)).toBe(true)
+    expect(prompt).toContain('sess-1')
+    expect(prompt).toContain('summarizeAndIndexSessions')
+  })
+
+  test('schedules exactly one durable task for a batch', async () => {
+    const projectDir = makeProjectDir()
+    setProjectRoot(projectDir)
+
+    const first = await scheduleKairosSessionMemoryTask({
+      transcriptDir: join(projectDir, '.claude', 'projects'),
+      sessionIds: ['sess-1', 'sess-2'],
+    })
+    const second = await scheduleKairosSessionMemoryTask({
+      transcriptDir: join(projectDir, '.claude', 'projects'),
+      sessionIds: ['sess-1', 'sess-2'],
+    })
+
+    expect(first.scheduled).toBe(true)
+    expect(second).toEqual({ scheduled: false, reason: 'duplicate' })
+    expect(await hasPendingKairosSessionMemoryTask()).toBe(true)
+
+    const raw = readFileSync(
+      join(projectDir, '.claude', 'scheduled_tasks.json'),
+      'utf8',
+    )
+    const parsed = JSON.parse(raw) as {
+      tasks: Array<{ prompt: string; recurring?: boolean }>
+    }
+    expect(parsed.tasks).toHaveLength(1)
+    expect(parsed.tasks[0]?.prompt.startsWith(KAIROS_SESSION_MEMORY_MARKER)).toBe(true)
+    expect(parsed.tasks[0]?.recurring).toBeUndefined()
+  })
+})

--- a/src 2/services/memory/sessionSummaryTask.ts
+++ b/src 2/services/memory/sessionSummaryTask.ts
@@ -1,0 +1,56 @@
+import { logForDebugging } from '../../utils/debug.js'
+import { addCronTask, readCronTasks } from '../../utils/cronTasks.js'
+import { isKairosMemoryIndexEnabled } from './config.js'
+import { buildSessionSummaryPrompt } from './summarizeSession.js'
+import { getSessionSummaryPath } from './paths.js'
+
+export const KAIROS_SESSION_MEMORY_MARKER = '<!-- kairos-session-memory -->'
+
+const ONE_SHOT_CRON = '* * * * *'
+
+export type KairosSessionMemoryTaskInputs = {
+  sessionIds: string[]
+  transcriptDir: string
+}
+
+export function buildKairosSessionMemoryPrompt(
+  inputs: KairosSessionMemoryTaskInputs,
+): string {
+  const perSession = inputs.sessionIds
+    .map(sessionId =>
+      buildSessionSummaryPrompt({
+        sessionId,
+        transcriptPath: `${inputs.transcriptDir}/${sessionId}.jsonl`,
+        summaryPath: getSessionSummaryPath(sessionId),
+      }),
+    )
+    .join('\n\n')
+  return `${KAIROS_SESSION_MEMORY_MARKER}\n${perSession}`
+}
+
+export async function hasPendingKairosSessionMemoryTask(
+  dir?: string,
+): Promise<boolean> {
+  const tasks = await readCronTasks(dir)
+  return tasks.some(task =>
+    task.prompt.startsWith(KAIROS_SESSION_MEMORY_MARKER),
+  )
+}
+
+export async function scheduleKairosSessionMemoryTask(
+  inputs: KairosSessionMemoryTaskInputs,
+): Promise<{ scheduled: true; id: string } | { scheduled: false; reason: 'disabled' | 'duplicate' }> {
+  if (!isKairosMemoryIndexEnabled()) {
+    return { scheduled: false, reason: 'disabled' }
+  }
+  if (await hasPendingKairosSessionMemoryTask()) {
+    logForDebugging('[memory] KAIROS session-memory task already pending')
+    return { scheduled: false, reason: 'duplicate' }
+  }
+  const prompt = buildKairosSessionMemoryPrompt(inputs)
+  const id = await addCronTask(ONE_SHOT_CRON, prompt, false, true)
+  logForDebugging(
+    `[memory] scheduled KAIROS session-memory task ${id} (${inputs.sessionIds.length} sessions)`,
+  )
+  return { scheduled: true, id }
+}

--- a/src 2/services/memory/summarizeSession.test.ts
+++ b/src 2/services/memory/summarizeSession.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import { getPendingProposalDir, getSessionSummaryPath } from './paths.js'
+import { summarizeAndIndexSessions, summarizeSessionAsync } from './summarizeSession.js'
+
+const TEMP_DIRS: string[] = []
+
+function makeConfigDir(settings: unknown = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-summary-test-'))
+  TEMP_DIRS.push(dir)
+  writeFileSync(join(dir, 'settings.json'), JSON.stringify(settings))
+  return dir
+}
+
+function writeTranscript(configDir: string, projectName: string, sessionId: string): void {
+  const projectDir = join(configDir, 'projects', projectName)
+  mkdirSync(projectDir, { recursive: true })
+  writeFileSync(join(projectDir, `${sessionId}.jsonl`), [
+    JSON.stringify({
+      type: 'user',
+      message: { content: 'We need to design session memory indexing for KAIROS.' },
+    }),
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        content:
+          "We decided to use SQLite FTS5 for recall. Next step: document the score floor and pending proposal review flow.",
+      },
+    }),
+    '',
+  ].join('\n'))
+}
+
+beforeEach(() => {
+  process.env.CLAUDE_CONFIG_DIR = makeConfigDir()
+  resetSettingsCache()
+})
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  resetSettingsCache()
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('summarizeSession', () => {
+  test('produces a structured summary from a transcript', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string
+    writeTranscript(configDir, 'demo-project', 'sess-1')
+
+    const summary = await summarizeSessionAsync('sess-1')
+
+    expect(summary.session_id).toBe('sess-1')
+    expect(summary.project).toBe('demo-project')
+    expect(summary.one_liner).toContain('session memory indexing')
+    expect(summary.decisions[0]).toContain('SQLite FTS5')
+    expect(summary.open_loops[0]).toContain('score floor')
+  })
+
+  test('writes summary files idempotently and queues proposals when curation is enabled', async () => {
+    const configDir = makeConfigDir({
+      kairos: {
+        memory: {
+          curation: { enabled: true },
+        },
+      },
+    })
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    resetSettingsCache()
+    writeTranscript(configDir, 'demo-project', 'sess-2')
+
+    const first = await summarizeAndIndexSessions(['sess-2'])
+    const second = await summarizeAndIndexSessions(['sess-2'])
+
+    expect(first[0]?.changed).toBe(true)
+    expect(second[0]?.changed).toBe(false)
+    expect(first[0]?.proposals).toBeGreaterThan(0)
+
+    const summaryPath = getSessionSummaryPath('sess-2')
+    const summary = JSON.parse(readFileSync(summaryPath, 'utf8')) as {
+      session_id: string
+    }
+    expect(summary.session_id).toBe('sess-2')
+
+    expect(readdirSync(getPendingProposalDir()).length).toBeGreaterThan(0)
+  })
+})

--- a/src 2/services/memory/summarizeSession.ts
+++ b/src 2/services/memory/summarizeSession.ts
@@ -1,0 +1,353 @@
+import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { basename, dirname } from 'node:path'
+import type { MemoryProposalInput, SessionSummary } from './curationProposer.js'
+import { deriveMemoryProposalsFromSummary } from './curationProposer.js'
+import { isKairosMemoryCurationEnabled } from './config.js'
+import { queueMemoryProposal } from './proposalQueue.js'
+import {
+  getSessionSummaryPath,
+  ensureKairosMemoryDirs,
+} from './paths.js'
+import { upsertSessionSummary } from './sessionIndex.js'
+import { resolveSessionFilePath } from '../../utils/sessionStoragePortable.js'
+
+type TranscriptEntry = {
+  type?: string
+  timestamp?: string
+  uuid?: string
+  message?: {
+    content?: unknown
+  }
+}
+
+type ExtractedTranscript = {
+  sessionId: string
+  project: string
+  when: string
+  turns: Array<{ role: 'user' | 'assistant'; text: string }>
+}
+
+const STOP_WORDS = new Set([
+  'about',
+  'after',
+  'again',
+  'also',
+  'because',
+  'before',
+  'being',
+  'between',
+  'build',
+  'change',
+  'changes',
+  'claude',
+  'code',
+  'current',
+  'file',
+  'files',
+  'from',
+  'have',
+  'into',
+  'issue',
+  'just',
+  'last',
+  'more',
+  'next',
+  'only',
+  'past',
+  'project',
+  'session',
+  'should',
+  'some',
+  'than',
+  'that',
+  'their',
+  'them',
+  'then',
+  'there',
+  'these',
+  'they',
+  'this',
+  'tool',
+  'used',
+  'user',
+  'using',
+  'with',
+  'work',
+  'would',
+])
+
+function compactWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function truncate(value: string, max = 140): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max - 1).trimEnd()}…`
+}
+
+function parseContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return compactWhitespace(content)
+  }
+  if (!Array.isArray(content)) {
+    return ''
+  }
+  return compactWhitespace(
+    content
+      .flatMap(block => {
+        if (
+          typeof block === 'object' &&
+          block !== null &&
+          'type' in block &&
+          'text' in block &&
+          (block as { type?: unknown }).type === 'text' &&
+          typeof (block as { text?: unknown }).text === 'string'
+        ) {
+          return [(block as { text: string }).text]
+        }
+        return []
+      })
+      .join(' '),
+  )
+}
+
+function splitSentences(text: string): string[] {
+  return text
+    .split(/(?<=[.!?])\s+/)
+    .map(compactWhitespace)
+    .filter(Boolean)
+}
+
+function collectTopics(turns: ExtractedTranscript['turns']): string[] {
+  const frequencies = new Map<string, number>()
+  for (const turn of turns) {
+    for (const token of turn.text.toLowerCase().match(/[a-z0-9]+/g) ?? []) {
+      if (token.length < 4 || STOP_WORDS.has(token)) continue
+      frequencies.set(token, (frequencies.get(token) ?? 0) + 1)
+    }
+  }
+  return [...frequencies.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, 5)
+    .map(([token]) => token)
+}
+
+function collectByPattern(
+  turns: ExtractedTranscript['turns'],
+  pattern: RegExp,
+  limit: number,
+): string[] {
+  const seen = new Set<string>()
+  const collected: string[] = []
+  for (const turn of turns) {
+    for (const sentence of splitSentences(turn.text)) {
+      if (!pattern.test(sentence)) continue
+      const normalized = truncate(sentence, 220)
+      const key = normalized.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      collected.push(normalized)
+      if (collected.length >= limit) {
+        return collected
+      }
+    }
+  }
+  return collected
+}
+
+function summarizeExtractedTranscript(
+  extracted: ExtractedTranscript,
+): SessionSummary {
+  const assistantTurns = extracted.turns.filter(
+    turn => turn.role === 'assistant',
+  )
+  const firstUserTurn =
+    extracted.turns.find(turn => turn.role === 'user' && turn.text.length > 0)
+      ?.text ?? 'Session summary unavailable.'
+
+  const decisionsFromAssistant = collectByPattern(
+    assistantTurns,
+    /\b(decide|decision|agreed|we will|we'll|use\b|ship|plan is|settled on)\b/i,
+    5,
+  )
+  const decisions =
+    decisionsFromAssistant.length > 0
+      ? decisionsFromAssistant
+      : collectByPattern(
+          extracted.turns,
+          /\b(decide|decision|agreed|we will|we'll|use\b|ship|plan is|settled on)\b/i,
+          5,
+        )
+  const openLoopsFromAssistant = collectByPattern(
+    assistantTurns,
+    /\b(todo|follow up|next step|next up|need to|pending|remaining|open question|still need)\b/i,
+    5,
+  )
+  const openLoops =
+    openLoopsFromAssistant.length > 0
+      ? openLoopsFromAssistant
+      : collectByPattern(
+          extracted.turns,
+          /\b(todo|follow up|next step|next up|need to|pending|remaining|open question|still need)\b/i,
+          5,
+        )
+
+  return {
+    session_id: extracted.sessionId,
+    project: extracted.project,
+    when: extracted.when,
+    one_liner: truncate(firstUserTurn, 120),
+    topics: collectTopics(extracted.turns),
+    decisions,
+    open_loops: openLoops,
+  }
+}
+
+function loadTranscriptEntries(raw: string): TranscriptEntry[] {
+  return raw
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .flatMap(line => {
+      try {
+        return [JSON.parse(line) as TranscriptEntry]
+      } catch {
+        return []
+      }
+    })
+}
+
+function extractTranscript(
+  sessionId: string,
+  filePath: string,
+  projectPath: string | undefined,
+): ExtractedTranscript {
+  const raw = readFileSync(filePath, 'utf8')
+  const stat = statSync(filePath)
+  const entries = loadTranscriptEntries(raw)
+  const turns = entries
+    .flatMap(entry => {
+      if (entry.type !== 'user' && entry.type !== 'assistant') {
+        return []
+      }
+      const text = parseContent(entry.message?.content)
+      if (!text) return []
+      return [
+        {
+          role: entry.type,
+          text,
+        } as const,
+      ]
+    })
+
+  return {
+    sessionId,
+    project:
+      projectPath?.split('/').filter(Boolean).at(-1) ??
+      basename(dirname(filePath)),
+    when: stat.mtime.toISOString(),
+    turns,
+  }
+}
+
+export function buildSessionSummaryPrompt(args: {
+  sessionId: string
+  transcriptPath: string
+  summaryPath: string
+}): string {
+  return [
+    'You are running a KAIROS session-memory indexing task.',
+    `Session: ${args.sessionId}`,
+    `Transcript: ${args.transcriptPath}`,
+    `Output summary: ${args.summaryPath}`,
+    '',
+    'Use Bash once to run the local summarizer service, then stop:',
+    `bun -e "import { summarizeAndIndexSessions } from './services/memory/summarizeSession.js'; const result = await summarizeAndIndexSessions(['${args.sessionId}']); console.log(JSON.stringify(result, null, 2));"`,
+  ].join('\n')
+}
+
+export async function summarizeSessionAsync(
+  sessionId: string,
+  opts: { dir?: string } = {},
+): Promise<SessionSummary> {
+  const resolved = await resolveSessionFilePath(sessionId, opts.dir)
+  if (!resolved) {
+    throw new Error(`Unable to locate transcript for session ${sessionId}.`)
+  }
+  const extracted = extractTranscript(
+    sessionId,
+    resolved.filePath,
+    resolved.projectPath,
+  )
+  return summarizeExtractedTranscript(extracted)
+}
+
+function writeSummaryFile(summary: SessionSummary): {
+  path: string
+  changed: boolean
+} {
+  ensureKairosMemoryDirs()
+  mkdirSync(dirname(getSessionSummaryPath(summary.session_id)), {
+    recursive: true,
+    mode: 0o700,
+  })
+  const path = getSessionSummaryPath(summary.session_id)
+  const next = `${JSON.stringify(summary, null, 2)}\n`
+  const previous = (() => {
+    try {
+      return readFileSync(path, 'utf8')
+    } catch {
+      return null
+    }
+  })()
+  if (previous === next) {
+    return { path, changed: false }
+  }
+  writeFileSync(path, next, { encoding: 'utf8', mode: 0o600 })
+  return { path, changed: true }
+}
+
+function maybeQueueProposals(summary: SessionSummary): MemoryProposalInput[] {
+  if (!isKairosMemoryCurationEnabled()) {
+    return []
+  }
+  const proposals = deriveMemoryProposalsFromSummary(summary)
+  for (const proposal of proposals) {
+    queueMemoryProposal(proposal)
+  }
+  return proposals
+}
+
+export async function summarizeAndIndexSessions(
+  sessionIds: string[],
+  opts: { dir?: string } = {},
+): Promise<
+  Array<{
+    sessionId: string
+    summaryPath: string
+    changed: boolean
+    proposals: number
+  }>
+> {
+  const results: Array<{
+    sessionId: string
+    summaryPath: string
+    changed: boolean
+    proposals: number
+  }> = []
+
+  for (const sessionId of sessionIds) {
+    const summary = await summarizeSessionAsync(sessionId, opts)
+    const { path, changed } = writeSummaryFile(summary)
+    upsertSessionSummary(summary)
+    const proposals = changed ? maybeQueueProposals(summary) : []
+    results.push({
+      sessionId,
+      summaryPath: path,
+      changed,
+      proposals: proposals.length,
+    })
+  }
+
+  return results
+}

--- a/src 2/tools/RecallPastSessionsTool/RecallPastSessionsTool.test.ts
+++ b/src 2/tools/RecallPastSessionsTool/RecallPastSessionsTool.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import { upsertSessionSummary, wipeSessionIndex } from '../../services/memory/sessionIndex.js'
+import { RecallPastSessionsTool } from './RecallPastSessionsTool.js'
+
+const TEMP_DIRS: string[] = []
+
+function makeConfigDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'kairos-recall-tool-'))
+  TEMP_DIRS.push(dir)
+  writeFileSync(join(dir, 'settings.json'), JSON.stringify({}))
+  return dir
+}
+
+beforeEach(() => {
+  process.env.CLAUDE_CONFIG_DIR = makeConfigDir()
+  resetSettingsCache()
+})
+
+afterEach(() => {
+  wipeSessionIndex()
+  delete process.env.CLAUDE_CONFIG_DIR
+  resetSettingsCache()
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('RecallPastSessionsTool', () => {
+  test('returns scored matches with relevant decisions', async () => {
+    upsertSessionSummary({
+      session_id: 'sess-1',
+      project: 'brasilia',
+      when: '2026-04-21T00:00:00.000Z',
+      one_liner: 'Settled the session recall design.',
+      topics: ['recall', 'fts5', 'memory'],
+      decisions: ['We chose SQLite FTS5 for session recall.'],
+      open_loops: ['Need to define the score floor.'],
+    })
+
+    const result = await RecallPastSessionsTool.call(
+      {
+        query: 'what did we decide about session recall',
+        top_k: 5,
+      },
+      // @ts-expect-error test-only invocation without tool context
+      undefined,
+    )
+
+    expect(result.data.matches).toHaveLength(1)
+    expect(result.data.matches[0]?.session_id).toBe('sess-1')
+    expect(result.data.matches[0]?.relevant_decisions[0]).toContain('FTS5')
+    expect(result.data.matches[0]?.score).toBeGreaterThan(0)
+  })
+
+  test('validateInput rejects invalid since values', async () => {
+    const result = await RecallPastSessionsTool.validateInput!(
+      {
+        query: 'past auth work',
+        since: 'not-a-date',
+      },
+      // @ts-expect-error test-only invocation without tool context
+      undefined,
+    )
+
+    expect(result.result).toBe(false)
+  })
+})

--- a/src 2/tools/RecallPastSessionsTool/RecallPastSessionsTool.ts
+++ b/src 2/tools/RecallPastSessionsTool/RecallPastSessionsTool.ts
@@ -1,0 +1,129 @@
+import { z } from 'zod/v4'
+import type { ValidationResult } from '../../Tool.js'
+import { buildTool, type ToolDef } from '../../Tool.js'
+import { searchSessionSummaries } from '../../services/memory/sessionIndex.js'
+import { lazySchema } from '../../utils/lazySchema.js'
+
+const TOOL_NAME = 'RecallPastSessions'
+
+const inputSchema = lazySchema(() =>
+  z.strictObject({
+    query: z
+      .string()
+      .describe(
+        'Natural-language description of the past work to recall, such as "what did we decide about auth last week?"',
+      ),
+    project: z
+      .string()
+      .optional()
+      .describe('Optional project name filter.'),
+    since: z
+      .string()
+      .optional()
+      .describe('Optional ISO date filter, such as 2026-04-01T00:00:00.000Z.'),
+    top_k: z
+      .number()
+      .int()
+      .min(1)
+      .max(25)
+      .optional()
+      .describe('Maximum number of matching sessions to return.'),
+  }),
+)
+type InputSchema = ReturnType<typeof inputSchema>
+
+const outputSchema = lazySchema(() =>
+  z.object({
+    matches: z.array(
+      z.object({
+        session_id: z.string(),
+        one_liner: z.string(),
+        relevant_decisions: z.array(z.string()),
+        score: z.number(),
+      }),
+    ),
+  }),
+)
+type OutputSchema = ReturnType<typeof outputSchema>
+type Output = z.infer<OutputSchema>
+
+function validateSinceDate(value: string | undefined): ValidationResult {
+  if (!value) return { result: true }
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return {
+      result: false,
+      message: '`since` must be an ISO date string.',
+      errorCode: 1,
+    }
+  }
+  return { result: true }
+}
+
+export const RecallPastSessionsTool = buildTool({
+  name: TOOL_NAME,
+  searchHint: 'search session-memory summaries from past sessions',
+  maxResultSizeChars: 20_000,
+  async description() {
+    return (
+      'Search indexed session summaries from prior KAIROS sessions. ' +
+      'Use this when the user asks about previous decisions, plans, or unresolved work.'
+    )
+  },
+  async prompt() {
+    return (
+      'Use this tool when the user references prior sessions, earlier plans, or ' +
+      'past decisions. Pass a focused query, and optionally narrow by project ' +
+      'or date when the user gives that context.'
+    )
+  },
+  get inputSchema(): InputSchema {
+    return inputSchema()
+  },
+  get outputSchema(): OutputSchema {
+    return outputSchema()
+  },
+  isConcurrencySafe() {
+    return true
+  },
+  isReadOnly() {
+    return true
+  },
+  toAutoClassifierInput(input) {
+    return [input.query, input.project, input.since].filter(Boolean).join('\n')
+  },
+  async validateInput(input) {
+    if (!input.query.trim()) {
+      return {
+        result: false,
+        message: '`query` must be non-empty.',
+        errorCode: 1,
+      }
+    }
+    return validateSinceDate(input.since)
+  },
+  renderToolUseMessage(input) {
+    return `Searching past sessions for "${input.query}"`
+  },
+  mapToolResultToToolResultBlockParam(output, toolUseID) {
+    const count = output.matches.length
+    return {
+      tool_use_id: toolUseID,
+      type: 'tool_result',
+      content:
+        count === 0
+          ? 'No relevant past sessions found.'
+          : `Found ${count} past session${count === 1 ? '' : 's'}.`,
+    }
+  },
+  async call({ query, project, since, top_k }) {
+    return {
+      data: searchSessionSummaries({
+        query,
+        project,
+        since,
+        top_k,
+      }),
+    }
+  },
+} satisfies ToolDef<InputSchema, Output>)


### PR DESCRIPTION
## Summary
Adds a leaf-only KAIROS memory stack with session summarization, SQLite FTS5 indexing, proposal queue review commands, and a RecallPastSessions tool.
Hooks KAIROS AutoDream scheduling to enqueue durable session-memory tasks and extends /kairos with memory-proposals and memory wipe flows.
Includes targeted coverage for indexing, summarization idempotency, proposal accept/reject, durable task scheduling, and recall scoring.

## Verification
- bun run typecheck
- bun test 'src 2/services/memory/sessionIndex.test.ts' 'src 2/services/memory/summarizeSession.test.ts' 'src 2/services/memory/proposalQueue.test.ts' 'src 2/services/memory/sessionSummaryTask.test.ts' 'src 2/tools/RecallPastSessionsTool/RecallPastSessionsTool.test.ts' 'src 2/commands/kairos.test.ts' 'src 2/services/autoDream/autoDream.test.ts'