### PR TITLE
feat(kairos): self-improving skills loop (closes #38)

### DIFF
--- a/src 2/commands/kairos-skill-improvements.test.ts
+++ b/src 2/commands/kairos-skill-improvements.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runSkillImprovementsCommand } from './kairos-skill-improvements.js'
+import {
+  getAppliedPatchPath,
+  getPendingPatchPath,
+  getRejectedPatchPath,
+  getSkillFilePath,
+} from '../services/skillLearning/paths.js'
+
+const TEMP_DIRS: string[] = []
+const ORIGINAL_CCD = process.env.CLAUDE_CONFIG_DIR
+
+afterEach(() => {
+  for (const d of TEMP_DIRS.splice(0)) rmSync(d, { recursive: true, force: true })
+  if (ORIGINAL_CCD === undefined) delete process.env.CLAUDE_CONFIG_DIR
+  else process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CCD
+})
+
+function setup(): string {
+  const d = mkdtempSync(join(tmpdir(), 'kairos-sl-cmd-'))
+  TEMP_DIRS.push(d)
+  process.env.CLAUDE_CONFIG_DIR = d
+  mkdirSync(join(d, 'skills', '.pending-improvements', 'applied'), {
+    recursive: true,
+  })
+  mkdirSync(join(d, 'skills', '.pending-improvements', 'rejected'), {
+    recursive: true,
+  })
+  mkdirSync(join(d, 'skills', '.pending-improvements', 'backups'), {
+    recursive: true,
+  })
+  return d
+}
+
+function writePending(id: string, skill: string): void {
+  writeFileSync(
+    getPendingPatchPath(id),
+    JSON.stringify({
+      id,
+      createdAt: 1_700_000_000_000,
+      patch: {
+        skill,
+        edits: [{ type: 'add_note', content: 'remember to check env files' }],
+      },
+    }),
+  )
+}
+
+function writeSkill(name: string, body: string): string {
+  const p = getSkillFilePath(name)
+  mkdirSync(join(p, '..'), { recursive: true })
+  writeFileSync(p, body)
+  return p
+}
+
+describe('runSkillImprovementsCommand', () => {
+  test('no args prints help', async () => {
+    setup()
+    const out = await runSkillImprovementsCommand([])
+    expect(out).toContain('Usage:')
+    expect(out).toContain('skill-improvements')
+  })
+
+  test('list reports empty when no pending patches', async () => {
+    setup()
+    const out = await runSkillImprovementsCommand(['list'])
+    expect(out).toBe('No pending skill improvements.')
+  })
+
+  test('list shows pending patches', async () => {
+    setup()
+    writePending('abc12345', 'investigate')
+    const out = await runSkillImprovementsCommand(['list'])
+    expect(out).toContain('abc12345')
+    expect(out).toContain('investigate')
+  })
+
+  test('diff unknown id reports not found', async () => {
+    setup()
+    const out = await runSkillImprovementsCommand(['diff', 'missing'])
+    expect(out).toContain('not found')
+  })
+
+  test('diff shows edit blocks for a pending patch', async () => {
+    setup()
+    writePending('id1', 'investigate')
+    const out = await runSkillImprovementsCommand(['diff', 'id1'])
+    expect(out).toContain('# Skill: investigate')
+    expect(out).toContain('+ remember to check env files')
+  })
+
+  test('accept applies patch, moves file, creates backup', async () => {
+    setup()
+    const skillPath = writeSkill('investigate', '# Investigate\n\nstep 1\n')
+    writePending('id2', 'investigate')
+    const out = await runSkillImprovementsCommand(['accept', 'id2'])
+    expect(out).toContain('accepted id2')
+    expect(existsSync(getPendingPatchPath('id2'))).toBe(false)
+    expect(existsSync(getAppliedPatchPath('id2'))).toBe(true)
+    const body = readFileSync(skillPath, 'utf-8')
+    expect(body).toContain('remember to check env files')
+  })
+
+  test('reject moves file to rejected without touching skill', async () => {
+    setup()
+    writeSkill('investigate', '# Investigate\n')
+    writePending('id3', 'investigate')
+    const out = await runSkillImprovementsCommand(['reject', 'id3'])
+    expect(out).toContain('rejected id3')
+    expect(existsSync(getRejectedPatchPath('id3'))).toBe(true)
+  })
+
+  test('accept fails cleanly when live skill file is missing', async () => {
+    setup()
+    writePending('id4', 'nonexistent')
+    const out = await runSkillImprovementsCommand(['accept', 'id4'])
+    expect(out).toContain('failed to apply id4')
+    // Patch must remain pending when apply fails.
+    expect(existsSync(getPendingPatchPath('id4'))).toBe(true)
+  })
+
+  test('rejects unknown action', async () => {
+    setup()
+    const out = await runSkillImprovementsCommand(['bogus'])
+    expect(out).toContain("unknown subcommand 'bogus'")
+  })
+})

--- a/src 2/commands/kairos-skill-improvements.ts
+++ b/src 2/commands/kairos-skill-improvements.ts
@@ -1,0 +1,100 @@
+// Handler for `/kairos skill-improvements {list|diff|accept|reject}`.
+//
+// Kept in its own file so the parent /kairos dispatcher stays terse and
+// this can be unit-tested in isolation.
+
+import { applySkillPatch, SkillPatchApplyError } from '../services/skillLearning/applyPatch.js'
+import {
+  listPendingPatches,
+  loadPatchById,
+  movePatchTo,
+  renderPatchDiff,
+} from '../services/skillLearning/reviewQueue.js'
+
+export type SkillImprovementsAction = 'list' | 'diff' | 'accept' | 'reject'
+
+const ACTIONS = new Set<SkillImprovementsAction>([
+  'list',
+  'diff',
+  'accept',
+  'reject',
+])
+
+const HELP = `Usage:
+/kairos skill-improvements list
+/kairos skill-improvements diff <id>
+/kairos skill-improvements accept <id>
+/kairos skill-improvements reject <id>`
+
+export async function runSkillImprovementsCommand(args: string[]): Promise<string> {
+  const [action, id] = args
+  if (!action) return HELP
+  if (!ACTIONS.has(action as SkillImprovementsAction)) {
+    return `unknown subcommand '${action}'\n\n${HELP}`
+  }
+  switch (action as SkillImprovementsAction) {
+    case 'list':
+      return handleList()
+    case 'diff':
+      if (!id) return 'diff requires a patch id'
+      return handleDiff(id)
+    case 'accept':
+      if (!id) return 'accept requires a patch id'
+      return handleAccept(id)
+    case 'reject':
+      if (!id) return 'reject requires a patch id'
+      return handleReject(id)
+  }
+}
+
+async function handleList(): Promise<string> {
+  const patches = await listPendingPatches()
+  if (patches.length === 0) return 'No pending skill improvements.'
+  return patches
+    .map(p => {
+      const ts = new Date(p.createdAt).toISOString()
+      return `${p.id}  ${ts}  ${p.patch.skill}  (${p.patch.edits.length} edit${
+        p.patch.edits.length === 1 ? '' : 's'
+      })`
+    })
+    .join('\n')
+}
+
+async function handleDiff(id: string): Promise<string> {
+  const patch = await loadPatchById(id)
+  if (!patch) return `patch ${id} not found`
+  return renderPatchDiff(patch.patch)
+}
+
+async function handleAccept(id: string): Promise<string> {
+  const patch = await loadPatchById(id)
+  if (!patch) return `patch ${id} not found`
+  if (patch.status !== 'pending') {
+    return `patch ${id} is already ${patch.status}`
+  }
+  try {
+    const applied = await applySkillPatch(patch.patch)
+    await movePatchTo(id, 'applied')
+    return [
+      `accepted ${id}`,
+      `skill: ${applied.skillPath}`,
+      `backup: ${applied.backupPath}`,
+      `edits applied: ${applied.editsApplied}`,
+    ].join('\n')
+  } catch (error) {
+    if (error instanceof SkillPatchApplyError) {
+      return `failed to apply ${id}: ${error.message}`
+    }
+    throw error
+  }
+}
+
+async function handleReject(id: string): Promise<string> {
+  const patch = await loadPatchById(id)
+  if (!patch) return `patch ${id} not found`
+  if (patch.status !== 'pending') {
+    return `patch ${id} is already ${patch.status}`
+  }
+  await movePatchTo(id, 'rejected')
+  return `rejected ${id}`
+}

--- a/src 2/commands/kairos.ts
+++ b/src 2/commands/kairos.ts
@@ -16,6 +16,7 @@ import {
   runKairosMemoryProposalsCommand,
 } from './kairos-memory-proposals.js'
 import { runKairosSkillsInteropCommand } from './kairos-skills-interop.js'
+import { runSkillImprovementsCommand } from './kairos-skill-improvements.js'
 import {
   enqueueDemoTask,
   optInProject,
@@ -48,6 +49,7 @@ const HELP_TEXT = `Usage:
 /kairos skills lint <path|skill-name|manifest-json>
 /kairos skills import <url|path|manifest-json> [--yes] [--overwrite]
 /kairos skills export <path|skill-name> [--publish]
+/kairos skill-improvements list|diff|accept|reject [id]
 /kairos memory-proposals list|diff|accept|reject
 /kairos memory wipe --confirm`
 
@@ -62,6 +64,7 @@ type Subcommand =
   | 'dashboard'
   | 'logs'
   | 'skills'
+  | 'skill-improvements'
   | 'memory-proposals'
   | 'memory'
 
@@ -76,6 +79,7 @@ const SUBCOMMANDS = new Set<Subcommand>([
   'dashboard',
   'logs',
   'skills',
+  'skill-improvements',
   'memory-proposals',
   'memory',
 ])
@@ -248,6 +252,8 @@ export async function runKairosCommand(args: string): Promise<string> {
       return runKairosSkillsInteropCommand(
         args.trim().slice('skills'.length).trim(),
       )
+    case 'skill-improvements':
+      return runSkillImprovementsCommand(rest)
     case 'memory-proposals':
       return runKairosMemoryProposalsCommand(rest)
     case 'memory':
@@ -260,7 +266,7 @@ const kairos = {
   name: 'kairos',
   description: 'Inspect and control the KAIROS background daemon',
   argumentHint:
-    'status|list|opt-in|opt-out|demo|pause|resume|dashboard|logs|skills|memory-proposals|memory',
+    'status|list|opt-in|opt-out|demo|pause|resume|dashboard|logs|skills|skill-improvements|memory-proposals|memory',
   load: () => import('./kairos-ui.js'),
 } satisfies Command
 

--- a/src 2/daemon/kairos/childRunner.test.ts
+++ b/src 2/daemon/kairos/childRunner.test.ts
@@ -114,6 +114,109 @@ describe('childRunner.runChild', () => {
     expect(finishedEvents).toHaveLength(1)
   })
 
+  test('emits tool_used for each tool_use block in assistant messages', async () => {
+    const events: ChildEvent[] = []
+    const { launcher } = makeLauncher([
+      {
+        type: 'assistant',
+        session_id: 'sess-tu',
+        message: {
+          content: [
+            { type: 'text', text: 'invoking a skill' },
+            {
+              type: 'tool_use',
+              id: 't1',
+              name: 'Skill',
+              input: { skill: 'investigate' },
+            },
+            {
+              type: 'tool_use',
+              id: 't2',
+              name: 'Read',
+              input: { file_path: '/tmp/x' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        total_cost_usd: 0,
+        session_id: 'sess-tu',
+      },
+    ])
+
+    await runChild(
+      {
+        taskId: 't-tu',
+        prompt: 'hi',
+        projectDir: '/tmp/proj',
+        allowedTools: ['Read', 'Skill'],
+        runId: 'run-tu',
+      },
+      {
+        launcher,
+        onEvent: e => {
+          events.push(e)
+        },
+        now: makeNow(1_700_000_000_000),
+      },
+    )
+
+    const toolUsed = events.filter(e => e.kind === 'tool_used')
+    expect(toolUsed).toHaveLength(2)
+    // Order preserved.
+    expect(toolUsed[0]).toMatchObject({
+      kind: 'tool_used',
+      runId: 'run-tu',
+      toolName: 'Skill',
+      toolInput: { skill: 'investigate' },
+      sessionId: 'sess-tu',
+    })
+    expect(toolUsed[1]).toMatchObject({
+      kind: 'tool_used',
+      runId: 'run-tu',
+      toolName: 'Read',
+    })
+  })
+
+  test('assistant message with no tool_use blocks emits no tool_used events', async () => {
+    const events: ChildEvent[] = []
+    const { launcher } = makeLauncher([
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'no tools here' }] },
+      },
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        num_turns: 1,
+        total_cost_usd: 0,
+      },
+    ])
+
+    await runChild(
+      {
+        taskId: 't-no-tu',
+        prompt: 'hi',
+        projectDir: '/tmp/proj',
+        allowedTools: ['Read'],
+      },
+      {
+        launcher,
+        onEvent: e => {
+          events.push(e)
+        },
+        now: makeNow(1_700_000_000_000),
+      },
+    )
+
+    expect(events.some(e => e.kind === 'tool_used')).toBe(false)
+  })
+
   test('tool allowlist boundary: launcher receives exactly the configured tools', async () => {
     const { launcher, calls } = makeLauncher([
       {

--- a/src 2/daemon/kairos/childRunner.ts
+++ b/src 2/daemon/kairos/childRunner.ts
@@ -134,6 +134,17 @@ export type ChildEvent =
       sessionId?: string
     }
   | {
+      // Emitted once per tool_use content block seen in an assistant message.
+      // Used by downstream observers (e.g. skillLearning) to know which tools
+      // the child actually invoked without re-parsing the SDK stream.
+      kind: 'tool_used'
+      t: string
+      runId: string
+      toolName: string
+      toolInput?: unknown
+      sessionId?: string
+    }
+  | {
       kind: 'child_finished'
       t: string
       runId: string
@@ -188,6 +199,33 @@ function exitReasonFromResult(
     default:
       return 'error'
   }
+}
+
+export type ToolUseBlock = { name: string; input?: unknown }
+
+/**
+ * Extract `tool_use` content blocks from an assistant message. Order preserved
+ * so observers can see the invocation sequence. Unknown shapes yield [].
+ */
+export function extractToolUses(message: unknown): ToolUseBlock[] {
+  if (!message || typeof message !== 'object') return []
+  const content = (message as { content?: unknown }).content
+  if (!Array.isArray(content)) return []
+  const out: ToolUseBlock[] = []
+  for (const block of content) {
+    if (
+      block &&
+      typeof block === 'object' &&
+      (block as { type?: unknown }).type === 'tool_use' &&
+      typeof (block as { name?: unknown }).name === 'string'
+    ) {
+      out.push({
+        name: (block as { name: string }).name,
+        input: (block as { input?: unknown }).input,
+      })
+    }
+  }
+  return out
 }
 
 function extractAssistantText(message: unknown): string | undefined {
@@ -287,6 +325,16 @@ export async function runChild(
       if (message.type === 'assistant') {
         lastAssistantText =
           extractAssistantText(message.message) ?? lastAssistantText
+        for (const toolUse of extractToolUses(message.message)) {
+          await deps.onEvent({
+            kind: 'tool_used',
+            t: now().toISOString(),
+            runId,
+            toolName: toolUse.name,
+            toolInput: toolUse.input,
+            sessionId,
+          })
+        }
       }
 
       if (message.type === 'result') {

--- a/src 2/daemon/kairos/skillLearning.integration.test.ts
+++ b/src 2/daemon/kairos/skillLearning.integration.test.ts
@@ -123,6 +123,14 @@ describe('skill-learning integration via makeRunFiredTask', () => {
     expect(scheduled.tasks[0].prompt.startsWith(SKILL_LEARNING_MARKER)).toBe(
       true,
     )
+    // Per-skill sentinel — not just the generic marker — so dedupe by skill
+    // is actually observable on disk.
+    expect(scheduled.tasks[0].prompt).toContain(
+      `${SKILL_LEARNING_MARKER} skill=investigate`,
+    )
+    // Structural discriminator — worker skips observer on `kind`, not the
+    // prompt prefix.
+    expect(scheduled.tasks[0].kind).toBe('skill_distillation')
   })
 
   test('distillation tasks do not re-trigger skill-learning', async () => {
@@ -143,8 +151,14 @@ describe('skill-learning integration via makeRunFiredTask', () => {
       now,
     })
 
+    // Discriminator is the structural `kind` field, not the prompt prefix.
+    // A distillation cron task is one the daemon itself stamped with
+    // `kind: 'skill_distillation'`.
     const outcome = await runFiredTask(
-      makeTask({ prompt: `${SKILL_LEARNING_MARKER} distill me` }),
+      makeTask({
+        prompt: 'distill me',
+        kind: 'skill_distillation',
+      }),
       'event',
     )
     expect(outcome.ok).toBe(true)
@@ -152,6 +166,42 @@ describe('skill-learning integration via makeRunFiredTask', () => {
     expect(
       existsSync(join(projectDir, '.claude', 'scheduled_tasks.json')),
     ).toBe(false)
+  })
+
+  test('user-authored prompt whose text begins with the sentinel still observes skills', async () => {
+    // Regression test for review feedback: the old prompt-prefix check
+    // could mistake a user-authored task (no `kind`) for a daemon task.
+    // Under the structural-kind discriminator it must NOT be skipped.
+    const { projectDir } = setupEnv(true)
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+    const now = () => new Date('2026-04-22T12:00:00.000Z')
+
+    const runFiredTask = makeRunFiredTask({
+      projectDir,
+      stateWriter,
+      costTracker: null,
+      launcher: skillInvokingLauncher(),
+      defaultAllowedTools: ['Read', 'Skill'],
+      maxTurns: 1,
+      timeoutMs: 5000,
+      handleCapHit: makeCapHitHandler(stateWriter, now),
+      now,
+    })
+
+    // User prompt that happens to lead with the reserved HTML comment
+    // (e.g. someone copy-pasted from docs). No `kind` field → observer
+    // fires, skill is recorded, distillation is enqueued.
+    const outcome = await runFiredTask(
+      makeTask({ prompt: `${SKILL_LEARNING_MARKER} legit user task` }),
+      'event',
+    )
+    expect(outcome.ok).toBe(true)
+    const scheduled = JSON.parse(
+      readFileSync(join(projectDir, '.claude', 'scheduled_tasks.json'), 'utf-8'),
+    )
+    expect(scheduled.tasks).toHaveLength(1)
+    expect(scheduled.tasks[0].kind).toBe('skill_distillation')
   })
 
   test('feature-flag off: no marker, no scheduled task', async () => {

--- a/src 2/daemon/kairos/skillLearning.integration.test.ts
+++ b/src 2/daemon/kairos/skillLearning.integration.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getProjectRoot,
+  setProjectRoot,
+} from '../../bootstrap/state.js'
+import { SKILL_LEARNING_MARKER } from '../../services/skillLearning/distillationPrompt.js'
+import { getSkillsUsedPath } from '../../services/skillLearning/skillUseObserver.js'
+import { createStateWriter } from './stateWriter.js'
+import type { ChildLauncher, ChildStreamMessage } from './childRunner.js'
+import { makeCapHitHandler, makeRunFiredTask } from './worker.js'
+import type { CronTask } from '../../utils/cronTasks.js'
+
+const TEMP_DIRS: string[] = []
+const ORIGINAL_CCD = process.env.CLAUDE_CONFIG_DIR
+const ORIGINAL_ROOT = getProjectRoot()
+
+afterEach(() => {
+  for (const d of TEMP_DIRS.splice(0)) rmSync(d, { recursive: true, force: true })
+  if (ORIGINAL_CCD === undefined) delete process.env.CLAUDE_CONFIG_DIR
+  else process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CCD
+  setProjectRoot(ORIGINAL_ROOT)
+})
+
+function setupEnv(enabled: boolean): {
+  projectDir: string
+  configDir: string
+} {
+  const configDir = mkdtempSync(join(tmpdir(), 'kairos-sl-int-cfg-'))
+  TEMP_DIRS.push(configDir)
+  process.env.CLAUDE_CONFIG_DIR = configDir
+  mkdirSync(join(configDir, 'skills'), { recursive: true })
+
+  const projectDir = mkdtempSync(join(tmpdir(), 'kairos-sl-int-proj-'))
+  TEMP_DIRS.push(projectDir)
+  mkdirSync(join(projectDir, '.claude'), { recursive: true })
+  writeFileSync(
+    join(projectDir, '.claude', 'settings.json'),
+    JSON.stringify({ kairos: { skillLearning: { enabled } } }),
+  )
+  setProjectRoot(projectDir)
+  return { projectDir, configDir }
+}
+
+function skillInvokingLauncher(): ChildLauncher {
+  const messages: ChildStreamMessage[] = [
+    {
+      type: 'assistant',
+      session_id: 's',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 't1',
+            name: 'Skill',
+            input: { skill: 'investigate' },
+          },
+        ],
+      },
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      num_turns: 1,
+      duration_ms: 100,
+      total_cost_usd: 0,
+    },
+  ]
+  return async function* () {
+    for (const m of messages) yield m
+  }
+}
+
+function makeTask(overrides: Partial<CronTask> = {}): CronTask {
+  return {
+    id: overrides.id ?? 't-1',
+    cron: '* * * * *',
+    prompt: overrides.prompt ?? 'do the thing',
+    createdAt: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('skill-learning integration via makeRunFiredTask', () => {
+  test('successful skill-invoking run writes marker and enqueues distillation', async () => {
+    const { projectDir } = setupEnv(true)
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+    const now = () => new Date('2026-04-22T12:00:00.000Z')
+
+    const runFiredTask = makeRunFiredTask({
+      projectDir,
+      stateWriter,
+      costTracker: null,
+      launcher: skillInvokingLauncher(),
+      defaultAllowedTools: ['Read', 'Skill'],
+      maxTurns: 1,
+      timeoutMs: 5000,
+      handleCapHit: makeCapHitHandler(stateWriter, now),
+      now,
+    })
+
+    const outcome = await runFiredTask(makeTask(), 'event')
+    expect(outcome.ok).toBe(true)
+    const runId = outcome.result?.runId
+    expect(runId).toBeDefined()
+    expect(existsSync(getSkillsUsedPath(projectDir, runId!))).toBe(true)
+
+    const scheduled = JSON.parse(
+      readFileSync(join(projectDir, '.claude', 'scheduled_tasks.json'), 'utf-8'),
+    )
+    expect(scheduled.tasks).toHaveLength(1)
+    expect(scheduled.tasks[0].prompt.startsWith(SKILL_LEARNING_MARKER)).toBe(
+      true,
+    )
+  })
+
+  test('distillation tasks do not re-trigger skill-learning', async () => {
+    const { projectDir } = setupEnv(true)
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+    const now = () => new Date('2026-04-22T12:00:00.000Z')
+
+    const runFiredTask = makeRunFiredTask({
+      projectDir,
+      stateWriter,
+      costTracker: null,
+      launcher: skillInvokingLauncher(),
+      defaultAllowedTools: ['Read', 'Skill'],
+      maxTurns: 1,
+      timeoutMs: 5000,
+      handleCapHit: makeCapHitHandler(stateWriter, now),
+      now,
+    })
+
+    const outcome = await runFiredTask(
+      makeTask({ prompt: `${SKILL_LEARNING_MARKER} distill me` }),
+      'event',
+    )
+    expect(outcome.ok).toBe(true)
+    // No scheduled file written.
+    expect(
+      existsSync(join(projectDir, '.claude', 'scheduled_tasks.json')),
+    ).toBe(false)
+  })
+
+  test('feature-flag off: no marker, no scheduled task', async () => {
+    const { projectDir } = setupEnv(false)
+    const stateWriter = await createStateWriter()
+    await stateWriter.ensureProjectDir(projectDir)
+    const now = () => new Date('2026-04-22T12:00:00.000Z')
+
+    const runFiredTask = makeRunFiredTask({
+      projectDir,
+      stateWriter,
+      costTracker: null,
+      launcher: skillInvokingLauncher(),
+      defaultAllowedTools: ['Read', 'Skill'],
+      maxTurns: 1,
+      timeoutMs: 5000,
+      handleCapHit: makeCapHitHandler(stateWriter, now),
+      now,
+    })
+
+    const outcome = await runFiredTask(makeTask(), 'event')
+    expect(outcome.ok).toBe(true)
+    // Observer still writes the marker (observation is cheap, gating is in
+    // the enqueue step) — but no cron task should be scheduled.
+    expect(
+      existsSync(join(projectDir, '.claude', 'scheduled_tasks.json')),
+    ).toBe(false)
+  })
+})

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -10,8 +10,10 @@ import {
   createSdkChildLauncher,
   runChild,
 } from './childRunner.js'
-import { SKILL_LEARNING_MARKER } from '../../services/skillLearning/distillationPrompt.js'
-import { enqueueSkillDistillation } from '../../services/skillLearning/enqueueSkillDistillation.js'
+import {
+  enqueueSkillDistillation,
+  SKILL_DISTILLATION_KIND,
+} from '../../services/skillLearning/enqueueSkillDistillation.js'
 import { createRunSkillUseObserver } from '../../services/skillLearning/skillUseObserver.js'
 import {
   createCostTracker,
@@ -295,7 +297,15 @@ export function makeRunFiredTask(options: RunFiredTaskOptions) {
     const allowedTools = computeEffectiveAllowedTools(defaultAllowedTools, task)
 
     // Distillation tasks MUST NOT re-trigger their own distillation loop.
-    const isDistillationTask = task.prompt.startsWith(SKILL_LEARNING_MARKER)
+    // We discriminate on the structural `kind` field (set only by the
+    // daemon's enqueueSkillDistillation) rather than sniffing the prompt,
+    // so a user-authored cron whose prompt happens to begin with the
+    // skill-learning HTML comment can never be mistaken for one of ours.
+    // If such a distillation child itself invoked `Skill`, we'd silently
+    // skip the observer — that's fine: the distillation prompt forbids
+    // tool use beyond Read/Glob/Grep, and re-entering the loop is worse
+    // than losing a theoretical observation.
+    const isDistillationTask = task.kind === SKILL_DISTILLATION_KIND
 
     const runId = randomUUID()
     const skillObserver = isDistillationTask

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -1,4 +1,5 @@
 import { appendFile, mkdir, writeFile } from 'fs/promises'
+import { randomUUID } from 'crypto'
 import type { Writable } from 'stream'
 import type {
   ChildLauncher,
@@ -9,6 +10,9 @@ import {
   createSdkChildLauncher,
   runChild,
 } from './childRunner.js'
+import { SKILL_LEARNING_MARKER } from '../../services/skillLearning/distillationPrompt.js'
+import { enqueueSkillDistillation } from '../../services/skillLearning/enqueueSkillDistillation.js'
+import { createRunSkillUseObserver } from '../../services/skillLearning/skillUseObserver.js'
 import {
   createCostTracker,
   type CapHit,
@@ -290,6 +294,21 @@ export function makeRunFiredTask(options: RunFiredTaskOptions) {
 
     const allowedTools = computeEffectiveAllowedTools(defaultAllowedTools, task)
 
+    // Distillation tasks MUST NOT re-trigger their own distillation loop.
+    const isDistillationTask = task.prompt.startsWith(SKILL_LEARNING_MARKER)
+
+    const runId = randomUUID()
+    const skillObserver = isDistillationTask
+      ? null
+      : createRunSkillUseObserver(task.id, runId, {
+          onEvent: event =>
+            stateWriter.appendProjectEvent(projectDir, {
+              ...event,
+              source,
+              taskId: task.id,
+            }),
+        })
+
     const result = await runChild(
       {
         taskId: task.id,
@@ -298,16 +317,19 @@ export function makeRunFiredTask(options: RunFiredTaskOptions) {
         allowedTools,
         maxTurns,
         timeoutMs,
+        runId,
       },
       {
         launcher,
         now,
-        onEvent: event =>
-          stateWriter.appendProjectEvent(projectDir, {
-            ...event,
-            source,
-            taskId: task.id,
-          }),
+        onEvent:
+          skillObserver?.onEvent ??
+          (event =>
+            stateWriter.appendProjectEvent(projectDir, {
+              ...event,
+              source,
+              taskId: task.id,
+            })),
       },
     )
 
@@ -334,6 +356,39 @@ export function makeRunFiredTask(options: RunFiredTaskOptions) {
       if (capHit) {
         await handleCapHit({ capHit, projectDir, task })
         paused = true
+      }
+    }
+
+    // After accounting runs, persist the skill-use marker and enqueue a
+    // distillation cron task if any skill was invoked in a successful run.
+    // Failures short-circuit so we never distill from broken transcripts.
+    if (
+      skillObserver &&
+      result.ok &&
+      !paused &&
+      skillObserver.hasSkillUse()
+    ) {
+      try {
+        await skillObserver.finalize(projectDir)
+        await enqueueSkillDistillation({
+          projectDir,
+          runResult: result,
+          skillsUsed: {
+            runId: result.runId,
+            taskId: task.id,
+            skills: skillObserver.getSkills(),
+          },
+          now,
+        })
+      } catch (error) {
+        await stateWriter.appendProjectEvent(projectDir, {
+          kind: 'skill_learning_error',
+          t: now().toISOString(),
+          runId: result.runId,
+          taskId: task.id,
+          errorMessage:
+            error instanceof Error ? error.message : String(error),
+        })
       }
     }
 

--- a/src 2/services/skillLearning/applyPatch.ts
+++ b/src 2/services/skillLearning/applyPatch.ts
@@ -11,7 +11,7 @@
 // immediately after the first line matching the anchor; without an anchor
 // it falls back to append. Nothing is ever removed.
 
-import { copyFile, mkdir, readFile, writeFile } from 'fs/promises'
+import { copyFile, mkdir, readFile, realpath, writeFile } from 'fs/promises'
 import { resolve, sep } from 'path'
 import { isFsInaccessible } from '../../utils/errors.js'
 import {
@@ -37,10 +37,28 @@ function isInsideSkillsRoot(path: string): boolean {
   return resolved === resolve(getSkillsRoot()) || resolved.startsWith(root)
 }
 
-function countLineDelta(before: string, after: string): number {
-  // Deletion lines = max(0, beforeLines - afterLines). Additive-only applies
-  // always yield a non-negative delta; this function still exists so that a
-  // buggy apply step that *did* remove text would be caught before write.
+/**
+ * Post-read defense-in-depth check: realpath both the root and the target
+ * so a symlinked skill directory (e.g. `investigate/` → `/etc/`) is
+ * detected even though the literal path `~/.claude/skills/investigate/SKILL.md`
+ * passes the string-based `isInsideSkillsRoot` guard. Must only be called
+ * after the target file has been opened for read, since `realpath` throws
+ * on missing paths.
+ */
+async function realpathInsideSkillsRoot(path: string): Promise<boolean> {
+  const rootReal = await realpath(getSkillsRoot())
+  const targetReal = await realpath(path)
+  return (
+    targetReal === rootReal || targetReal.startsWith(rootReal + sep)
+  )
+}
+
+function countNetLineDelta(before: string, after: string): number {
+  // Net shrinkage in line count. Additive-only edits produce `afterLines
+  // >= beforeLines`, so the expected value is 0. A non-zero return means
+  // the apply step collapsed existing content — a bug symptom, not a
+  // precise count of deleted lines. Catches net removal only: a rewrite
+  // that deletes N lines and adds N new ones still returns 0.
   const beforeLines = before.split('\n').length
   const afterLines = after.split('\n').length
   return Math.max(0, beforeLines - afterLines)
@@ -112,6 +130,14 @@ export async function applySkillPatch(
     throw e
   }
 
+  // Target exists → realpath can't throw. Belt-and-suspenders against a
+  // symlinked skill directory that would escape the literal-path check.
+  if (!(await realpathInsideSkillsRoot(skillPath))) {
+    throw new SkillPatchApplyError(
+      `refusing to apply: realpath of skill escapes skills root (${skillPath})`,
+    )
+  }
+
   const backupPath = getBackupPath(patch.skill, now.toISOString())
   await mkdir(getBackupsDir(), { recursive: true })
   await copyFile(skillPath, backupPath)
@@ -121,7 +147,7 @@ export async function applySkillPatch(
     next = applyOneEdit(next, edit)
   }
 
-  const delta = countLineDelta(original, next)
+  const delta = countNetLineDelta(original, next)
   if (delta > MAX_DELETION_LINES) {
     throw new SkillPatchApplyError(
       `refusing to apply: patch would remove ${delta} lines (> ${MAX_DELETION_LINES})`,

--- a/src 2/services/skillLearning/applyPatch.ts
+++ b/src 2/services/skillLearning/applyPatch.ts
@@ -1,0 +1,137 @@
+// Apply an accepted SkillPatch to the live skill file.
+//
+// Safety invariants (non-negotiable — enforced in this order):
+//   1. Target path must resolve strictly inside ~/.claude/skills/.
+//   2. Pre-apply, copy the live file to backups/<skill>-<iso>.md.
+//   3. v1 is additive — refuse to apply if the diff would delete >10 lines.
+//
+// Implementation: edits are all additive (add_note / refine_step /
+// add_example) so the applied result is the original text + appended or
+// anchored sections. "refine_step" with an anchor inserts content
+// immediately after the first line matching the anchor; without an anchor
+// it falls back to append. Nothing is ever removed.
+
+import { copyFile, mkdir, readFile, writeFile } from 'fs/promises'
+import { resolve, sep } from 'path'
+import { isFsInaccessible } from '../../utils/errors.js'
+import {
+  getBackupPath,
+  getBackupsDir,
+  getSkillFilePath,
+  getSkillsRoot,
+} from './paths.js'
+import type { SkillEdit, SkillPatch } from './patchSchema.js'
+
+export const MAX_DELETION_LINES = 10
+
+export class SkillPatchApplyError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SkillPatchApplyError'
+  }
+}
+
+function isInsideSkillsRoot(path: string): boolean {
+  const root = resolve(getSkillsRoot()) + sep
+  const resolved = resolve(path)
+  return resolved === resolve(getSkillsRoot()) || resolved.startsWith(root)
+}
+
+function countLineDelta(before: string, after: string): number {
+  // Deletion lines = max(0, beforeLines - afterLines). Additive-only applies
+  // always yield a non-negative delta; this function still exists so that a
+  // buggy apply step that *did* remove text would be caught before write.
+  const beforeLines = before.split('\n').length
+  const afterLines = after.split('\n').length
+  return Math.max(0, beforeLines - afterLines)
+}
+
+function renderEdit(edit: SkillEdit): string {
+  switch (edit.type) {
+    case 'add_note':
+      return `\n\n> [!note] KAIROS skill-learning\n${edit.content
+        .split('\n')
+        .map(l => `> ${l}`)
+        .join('\n')}\n`
+    case 'add_example':
+      return `\n\n### Example (added by KAIROS)\n${edit.content}\n`
+    case 'refine_step':
+      return `\n\n> [!tip] KAIROS skill-learning refinement\n${edit.content
+        .split('\n')
+        .map(l => `> ${l}`)
+        .join('\n')}\n`
+  }
+}
+
+function applyOneEdit(text: string, edit: SkillEdit): string {
+  const rendered = renderEdit(edit)
+  if (edit.type !== 'refine_step' || !edit.anchor) {
+    return `${text.trimEnd()}${rendered}\n`
+  }
+  const lines = text.split('\n')
+  const idx = lines.findIndex(l => l.includes(edit.anchor!))
+  if (idx === -1) {
+    return `${text.trimEnd()}${rendered}\n`
+  }
+  const before = lines.slice(0, idx + 1).join('\n')
+  const after = lines.slice(idx + 1).join('\n')
+  return `${before}${rendered}${after.length > 0 ? '\n' + after : '\n'}`
+}
+
+export type ApplySkillPatchResult = {
+  skillPath: string
+  backupPath: string
+  editsApplied: number
+}
+
+/**
+ * Apply a validated patch to its live skill file. Throws
+ * SkillPatchApplyError if any safety check fails (target outside skills
+ * root, deletion rule tripped).
+ */
+export async function applySkillPatch(
+  patch: SkillPatch,
+  now: Date = new Date(),
+): Promise<ApplySkillPatchResult> {
+  const skillPath = getSkillFilePath(patch.skill)
+  if (!isInsideSkillsRoot(skillPath)) {
+    throw new SkillPatchApplyError(
+      `refusing to apply: skill path escapes skills root (${skillPath})`,
+    )
+  }
+
+  let original: string
+  try {
+    original = await readFile(skillPath, 'utf-8')
+  } catch (e) {
+    if (isFsInaccessible(e)) {
+      throw new SkillPatchApplyError(
+        `cannot apply patch: live skill file not found at ${skillPath}`,
+      )
+    }
+    throw e
+  }
+
+  const backupPath = getBackupPath(patch.skill, now.toISOString())
+  await mkdir(getBackupsDir(), { recursive: true })
+  await copyFile(skillPath, backupPath)
+
+  let next = original
+  for (const edit of patch.edits) {
+    next = applyOneEdit(next, edit)
+  }
+
+  const delta = countLineDelta(original, next)
+  if (delta > MAX_DELETION_LINES) {
+    throw new SkillPatchApplyError(
+      `refusing to apply: patch would remove ${delta} lines (> ${MAX_DELETION_LINES})`,
+    )
+  }
+
+  await writeFile(skillPath, next, 'utf-8')
+  return {
+    skillPath,
+    backupPath,
+    editsApplied: patch.edits.length,
+  }
+}

--- a/src 2/services/skillLearning/distillationPrompt.ts
+++ b/src 2/services/skillLearning/distillationPrompt.ts
@@ -1,0 +1,79 @@
+// Build the prompt for the short-lived child Claude run that produces a
+// single structured patch for one skill.
+//
+// Guidance baked in:
+// - additive only (add_note / refine_step / add_example)
+// - at most MAX_EDITS edits per patch
+// - output must be one JSON object, nothing else
+//
+// Sentinel marker at the top of the prompt so the daemon can identify a
+// pending distillation task without extending scheduled_tasks.json's schema.
+
+import { MAX_EDITS } from './patchSchema.js'
+
+export const SKILL_LEARNING_MARKER = '<!-- kairos-skill-learning -->'
+
+export type DistillationPromptInputs = {
+  skill: string
+  /** Path to the live SKILL.md file the distillation should read. */
+  skillFilePath: string
+  /**
+   * Path to the skills-used.json marker for the run that triggered this
+   * distillation. The child reads invocation context from here.
+   */
+  skillsUsedPath: string
+  /**
+   * Path where the daemon expects the child to write its patch.
+   * Must live inside `~/.claude/skills/.pending-improvements/`.
+   */
+  patchOutputPath: string
+  /** ISO timestamp at which the task was enqueued. */
+  enqueuedAt: string
+}
+
+export function buildDistillationPrompt(inputs: DistillationPromptInputs): string {
+  const {
+    skill,
+    skillFilePath,
+    skillsUsedPath,
+    patchOutputPath,
+    enqueuedAt,
+  } = inputs
+  return [
+    SKILL_LEARNING_MARKER,
+    '',
+    'You are the KAIROS skill-learning distiller.',
+    `Target skill: ${skill}`,
+    `Enqueued: ${enqueuedAt}`,
+    '',
+    'Your job: compare what the skill file currently instructs vs. what happened in the most recent run that used this skill. Emit at most a few tiny additive edits — notes, one-line step refinements, or small concrete examples — that would make the skill slightly more effective next time.',
+    '',
+    'Read these files:',
+    `- Skill file (read-only): ${skillFilePath}`,
+    `- Recent run invocation marker: ${skillsUsedPath}`,
+    '',
+    'Rules:',
+    '- Additive only. Do NOT rewrite, reorder, or delete existing guidance.',
+    `- At most ${MAX_EDITS} edits. Prefer 1–3. Fewer is better.`,
+    '- Each edit is one of: add_note, refine_step, add_example.',
+    '- Each edit\'s `content` is plain markdown. No frontmatter, no headings larger than H3.',
+    '- If you cannot produce a high-confidence improvement, emit zero edits by returning { "skill": "<name>", "edits": [{ "type": "add_note", "content": "(no improvement identified)" }] } — the reviewer will reject it.',
+    '- Do NOT write to any file. Do NOT invoke any tools beyond Read/Glob/Grep.',
+    '',
+    'Output: write a single JSON object to this exact path using the Write tool:',
+    `  ${patchOutputPath}`,
+    '',
+    'JSON shape (strict):',
+    '```json',
+    '{',
+    `  "skill": "${skill}",`,
+    '  "edits": [',
+    '    { "type": "add_note", "content": "..." }',
+    '  ],',
+    '  "summary": "optional one-line description"',
+    '}',
+    '```',
+    '',
+    'Return nothing else. Do not emit commentary outside the JSON object. The daemon discards any patch that fails schema validation.',
+  ].join('\n')
+}

--- a/src 2/services/skillLearning/enqueueSkillDistillation.test.ts
+++ b/src 2/services/skillLearning/enqueueSkillDistillation.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getProjectRoot,
+  setProjectRoot,
+} from '../../bootstrap/state.js'
+import { enqueueSkillDistillation } from './enqueueSkillDistillation.js'
+import { SKILL_LEARNING_MARKER } from './distillationPrompt.js'
+import type { SkillsUsedMarker } from './skillUseObserver.js'
+
+const TEMP_DIRS: string[] = []
+const ORIGINAL_CCD = process.env.CLAUDE_CONFIG_DIR
+const ORIGINAL_ROOT = getProjectRoot()
+
+afterEach(() => {
+  for (const d of TEMP_DIRS.splice(0)) rmSync(d, { recursive: true, force: true })
+  if (ORIGINAL_CCD === undefined) delete process.env.CLAUDE_CONFIG_DIR
+  else process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CCD
+  setProjectRoot(ORIGINAL_ROOT)
+})
+
+function setup(options: { enabled: boolean } = { enabled: true }): {
+  projectDir: string
+  configDir: string
+} {
+  const configDir = mkdtempSync(join(tmpdir(), 'kairos-sl-enq-cfg-'))
+  TEMP_DIRS.push(configDir)
+  process.env.CLAUDE_CONFIG_DIR = configDir
+  mkdirSync(join(configDir, 'skills'), { recursive: true })
+
+  const projectDir = mkdtempSync(join(tmpdir(), 'kairos-sl-enq-proj-'))
+  TEMP_DIRS.push(projectDir)
+  mkdirSync(join(projectDir, '.claude'), { recursive: true })
+  writeFileSync(
+    join(projectDir, '.claude', 'settings.json'),
+    JSON.stringify({
+      kairos: { skillLearning: { enabled: options.enabled } },
+    }),
+  )
+  setProjectRoot(projectDir)
+  return { projectDir, configDir }
+}
+
+function marker(skills: string[]): SkillsUsedMarker {
+  return {
+    runId: 'run-1',
+    taskId: 'task-1',
+    skills: skills.map(name => ({
+      name,
+      firstAt: '2026-04-22T12:00:00.000Z',
+      count: 1,
+    })),
+  }
+}
+
+describe('enqueueSkillDistillation', () => {
+  test('returns disabled when feature flag is off', async () => {
+    const { projectDir } = setup({ enabled: false })
+    const res = await enqueueSkillDistillation({
+      projectDir,
+      runResult: { runId: 'r1', ok: true },
+      skillsUsed: marker(['investigate']),
+    })
+    expect(res.status).toBe('disabled')
+  })
+
+  test('returns run_failed when the parent run did not succeed', async () => {
+    const { projectDir } = setup()
+    const res = await enqueueSkillDistillation({
+      projectDir,
+      runResult: { runId: 'r1', ok: false },
+      skillsUsed: marker(['investigate']),
+    })
+    expect(res.status).toBe('run_failed')
+  })
+
+  test('returns no_skills when the marker is empty', async () => {
+    const { projectDir } = setup()
+    const res = await enqueueSkillDistillation({
+      projectDir,
+      runResult: { runId: 'r1', ok: true },
+      skillsUsed: marker([]),
+    })
+    expect(res.status).toBe('no_skills')
+  })
+
+  test('happy path: enqueues one cron task per skill with sentinel', async () => {
+    const { projectDir } = setup()
+    const res = await enqueueSkillDistillation({
+      projectDir,
+      runResult: { runId: 'r1', ok: true },
+      skillsUsed: marker(['investigate', 'debug']),
+    })
+    expect(res.status).toBe('enqueued')
+    const file = join(projectDir, '.claude', 'scheduled_tasks.json')
+    const body = JSON.parse(readFileSync(file, 'utf-8'))
+    expect(body.tasks).toHaveLength(2)
+    for (const t of body.tasks) {
+      expect(t.prompt.startsWith(`${SKILL_LEARNING_MARKER} skill=`)).toBe(true)
+      expect(t.recurring).toBeUndefined()
+    }
+  })
+
+  test('does not enqueue a second task for the same skill while one is pending', async () => {
+    const { projectDir } = setup()
+    await enqueueSkillDistillation({
+      projectDir,
+      runResult: { runId: 'r1', ok: true },
+      skillsUsed: marker(['investigate']),
+    })
+    const res = await enqueueSkillDistillation({
+      projectDir,
+      runResult: { runId: 'r2', ok: true },
+      skillsUsed: marker(['investigate']),
+    })
+    expect(res.status).toBe('duplicate')
+  })
+})

--- a/src 2/services/skillLearning/enqueueSkillDistillation.test.ts
+++ b/src 2/services/skillLearning/enqueueSkillDistillation.test.ts
@@ -123,4 +123,33 @@ describe('enqueueSkillDistillation', () => {
     })
     expect(res.status).toBe('duplicate')
   })
+
+  test('concurrent calls on the same project+skill enqueue exactly one task', async () => {
+    // Regression for the check-then-write race: without the per-project
+    // lock, two in-flight enqueues can both pass the pending/rate-limit
+    // checks and both call addCronTask, producing two identical tasks.
+    const { projectDir } = setup()
+    const [a, b] = await Promise.all([
+      enqueueSkillDistillation({
+        projectDir,
+        runResult: { runId: 'rA', ok: true },
+        skillsUsed: marker(['investigate']),
+      }),
+      enqueueSkillDistillation({
+        projectDir,
+        runResult: { runId: 'rB', ok: true },
+        skillsUsed: marker(['investigate']),
+      }),
+    ])
+    const statuses = [a.status, b.status].sort()
+    expect(statuses).toEqual(['duplicate', 'enqueued'])
+    const body = JSON.parse(
+      readFileSync(
+        join(projectDir, '.claude', 'scheduled_tasks.json'),
+        'utf-8',
+      ),
+    )
+    expect(body.tasks).toHaveLength(1)
+    expect(body.tasks[0].kind).toBe('skill_distillation')
+  })
 })

--- a/src 2/services/skillLearning/enqueueSkillDistillation.ts
+++ b/src 2/services/skillLearning/enqueueSkillDistillation.ts
@@ -1,0 +1,152 @@
+// Called by the daemon after a successful child run that invoked at least
+// one skill. Enqueues a durable one-shot cron task per skill for the next
+// daemon tick, subject to:
+//
+//   - feature flag: settings.kairos.skillLearning.enabled
+//   - rate limit: one active (pending/applied) patch per skill per 24h
+//   - de-dupe: we never enqueue a distillation task if one is already
+//     pending in scheduled_tasks.json for the same skill
+//
+// The resulting cron task's prompt carries SKILL_LEARNING_MARKER; when the
+// daemon fires it, the child writes its patch to the pending-improvements
+// directory. Applying a patch to the live skill is a separate, user-gated
+// step (see reviewQueue.ts + applyPatch.ts).
+
+import { randomUUID } from 'crypto'
+import { mkdir } from 'fs/promises'
+import type { ChildRunResult } from '../../daemon/kairos/childRunner.js'
+import { addCronTask, readCronTasks } from '../../utils/cronTasks.js'
+import { logForDebugging } from '../../utils/debug.js'
+import {
+  buildDistillationPrompt,
+  SKILL_LEARNING_MARKER,
+} from './distillationPrompt.js'
+import {
+  getPendingImprovementsDir,
+  getPendingPatchPath,
+  getSkillFilePath,
+} from './paths.js'
+import { checkSkillRateLimit } from './rateLimiter.js'
+import { readSkillLearningConfig } from './skillLearningConfig.js'
+import type { SkillsUsedMarker } from './skillUseObserver.js'
+import { getSkillsUsedPath } from './skillUseObserver.js'
+
+const ONE_SHOT_CRON = '* * * * *'
+
+export type EnqueueSkillDistillationInputs = {
+  projectDir: string
+  runResult: Pick<ChildRunResult, 'runId' | 'ok'>
+  skillsUsed: SkillsUsedMarker
+  /** Optional override so tests can pin task IDs and timestamps. */
+  now?: () => Date
+  /** Override for tests that don't want to hit the real cron file. */
+  addCronTask?: typeof addCronTask
+}
+
+export type EnqueueOutcome =
+  | { status: 'disabled' }
+  | { status: 'run_failed' }
+  | { status: 'no_skills' }
+  | {
+      status: 'enqueued' | 'rate_limited' | 'duplicate'
+      perSkill: PerSkillOutcome[]
+    }
+
+export type PerSkillOutcome =
+  | { skill: string; status: 'enqueued'; taskId: string; patchId: string }
+  | {
+      skill: string
+      status: 'rate_limited'
+      nextAllowedAt: number
+    }
+  | { skill: string; status: 'duplicate' }
+
+/**
+ * Return the list of per-skill distillation marker sentinels we'd look for
+ * in scheduled_tasks.json. One per skill.
+ */
+function perSkillSentinel(skill: string): string {
+  return `${SKILL_LEARNING_MARKER} skill=${skill}`
+}
+
+/**
+ * Has a distillation task for this skill already been enqueued (and not yet
+ * fired)? The marker lives on the FIRST LINE of the prompt so a substring
+ * scan over readCronTasks() is sufficient.
+ */
+async function hasPendingDistillation(
+  projectDir: string,
+  skill: string,
+): Promise<boolean> {
+  const tasks = await readCronTasks(projectDir)
+  const marker = perSkillSentinel(skill)
+  return tasks.some(t => t.prompt.startsWith(marker))
+}
+
+export async function enqueueSkillDistillation(
+  inputs: EnqueueSkillDistillationInputs,
+): Promise<EnqueueOutcome> {
+  const now = inputs.now ?? (() => new Date())
+  const adder = inputs.addCronTask ?? addCronTask
+
+  const config = readSkillLearningConfig(inputs.projectDir)
+  if (!config.enabled) return { status: 'disabled' }
+  if (!inputs.runResult.ok) return { status: 'run_failed' }
+  if (inputs.skillsUsed.skills.length === 0) return { status: 'no_skills' }
+
+  // Ensure the pending directory exists before any child references it.
+  await mkdir(getPendingImprovementsDir(), { recursive: true })
+
+  const perSkill: PerSkillOutcome[] = []
+  let anyEnqueued = false
+
+  for (const record of inputs.skillsUsed.skills) {
+    const skill = record.name
+
+    if (await hasPendingDistillation(inputs.projectDir, skill)) {
+      perSkill.push({ skill, status: 'duplicate' })
+      continue
+    }
+
+    const limit = await checkSkillRateLimit(
+      skill,
+      now().getTime(),
+      config.rateLimitMs,
+    )
+    if (!limit.ok) {
+      perSkill.push({
+        skill,
+        status: 'rate_limited',
+        nextAllowedAt: limit.nextAllowedAt,
+      })
+      continue
+    }
+
+    const patchId = randomUUID().slice(0, 8)
+    const sentinel = perSkillSentinel(skill)
+    const body = buildDistillationPrompt({
+      skill,
+      skillFilePath: getSkillFilePath(skill),
+      skillsUsedPath: getSkillsUsedPath(
+        inputs.projectDir,
+        inputs.runResult.runId,
+      ),
+      patchOutputPath: getPendingPatchPath(patchId),
+      enqueuedAt: now().toISOString(),
+    })
+    const prompt = `${sentinel}\n${body}`
+
+    const taskId = await adder(ONE_SHOT_CRON, prompt, false, true)
+    perSkill.push({ skill, status: 'enqueued', taskId, patchId })
+    anyEnqueued = true
+    logForDebugging(
+      `[skillLearning] enqueued distillation task=${taskId} skill=${skill} patchId=${patchId}`,
+    )
+  }
+
+  if (anyEnqueued) return { status: 'enqueued', perSkill }
+  if (perSkill.every(p => p.status === 'rate_limited')) {
+    return { status: 'rate_limited', perSkill }
+  }
+  return { status: 'duplicate', perSkill }
+}

--- a/src 2/services/skillLearning/enqueueSkillDistillation.ts
+++ b/src 2/services/skillLearning/enqueueSkillDistillation.ts
@@ -26,12 +26,24 @@ import {
   getPendingPatchPath,
   getSkillFilePath,
 } from './paths.js'
-import { checkSkillRateLimit } from './rateLimiter.js'
+import {
+  archiveOldAppliedPatches,
+  checkSkillRateLimit,
+} from './rateLimiter.js'
 import { readSkillLearningConfig } from './skillLearningConfig.js'
 import type { SkillsUsedMarker } from './skillUseObserver.js'
 import { getSkillsUsedPath } from './skillUseObserver.js'
 
 const ONE_SHOT_CRON = '* * * * *'
+
+/**
+ * Structural discriminator stamped on the CronTask so the worker can skip
+ * re-entrant observation without reading the prompt. User-authored cron
+ * tasks leave `kind` undefined, so a docs copy-paste of the sentinel
+ * comment at the top of a prompt can never look like a daemon-internal
+ * distillation task.
+ */
+export const SKILL_DISTILLATION_KIND = 'skill_distillation'
 
 export type EnqueueSkillDistillationInputs = {
   projectDir: string
@@ -71,8 +83,8 @@ function perSkillSentinel(skill: string): string {
 
 /**
  * Has a distillation task for this skill already been enqueued (and not yet
- * fired)? The marker lives on the FIRST LINE of the prompt so a substring
- * scan over readCronTasks() is sufficient.
+ * fired)? Authoritative check is the structural `kind` field; the per-skill
+ * sentinel in the prompt is only used to narrow by which skill.
  */
 async function hasPendingDistillation(
   projectDir: string,
@@ -80,7 +92,37 @@ async function hasPendingDistillation(
 ): Promise<boolean> {
   const tasks = await readCronTasks(projectDir)
   const marker = perSkillSentinel(skill)
-  return tasks.some(t => t.prompt.startsWith(marker))
+  return tasks.some(
+    t => t.kind === SKILL_DISTILLATION_KIND && t.prompt.startsWith(marker),
+  )
+}
+
+/**
+ * In-process chain of in-flight enqueue calls keyed by projectDir. Two
+ * near-simultaneous successful child runs on the same project that both
+ * invoked the same skill would otherwise race the read-modify-write between
+ * `hasPendingDistillation` / `checkSkillRateLimit` and `addCronTask`, and
+ * produce two duplicate cron tasks. Serializing enqueue per project keeps
+ * the compound check-then-write atomic from the daemon's perspective.
+ *
+ * Cross-project calls fan out freely — they target different files.
+ */
+const projectEnqueueChains = new Map<string, Promise<unknown>>()
+
+async function withProjectLock<T>(
+  projectDir: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev = projectEnqueueChains.get(projectDir) ?? Promise.resolve()
+  const next = prev.then(fn, fn)
+  projectEnqueueChains.set(projectDir, next)
+  try {
+    return await next
+  } finally {
+    if (projectEnqueueChains.get(projectDir) === next) {
+      projectEnqueueChains.delete(projectDir)
+    }
+  }
 }
 
 export async function enqueueSkillDistillation(
@@ -94,59 +136,76 @@ export async function enqueueSkillDistillation(
   if (!inputs.runResult.ok) return { status: 'run_failed' }
   if (inputs.skillsUsed.skills.length === 0) return { status: 'no_skills' }
 
-  // Ensure the pending directory exists before any child references it.
-  await mkdir(getPendingImprovementsDir(), { recursive: true })
+  return withProjectLock(inputs.projectDir, async () => {
+    // Ensure the pending directory exists before any child references it.
+    await mkdir(getPendingImprovementsDir(), { recursive: true })
 
-  const perSkill: PerSkillOutcome[] = []
-  let anyEnqueued = false
-
-  for (const record of inputs.skillsUsed.skills) {
-    const skill = record.name
-
-    if (await hasPendingDistillation(inputs.projectDir, skill)) {
-      perSkill.push({ skill, status: 'duplicate' })
-      continue
+    // Opportunistic prune: move applied patches older than 2× the rate-limit
+    // window out of the hot path so `listActivePatches` stays small. We use
+    // a generous multiplier so anything still plausibly affecting a rate
+    // limit decision is preserved in-place.
+    if (config.rateLimitMs > 0) {
+      await archiveOldAppliedPatches(now().getTime() - config.rateLimitMs * 2)
     }
 
-    const limit = await checkSkillRateLimit(
-      skill,
-      now().getTime(),
-      config.rateLimitMs,
-    )
-    if (!limit.ok) {
-      perSkill.push({
+    const perSkill: PerSkillOutcome[] = []
+    let anyEnqueued = false
+
+    for (const record of inputs.skillsUsed.skills) {
+      const skill = record.name
+
+      if (await hasPendingDistillation(inputs.projectDir, skill)) {
+        perSkill.push({ skill, status: 'duplicate' })
+        continue
+      }
+
+      const limit = await checkSkillRateLimit(
         skill,
-        status: 'rate_limited',
-        nextAllowedAt: limit.nextAllowedAt,
+        now().getTime(),
+        config.rateLimitMs,
+      )
+      if (!limit.ok) {
+        perSkill.push({
+          skill,
+          status: 'rate_limited',
+          nextAllowedAt: limit.nextAllowedAt,
+        })
+        continue
+      }
+
+      const patchId = randomUUID().slice(0, 8)
+      const sentinel = perSkillSentinel(skill)
+      const body = buildDistillationPrompt({
+        skill,
+        skillFilePath: getSkillFilePath(skill),
+        skillsUsedPath: getSkillsUsedPath(
+          inputs.projectDir,
+          inputs.runResult.runId,
+        ),
+        patchOutputPath: getPendingPatchPath(patchId),
+        enqueuedAt: now().toISOString(),
       })
-      continue
+      const prompt = `${sentinel}\n${body}`
+
+      const taskId = await adder(
+        ONE_SHOT_CRON,
+        prompt,
+        false,
+        true,
+        undefined,
+        SKILL_DISTILLATION_KIND,
+      )
+      perSkill.push({ skill, status: 'enqueued', taskId, patchId })
+      anyEnqueued = true
+      logForDebugging(
+        `[skillLearning] enqueued distillation task=${taskId} skill=${skill} patchId=${patchId}`,
+      )
     }
 
-    const patchId = randomUUID().slice(0, 8)
-    const sentinel = perSkillSentinel(skill)
-    const body = buildDistillationPrompt({
-      skill,
-      skillFilePath: getSkillFilePath(skill),
-      skillsUsedPath: getSkillsUsedPath(
-        inputs.projectDir,
-        inputs.runResult.runId,
-      ),
-      patchOutputPath: getPendingPatchPath(patchId),
-      enqueuedAt: now().toISOString(),
-    })
-    const prompt = `${sentinel}\n${body}`
-
-    const taskId = await adder(ONE_SHOT_CRON, prompt, false, true)
-    perSkill.push({ skill, status: 'enqueued', taskId, patchId })
-    anyEnqueued = true
-    logForDebugging(
-      `[skillLearning] enqueued distillation task=${taskId} skill=${skill} patchId=${patchId}`,
-    )
-  }
-
-  if (anyEnqueued) return { status: 'enqueued', perSkill }
-  if (perSkill.every(p => p.status === 'rate_limited')) {
-    return { status: 'rate_limited', perSkill }
-  }
-  return { status: 'duplicate', perSkill }
+    if (anyEnqueued) return { status: 'enqueued', perSkill }
+    if (perSkill.every(p => p.status === 'rate_limited')) {
+      return { status: 'rate_limited', perSkill }
+    }
+    return { status: 'duplicate', perSkill }
+  })
 }

--- a/src 2/services/skillLearning/patchSchema.test.ts
+++ b/src 2/services/skillLearning/patchSchema.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+import { parseSkillPatch, SkillPatchSchema } from './patchSchema.js'
+
+describe('SkillPatchSchema', () => {
+  test('accepts minimal valid patch', () => {
+    const ok = SkillPatchSchema.parse({
+      skill: 'investigate',
+      edits: [{ type: 'add_note', content: 'remember to check env files' }],
+    })
+    expect(ok.skill).toBe('investigate')
+    expect(ok.edits).toHaveLength(1)
+  })
+
+  test('rejects skill with path traversal', () => {
+    expect(() =>
+      SkillPatchSchema.parse({
+        skill: '../etc/passwd',
+        edits: [{ type: 'add_note', content: 'x' }],
+      }),
+    ).toThrow()
+  })
+
+  test('rejects unknown edit type', () => {
+    expect(() =>
+      SkillPatchSchema.parse({
+        skill: 'x',
+        edits: [{ type: 'replace_all', content: 'nope' }],
+      }),
+    ).toThrow()
+  })
+
+  test('rejects zero edits', () => {
+    expect(() =>
+      SkillPatchSchema.parse({ skill: 'x', edits: [] }),
+    ).toThrow()
+  })
+
+  test('rejects too many edits', () => {
+    const edits = Array.from({ length: 7 }, () => ({
+      type: 'add_note' as const,
+      content: 'x',
+    }))
+    expect(() => SkillPatchSchema.parse({ skill: 'x', edits })).toThrow()
+  })
+
+  test('rejects oversized content', () => {
+    const big = 'x'.repeat(3000)
+    expect(() =>
+      SkillPatchSchema.parse({
+        skill: 'x',
+        edits: [{ type: 'add_note', content: big }],
+      }),
+    ).toThrow()
+  })
+})
+
+describe('parseSkillPatch', () => {
+  test('parses raw JSON', () => {
+    const patch = parseSkillPatch(
+      '{"skill":"x","edits":[{"type":"add_note","content":"y"}]}',
+    )
+    expect(patch.skill).toBe('x')
+  })
+
+  test('strips fenced json', () => {
+    const raw = '```json\n{"skill":"x","edits":[{"type":"add_note","content":"y"}]}\n```'
+    const patch = parseSkillPatch(raw)
+    expect(patch.skill).toBe('x')
+  })
+
+  test('handles leading commentary before the json object', () => {
+    const raw =
+      'Here is the patch:\n{"skill":"x","edits":[{"type":"add_note","content":"y"}]}'
+    const patch = parseSkillPatch(raw)
+    expect(patch.skill).toBe('x')
+  })
+
+  test('throws on malformed JSON', () => {
+    expect(() => parseSkillPatch('not json at all')).toThrow()
+  })
+})

--- a/src 2/services/skillLearning/patchSchema.test.ts
+++ b/src 2/services/skillLearning/patchSchema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { parseSkillPatch, SkillPatchSchema } from './patchSchema.js'
+import { SkillPatchSchema } from './patchSchema.js'
 
 describe('SkillPatchSchema', () => {
   test('accepts minimal valid patch', () => {
@@ -51,31 +51,5 @@ describe('SkillPatchSchema', () => {
         edits: [{ type: 'add_note', content: big }],
       }),
     ).toThrow()
-  })
-})
-
-describe('parseSkillPatch', () => {
-  test('parses raw JSON', () => {
-    const patch = parseSkillPatch(
-      '{"skill":"x","edits":[{"type":"add_note","content":"y"}]}',
-    )
-    expect(patch.skill).toBe('x')
-  })
-
-  test('strips fenced json', () => {
-    const raw = '```json\n{"skill":"x","edits":[{"type":"add_note","content":"y"}]}\n```'
-    const patch = parseSkillPatch(raw)
-    expect(patch.skill).toBe('x')
-  })
-
-  test('handles leading commentary before the json object', () => {
-    const raw =
-      'Here is the patch:\n{"skill":"x","edits":[{"type":"add_note","content":"y"}]}'
-    const patch = parseSkillPatch(raw)
-    expect(patch.skill).toBe('x')
-  })
-
-  test('throws on malformed JSON', () => {
-    expect(() => parseSkillPatch('not json at all')).toThrow()
   })
 })

--- a/src 2/services/skillLearning/patchSchema.ts
+++ b/src 2/services/skillLearning/patchSchema.ts
@@ -1,0 +1,61 @@
+// Schema for the structured patch the distillation child emits.
+//
+// Intentionally narrow. v1 only accepts additive edits (note, example, step
+// refinement) — no whole-file replacements, no deletes. That keeps the
+// review diff scannable and matches the issue's "additive learning" rule.
+
+import { z } from 'zod/v4'
+
+export const MAX_CONTENT_CHARS = 2000
+export const MAX_EDITS = 6
+
+export const SkillEditSchema = z
+  .object({
+    type: z.enum(['add_note', 'refine_step', 'add_example']),
+    content: z.string().trim().min(1).max(MAX_CONTENT_CHARS),
+    /** Optional human-readable anchor the reviewer can scan. */
+    rationale: z.string().trim().min(1).max(500).optional(),
+    /**
+     * Optional heading or line the edit targets. The apply step uses this
+     * for `refine_step` — if absent, the edit is appended at end-of-file.
+     */
+    anchor: z.string().trim().min(1).max(500).optional(),
+  })
+  .strict()
+
+export type SkillEdit = z.infer<typeof SkillEditSchema>
+
+export const SkillPatchSchema = z
+  .object({
+    skill: z
+      .string()
+      .trim()
+      .min(1)
+      .max(200)
+      // Match the skill directory-name convention: lowercase, digits, dashes,
+      // colons (plugin namespaces). Rejects path traversal outright.
+      .regex(/^[a-z0-9][a-z0-9:\-_]*$/),
+    edits: z.array(SkillEditSchema).min(1).max(MAX_EDITS),
+    summary: z.string().trim().min(1).max(500).optional(),
+  })
+  .strict()
+
+export type SkillPatch = z.infer<typeof SkillPatchSchema>
+
+/**
+ * Parse a raw child output into a validated patch, or throw. Accepts a
+ * single JSON object; the distillation prompt tells the child to emit
+ * exactly that. Fenced-json wrappers are stripped.
+ */
+export function parseSkillPatch(raw: string): SkillPatch {
+  const trimmed = raw.trim()
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)?.[1]?.trim()
+  const candidate = fenced ?? trimmed
+  const start = candidate.indexOf('{')
+  const end = candidate.lastIndexOf('}')
+  const jsonSlice =
+    start !== -1 && end !== -1 && end > start
+      ? candidate.slice(start, end + 1)
+      : candidate
+  return SkillPatchSchema.parse(JSON.parse(jsonSlice))
+}

--- a/src 2/services/skillLearning/patchSchema.ts
+++ b/src 2/services/skillLearning/patchSchema.ts
@@ -41,21 +41,3 @@ export const SkillPatchSchema = z
   .strict()
 
 export type SkillPatch = z.infer<typeof SkillPatchSchema>
-
-/**
- * Parse a raw child output into a validated patch, or throw. Accepts a
- * single JSON object; the distillation prompt tells the child to emit
- * exactly that. Fenced-json wrappers are stripped.
- */
-export function parseSkillPatch(raw: string): SkillPatch {
-  const trimmed = raw.trim()
-  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i)?.[1]?.trim()
-  const candidate = fenced ?? trimmed
-  const start = candidate.indexOf('{')
-  const end = candidate.lastIndexOf('}')
-  const jsonSlice =
-    start !== -1 && end !== -1 && end > start
-      ? candidate.slice(start, end + 1)
-      : candidate
-  return SkillPatchSchema.parse(JSON.parse(jsonSlice))
-}

--- a/src 2/services/skillLearning/paths.ts
+++ b/src 2/services/skillLearning/paths.ts
@@ -1,0 +1,55 @@
+// Canonical on-disk layout for the skill-learning review queue.
+//
+// Layout under ~/.claude/skills/.pending-improvements/:
+//   <id>.json              — patch awaiting review
+//   applied/<id>.json      — accepted; backup of live skill is in backups/
+//   rejected/<id>.json     — rejected; kept for audit
+//   backups/<skill>-<ts>.md — snapshot of the live skill file pre-apply
+
+import { join } from 'path'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+
+export const PENDING_DIR_NAME = '.pending-improvements'
+
+export function getSkillsRoot(): string {
+  return join(getClaudeConfigHomeDir(), 'skills')
+}
+
+export function getPendingImprovementsDir(): string {
+  return join(getSkillsRoot(), PENDING_DIR_NAME)
+}
+
+export function getAppliedDir(): string {
+  return join(getPendingImprovementsDir(), 'applied')
+}
+
+export function getRejectedDir(): string {
+  return join(getPendingImprovementsDir(), 'rejected')
+}
+
+export function getBackupsDir(): string {
+  return join(getPendingImprovementsDir(), 'backups')
+}
+
+export function getPendingPatchPath(id: string): string {
+  return join(getPendingImprovementsDir(), `${id}.json`)
+}
+
+export function getAppliedPatchPath(id: string): string {
+  return join(getAppliedDir(), `${id}.json`)
+}
+
+export function getRejectedPatchPath(id: string): string {
+  return join(getRejectedDir(), `${id}.json`)
+}
+
+/** Path to a skill's live SKILL.md in the user skills root. */
+export function getSkillFilePath(skillName: string): string {
+  return join(getSkillsRoot(), skillName, 'SKILL.md')
+}
+
+export function getBackupPath(skillName: string, iso: string): string {
+  // ISO timestamps contain colons and dots — map to filesystem-safe runs.
+  const safe = iso.replace(/[:.]/g, '-')
+  return join(getBackupsDir(), `${skillName}-${safe}.md`)
+}

--- a/src 2/services/skillLearning/paths.ts
+++ b/src 2/services/skillLearning/paths.ts
@@ -4,6 +4,8 @@
 //   <id>.json              — patch awaiting review
 //   applied/<id>.json      — accepted; backup of live skill is in backups/
 //   rejected/<id>.json     — rejected; kept for audit
+//   archive/<id>.json      — accepted long ago; kept for audit but excluded
+//                            from rate-limit reads so the hot path stays O(1)
 //   backups/<skill>-<ts>.md — snapshot of the live skill file pre-apply
 
 import { join } from 'path'
@@ -29,6 +31,14 @@ export function getRejectedDir(): string {
 
 export function getBackupsDir(): string {
   return join(getPendingImprovementsDir(), 'backups')
+}
+
+export function getArchiveDir(): string {
+  return join(getPendingImprovementsDir(), 'archive')
+}
+
+export function getArchivePatchPath(id: string): string {
+  return join(getArchiveDir(), `${id}.json`)
 }
 
 export function getPendingPatchPath(id: string): string {

--- a/src 2/services/skillLearning/rateLimiter.test.ts
+++ b/src 2/services/skillLearning/rateLimiter.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { checkSkillRateLimit } from './rateLimiter.js'
+
+const TEMP_DIRS: string[] = []
+const ORIGINAL_CCD = process.env.CLAUDE_CONFIG_DIR
+
+afterEach(() => {
+  for (const d of TEMP_DIRS.splice(0)) rmSync(d, { recursive: true, force: true })
+  if (ORIGINAL_CCD === undefined) delete process.env.CLAUDE_CONFIG_DIR
+  else process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CCD
+})
+
+function setupConfigDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'kairos-sl-rl-'))
+  TEMP_DIRS.push(d)
+  process.env.CLAUDE_CONFIG_DIR = d
+  const base = join(d, 'skills', '.pending-improvements')
+  mkdirSync(join(base, 'applied'), { recursive: true })
+  mkdirSync(join(base, 'rejected'), { recursive: true })
+  return d
+}
+
+function writePending(
+  configDir: string,
+  id: string,
+  skill: string,
+  createdAt: number,
+): void {
+  const path = join(
+    configDir,
+    'skills',
+    '.pending-improvements',
+    `${id}.json`,
+  )
+  writeFileSync(
+    path,
+    JSON.stringify({
+      id,
+      createdAt,
+      patch: {
+        skill,
+        edits: [{ type: 'add_note', content: 'x' }],
+      },
+    }),
+  )
+}
+
+function writeApplied(
+  configDir: string,
+  id: string,
+  skill: string,
+  createdAt: number,
+): void {
+  const path = join(
+    configDir,
+    'skills',
+    '.pending-improvements',
+    'applied',
+    `${id}.json`,
+  )
+  writeFileSync(
+    path,
+    JSON.stringify({
+      id,
+      createdAt,
+      patch: {
+        skill,
+        edits: [{ type: 'add_note', content: 'x' }],
+      },
+    }),
+  )
+}
+
+describe('checkSkillRateLimit', () => {
+  test('allows first distillation', async () => {
+    setupConfigDir()
+    const now = 1_700_000_000_000
+    const res = await checkSkillRateLimit('investigate', now, 24 * 3600_000)
+    expect(res.ok).toBe(true)
+  })
+
+  test('blocks second distillation within window', async () => {
+    const dir = setupConfigDir()
+    const t0 = 1_700_000_000_000
+    writePending(dir, 'p1', 'investigate', t0)
+    const res = await checkSkillRateLimit('investigate', t0 + 60_000, 24 * 3600_000)
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.nextAllowedAt).toBe(t0 + 24 * 3600_000)
+  })
+
+  test('allows distillation after window', async () => {
+    const dir = setupConfigDir()
+    const t0 = 1_700_000_000_000
+    writePending(dir, 'p1', 'investigate', t0)
+    const res = await checkSkillRateLimit(
+      'investigate',
+      t0 + 24 * 3600_000 + 1,
+      24 * 3600_000,
+    )
+    expect(res.ok).toBe(true)
+  })
+
+  test('applied patches count toward the limit', async () => {
+    const dir = setupConfigDir()
+    const t0 = 1_700_000_000_000
+    writeApplied(dir, 'a1', 'investigate', t0)
+    const res = await checkSkillRateLimit('investigate', t0 + 60_000, 24 * 3600_000)
+    expect(res.ok).toBe(false)
+  })
+
+  test('different skills are independent', async () => {
+    const dir = setupConfigDir()
+    const t0 = 1_700_000_000_000
+    writePending(dir, 'p1', 'investigate', t0)
+    const res = await checkSkillRateLimit('debug', t0 + 60_000, 24 * 3600_000)
+    expect(res.ok).toBe(true)
+  })
+})

--- a/src 2/services/skillLearning/rateLimiter.test.ts
+++ b/src 2/services/skillLearning/rateLimiter.test.ts
@@ -1,8 +1,18 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { checkSkillRateLimit } from './rateLimiter.js'
+import {
+  archiveOldAppliedPatches,
+  checkSkillRateLimit,
+} from './rateLimiter.js'
 
 const TEMP_DIRS: string[] = []
 const ORIGINAL_CCD = process.env.CLAUDE_CONFIG_DIR
@@ -117,5 +127,56 @@ describe('checkSkillRateLimit', () => {
     writePending(dir, 'p1', 'investigate', t0)
     const res = await checkSkillRateLimit('debug', t0 + 60_000, 24 * 3600_000)
     expect(res.ok).toBe(true)
+  })
+})
+
+describe('archiveOldAppliedPatches', () => {
+  test('moves old applied patches to archive/ and leaves recent ones', async () => {
+    const dir = setupConfigDir()
+    const t0 = 1_700_000_000_000
+    const dayMs = 24 * 3600_000
+    writeApplied(dir, 'old-1', 'investigate', t0)
+    writeApplied(dir, 'old-2', 'debug', t0 + 1)
+    writeApplied(dir, 'recent', 'investigate', t0 + 10 * dayMs)
+
+    // Cutoff: anything strictly older than t0 + 5 days moves.
+    const moved = await archiveOldAppliedPatches(t0 + 5 * dayMs)
+    expect(moved).toBe(2)
+
+    const appliedDir = join(dir, 'skills', '.pending-improvements', 'applied')
+    const archiveDir = join(dir, 'skills', '.pending-improvements', 'archive')
+    expect(readdirSync(appliedDir).sort()).toEqual(['recent.json'])
+    expect(readdirSync(archiveDir).sort()).toEqual(['old-1.json', 'old-2.json'])
+  })
+
+  test('archived patches no longer affect rate limit', async () => {
+    const dir = setupConfigDir()
+    const t0 = 1_700_000_000_000
+    const dayMs = 24 * 3600_000
+    writeApplied(dir, 'ancient', 'investigate', t0)
+    // Before archiving: within a very long window, the ancient patch blocks.
+    const before = await checkSkillRateLimit('investigate', t0 + dayMs, 30 * dayMs)
+    expect(before.ok).toBe(false)
+
+    await archiveOldAppliedPatches(t0 + dayMs)
+    // After archiving: the applied file is gone from applied/, so rate-limit
+    // no longer sees it.
+    const after = await checkSkillRateLimit('investigate', t0 + dayMs, 30 * dayMs)
+    expect(after.ok).toBe(true)
+  })
+
+  test('no-op when applied/ is empty', async () => {
+    setupConfigDir()
+    const moved = await archiveOldAppliedPatches(Date.now())
+    expect(moved).toBe(0)
+  })
+
+  test('does not create archive/ dir when nothing to move', async () => {
+    const dir = setupConfigDir()
+    const t0 = 1_700_000_000_000
+    writeApplied(dir, 'recent', 'investigate', t0 + 100)
+    await archiveOldAppliedPatches(t0)
+    const archiveDir = join(dir, 'skills', '.pending-improvements', 'archive')
+    expect(existsSync(archiveDir)).toBe(false)
   })
 })

--- a/src 2/services/skillLearning/rateLimiter.ts
+++ b/src 2/services/skillLearning/rateLimiter.ts
@@ -1,0 +1,113 @@
+// Rate-limit distillation-per-skill to one patch per configurable window.
+//
+// Checks BOTH pending and applied patches — a patch sitting unreviewed
+// still counts against the budget, otherwise the queue can pile up while
+// the user is away. Rejected patches DO NOT count (the skill effectively
+// had no learning this cycle, so we can try again).
+
+import { readdir, readFile } from 'fs/promises'
+import { join } from 'path'
+import { isFsInaccessible } from '../../utils/errors.js'
+import {
+  getAppliedDir,
+  getPendingImprovementsDir,
+} from './paths.js'
+import { SkillPatchSchema } from './patchSchema.js'
+
+export type StoredPatchMeta = {
+  id: string
+  skill: string
+  createdAt: number
+  status: 'pending' | 'applied'
+}
+
+async function readDirSafe(path: string): Promise<string[]> {
+  try {
+    return await readdir(path)
+  } catch (e) {
+    if (isFsInaccessible(e)) return []
+    throw e
+  }
+}
+
+async function readPatchMeta(
+  path: string,
+  status: 'pending' | 'applied',
+): Promise<StoredPatchMeta | null> {
+  let raw: string
+  try {
+    raw = await readFile(path, 'utf-8')
+  } catch {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const rec = parsed as Record<string, unknown>
+  if (typeof rec.id !== 'string' || typeof rec.createdAt !== 'number') return null
+  // Validate skill field independently — a malformed patch on disk should be
+  // skipped but not crash the rate limiter.
+  const patchCheck = SkillPatchSchema.safeParse(rec.patch)
+  if (!patchCheck.success) return null
+  return {
+    id: rec.id,
+    skill: patchCheck.data.skill,
+    createdAt: rec.createdAt,
+    status,
+  }
+}
+
+async function listMetaIn(
+  dir: string,
+  status: 'pending' | 'applied',
+): Promise<StoredPatchMeta[]> {
+  const entries = await readDirSafe(dir)
+  const out: StoredPatchMeta[] = []
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue
+    const meta = await readPatchMeta(join(dir, name), status)
+    if (meta) out.push(meta)
+  }
+  return out
+}
+
+/** All pending + applied patches across the queue, union. */
+export async function listActivePatches(): Promise<StoredPatchMeta[]> {
+  const [pending, applied] = await Promise.all([
+    listMetaIn(getPendingImprovementsDir(), 'pending'),
+    listMetaIn(getAppliedDir(), 'applied'),
+  ])
+  return [...pending, ...applied]
+}
+
+export type RateLimitCheck =
+  | { ok: true }
+  | { ok: false; reason: 'rate_limited'; lastAt: number; nextAllowedAt: number }
+
+/**
+ * True when this skill may be re-distilled. A prior pending or applied patch
+ * within `windowMs` blocks; anything older (or rejected) does not.
+ */
+export async function checkSkillRateLimit(
+  skill: string,
+  nowMs: number,
+  windowMs: number,
+): Promise<RateLimitCheck> {
+  if (windowMs <= 0) return { ok: true }
+  const active = await listActivePatches()
+  const matching = active.filter(p => p.skill === skill)
+  if (matching.length === 0) return { ok: true }
+  const latest = matching.reduce((a, b) => (a.createdAt > b.createdAt ? a : b))
+  const nextAllowedAt = latest.createdAt + windowMs
+  if (nowMs >= nextAllowedAt) return { ok: true }
+  return {
+    ok: false,
+    reason: 'rate_limited',
+    lastAt: latest.createdAt,
+    nextAllowedAt,
+  }
+}

--- a/src 2/services/skillLearning/rateLimiter.ts
+++ b/src 2/services/skillLearning/rateLimiter.ts
@@ -5,11 +5,13 @@
 // the user is away. Rejected patches DO NOT count (the skill effectively
 // had no learning this cycle, so we can try again).
 
-import { readdir, readFile } from 'fs/promises'
+import { mkdir, readdir, readFile, rename } from 'fs/promises'
 import { join } from 'path'
 import { isFsInaccessible } from '../../utils/errors.js'
 import {
   getAppliedDir,
+  getArchiveDir,
+  getArchivePatchPath,
   getPendingImprovementsDir,
 } from './paths.js'
 import { SkillPatchSchema } from './patchSchema.js'
@@ -82,6 +84,47 @@ export async function listActivePatches(): Promise<StoredPatchMeta[]> {
     listMetaIn(getAppliedDir(), 'applied'),
   ])
   return [...pending, ...applied]
+}
+
+/**
+ * Move applied patches older than `cutoffMs` (epoch) into `archive/` so the
+ * rate-limit read path stays O(recent-applied) instead of O(all-time
+ * applied). Archived patches are still on disk for audit — they're just
+ * invisible to `listActivePatches`. Callers typically pass
+ * `nowMs - rateLimitMs * 2` as the cutoff so anything too old to affect
+ * rate limits anyway gets moved out.
+ *
+ * Best-effort — silently skips individual failures (missing files, race
+ * with another caller, fs errors on rename). The rate limiter's correctness
+ * does not depend on archiving succeeding.
+ */
+export async function archiveOldAppliedPatches(cutoffMs: number): Promise<number> {
+  const entries = await readDirSafe(getAppliedDir())
+  if (entries.length === 0) return 0
+  let moved = 0
+  let ensuredDir = false
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue
+    const src = join(getAppliedDir(), name)
+    const meta = await readPatchMeta(src, 'applied')
+    if (!meta || meta.createdAt >= cutoffMs) continue
+    if (!ensuredDir) {
+      try {
+        await mkdir(getArchiveDir(), { recursive: true })
+        ensuredDir = true
+      } catch {
+        return moved
+      }
+    }
+    const id = name.slice(0, -5)
+    try {
+      await rename(src, getArchivePatchPath(id))
+      moved += 1
+    } catch {
+      // Another caller raced us or the file vanished — fine, skip.
+    }
+  }
+  return moved
 }
 
 export type RateLimitCheck =

--- a/src 2/services/skillLearning/reviewQueue.test.ts
+++ b/src 2/services/skillLearning/reviewQueue.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { applySkillPatch, SkillPatchApplyError } from './applyPatch.js'
+import {
+  getAppliedPatchPath,
+  getPendingPatchPath,
+  getRejectedPatchPath,
+  getSkillFilePath,
+} from './paths.js'
+import type { SkillPatch } from './patchSchema.js'
+import {
+  listPendingPatches,
+  loadPatchById,
+  movePatchTo,
+  renderPatchDiff,
+} from './reviewQueue.js'
+
+const TEMP_DIRS: string[] = []
+const ORIGINAL_CCD = process.env.CLAUDE_CONFIG_DIR
+
+afterEach(() => {
+  for (const d of TEMP_DIRS.splice(0)) rmSync(d, { recursive: true, force: true })
+  if (ORIGINAL_CCD === undefined) delete process.env.CLAUDE_CONFIG_DIR
+  else process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CCD
+})
+
+function setup(): string {
+  const d = mkdtempSync(join(tmpdir(), 'kairos-sl-rq-'))
+  TEMP_DIRS.push(d)
+  process.env.CLAUDE_CONFIG_DIR = d
+  mkdirSync(join(d, 'skills', '.pending-improvements', 'applied'), {
+    recursive: true,
+  })
+  mkdirSync(join(d, 'skills', '.pending-improvements', 'rejected'), {
+    recursive: true,
+  })
+  mkdirSync(join(d, 'skills', '.pending-improvements', 'backups'), {
+    recursive: true,
+  })
+  return d
+}
+
+function writePending(id: string, patch: SkillPatch, createdAt = 1_700_000_000_000): void {
+  writeFileSync(
+    getPendingPatchPath(id),
+    JSON.stringify({ id, createdAt, patch }, null, 2),
+  )
+}
+
+const SAMPLE_PATCH: SkillPatch = {
+  skill: 'investigate',
+  edits: [{ type: 'add_note', content: 'remember to check env files' }],
+}
+
+describe('reviewQueue', () => {
+  test('list returns pending patches newest-first', async () => {
+    setup()
+    writePending('a', SAMPLE_PATCH, 1000)
+    writePending('b', SAMPLE_PATCH, 2000)
+    const patches = await listPendingPatches()
+    expect(patches.map(p => p.id)).toEqual(['b', 'a'])
+  })
+
+  test('loadPatchById finds pending', async () => {
+    setup()
+    writePending('x', SAMPLE_PATCH)
+    const p = await loadPatchById('x')
+    expect(p?.status).toBe('pending')
+  })
+
+  test('loadPatchById returns null for unknown id', async () => {
+    setup()
+    const p = await loadPatchById('missing')
+    expect(p).toBeNull()
+  })
+
+  test('movePatchTo(rejected) moves the file', async () => {
+    setup()
+    writePending('c', SAMPLE_PATCH)
+    await movePatchTo('c', 'rejected')
+    expect(existsSync(getPendingPatchPath('c'))).toBe(false)
+    expect(existsSync(getRejectedPatchPath('c'))).toBe(true)
+  })
+
+  test('renderPatchDiff includes edit headers and additive lines', () => {
+    const out = renderPatchDiff({
+      skill: 'x',
+      edits: [
+        { type: 'add_note', content: 'hello\nworld' },
+        { type: 'add_example', content: 'ex' },
+      ],
+      summary: 's',
+    })
+    expect(out).toContain('# Skill: x')
+    expect(out).toContain('# Summary: s')
+    expect(out).toContain('## Edit 1: add_note')
+    expect(out).toContain('+ hello')
+    expect(out).toContain('## Edit 2: add_example')
+  })
+})
+
+describe('applySkillPatch', () => {
+  function writeSkillFile(name: string, body: string): string {
+    const p = getSkillFilePath(name)
+    mkdirSync(join(p, '..'), { recursive: true })
+    writeFileSync(p, body, 'utf-8')
+    return p
+  }
+
+  test('applies additive patch and writes a backup', async () => {
+    setup()
+    const skillPath = writeSkillFile('investigate', '# Investigate\n\nstep 1\n')
+    const result = await applySkillPatch(SAMPLE_PATCH)
+    const written = readFileSync(skillPath, 'utf-8')
+    expect(written).toContain('step 1')
+    expect(written).toContain('remember to check env files')
+    expect(existsSync(result.backupPath)).toBe(true)
+    const backup = readFileSync(result.backupPath, 'utf-8')
+    expect(backup).toBe('# Investigate\n\nstep 1\n')
+  })
+
+  test('refine_step with anchor inserts after the matching line', async () => {
+    setup()
+    const skillPath = writeSkillFile(
+      'investigate',
+      '# Investigate\n\nstep one\nstep two\nstep three\n',
+    )
+    await applySkillPatch({
+      skill: 'investigate',
+      edits: [
+        {
+          type: 'refine_step',
+          content: 'after step two, also verify env',
+          anchor: 'step two',
+        },
+      ],
+    })
+    const body = readFileSync(skillPath, 'utf-8')
+    const idxTwo = body.indexOf('step two')
+    const idxInjected = body.indexOf('after step two')
+    const idxThree = body.indexOf('step three')
+    expect(idxTwo).toBeLessThan(idxInjected)
+    expect(idxInjected).toBeLessThan(idxThree)
+  })
+
+  test('throws if live skill file is missing', async () => {
+    setup()
+    await expect(applySkillPatch(SAMPLE_PATCH)).rejects.toBeInstanceOf(
+      SkillPatchApplyError,
+    )
+  })
+})

--- a/src 2/services/skillLearning/reviewQueue.ts
+++ b/src 2/services/skillLearning/reviewQueue.ts
@@ -1,0 +1,146 @@
+// Browse and mutate the pending-improvements queue from the command line.
+//
+// On-disk layout (see paths.ts):
+//   <id>.json             — pending
+//   applied/<id>.json     — accepted and written back to live skill
+//   rejected/<id>.json    — rejected, kept for audit
+//   backups/<skill>-<ts>.md — pre-apply snapshots
+
+import { readdir, readFile, rename } from 'fs/promises'
+import { join } from 'path'
+import { mkdir } from 'fs/promises'
+import { isFsInaccessible } from '../../utils/errors.js'
+import {
+  getAppliedDir,
+  getAppliedPatchPath,
+  getPendingImprovementsDir,
+  getPendingPatchPath,
+  getRejectedDir,
+  getRejectedPatchPath,
+} from './paths.js'
+import { SkillPatchSchema, type SkillPatch } from './patchSchema.js'
+
+export type StoredPatch = {
+  id: string
+  createdAt: number
+  patch: SkillPatch
+  status: 'pending' | 'applied' | 'rejected'
+  path: string
+}
+
+async function readJsonSafe(path: string): Promise<unknown | null> {
+  try {
+    const raw = await readFile(path, 'utf-8')
+    return JSON.parse(raw)
+  } catch (e) {
+    if (isFsInaccessible(e)) return null
+    return null
+  }
+}
+
+function parseStored(
+  id: string,
+  raw: unknown,
+  status: StoredPatch['status'],
+  path: string,
+): StoredPatch | null {
+  if (!raw || typeof raw !== 'object') return null
+  const rec = raw as Record<string, unknown>
+  if (typeof rec.createdAt !== 'number') return null
+  const patch = SkillPatchSchema.safeParse(rec.patch)
+  if (!patch.success) return null
+  return {
+    id,
+    createdAt: rec.createdAt,
+    patch: patch.data,
+    status,
+    path,
+  }
+}
+
+async function readStoredIn(
+  dir: string,
+  status: StoredPatch['status'],
+): Promise<StoredPatch[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(dir)
+  } catch (e) {
+    if (isFsInaccessible(e)) return []
+    return []
+  }
+  const out: StoredPatch[] = []
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue
+    const id = name.slice(0, -5)
+    const path = join(dir, name)
+    const raw = await readJsonSafe(path)
+    const stored = parseStored(id, raw, status, path)
+    if (stored) out.push(stored)
+  }
+  return out
+}
+
+export async function listPendingPatches(): Promise<StoredPatch[]> {
+  const list = await readStoredIn(getPendingImprovementsDir(), 'pending')
+  return list.sort((a, b) => b.createdAt - a.createdAt)
+}
+
+export async function loadPatchById(id: string): Promise<StoredPatch | null> {
+  // Check pending first (hot path), then applied/rejected for historical.
+  for (const [dir, status] of [
+    [getPendingImprovementsDir(), 'pending'],
+    [getAppliedDir(), 'applied'],
+    [getRejectedDir(), 'rejected'],
+  ] as const) {
+    const path = join(dir, `${id}.json`)
+    const raw = await readJsonSafe(path)
+    if (!raw) continue
+    const stored = parseStored(id, raw, status, path)
+    if (stored) return stored
+  }
+  return null
+}
+
+/**
+ * Move a pending patch to `applied/` or `rejected/`. Does NOT touch the live
+ * skill file — that's `applyPatch.ts`'s job; acceptance calls it before
+ * calling this. Rejection just moves the file; no skill changes.
+ */
+export async function movePatchTo(
+  id: string,
+  target: 'applied' | 'rejected',
+): Promise<void> {
+  const from = getPendingPatchPath(id)
+  const toDir = target === 'applied' ? getAppliedDir() : getRejectedDir()
+  const to =
+    target === 'applied'
+      ? getAppliedPatchPath(id)
+      : getRejectedPatchPath(id)
+  await mkdir(toDir, { recursive: true })
+  await rename(from, to)
+}
+
+/**
+ * Render a simple unified-ish diff of the edits in a patch for the CLI's
+ * `diff` subcommand. Not a real git diff — each edit gets a header and the
+ * new content. Kept narrow because v1 is additive-only.
+ */
+export function renderPatchDiff(patch: SkillPatch): string {
+  const lines: string[] = []
+  lines.push(`# Skill: ${patch.skill}`)
+  if (patch.summary) lines.push(`# Summary: ${patch.summary}`)
+  lines.push('')
+  for (let i = 0; i < patch.edits.length; i += 1) {
+    const edit = patch.edits[i]!
+    lines.push(`## Edit ${i + 1}: ${edit.type}`)
+    if (edit.anchor) lines.push(`anchor: ${edit.anchor}`)
+    if (edit.rationale) lines.push(`rationale: ${edit.rationale}`)
+    lines.push('---')
+    for (const line of edit.content.split('\n')) {
+      lines.push(`+ ${line}`)
+    }
+    lines.push('')
+  }
+  return lines.join('\n')
+}

--- a/src 2/services/skillLearning/skillLearningConfig.test.ts
+++ b/src 2/services/skillLearning/skillLearningConfig.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readSkillLearningConfig } from './skillLearningConfig.js'
+
+const TEMP_DIRS: string[] = []
+const ORIGINAL_CCD = process.env.CLAUDE_CONFIG_DIR
+
+afterEach(() => {
+  for (const d of TEMP_DIRS.splice(0)) rmSync(d, { recursive: true, force: true })
+  if (ORIGINAL_CCD === undefined) delete process.env.CLAUDE_CONFIG_DIR
+  else process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CCD
+})
+
+function makeProjectDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'kairos-sl-cfg-'))
+  TEMP_DIRS.push(d)
+  mkdirSync(join(d, '.claude'), { recursive: true })
+  return d
+}
+
+function makeUserConfigDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'kairos-sl-cfg-user-'))
+  TEMP_DIRS.push(d)
+  process.env.CLAUDE_CONFIG_DIR = d
+  return d
+}
+
+describe('readSkillLearningConfig', () => {
+  test('returns defaults (disabled) when no settings file exists', () => {
+    makeUserConfigDir()
+    const projectDir = makeProjectDir()
+    const cfg = readSkillLearningConfig(projectDir)
+    expect(cfg.enabled).toBe(false)
+    expect(cfg.costCeilingUSD).toBe(0.05)
+    expect(cfg.rateLimitMs).toBe(24 * 60 * 60 * 1000)
+  })
+
+  test('reads enabled=true from project settings', () => {
+    makeUserConfigDir()
+    const projectDir = makeProjectDir()
+    writeFileSync(
+      join(projectDir, '.claude', 'settings.json'),
+      JSON.stringify({ kairos: { skillLearning: { enabled: true } } }),
+    )
+    const cfg = readSkillLearningConfig(projectDir)
+    expect(cfg.enabled).toBe(true)
+  })
+
+  test('local settings override project settings', () => {
+    makeUserConfigDir()
+    const projectDir = makeProjectDir()
+    writeFileSync(
+      join(projectDir, '.claude', 'settings.json'),
+      JSON.stringify({ kairos: { skillLearning: { enabled: true } } }),
+    )
+    writeFileSync(
+      join(projectDir, '.claude', 'settings.local.json'),
+      JSON.stringify({ kairos: { skillLearning: { enabled: false } } }),
+    )
+    const cfg = readSkillLearningConfig(projectDir)
+    expect(cfg.enabled).toBe(false)
+  })
+
+  test('ignores non-positive cost ceiling, keeps default', () => {
+    makeUserConfigDir()
+    const projectDir = makeProjectDir()
+    writeFileSync(
+      join(projectDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        kairos: { skillLearning: { enabled: true, costCeilingUSD: 0 } },
+      }),
+    )
+    const cfg = readSkillLearningConfig(projectDir)
+    expect(cfg.costCeilingUSD).toBe(0.05)
+  })
+
+  test('accepts a valid custom rate limit', () => {
+    makeUserConfigDir()
+    const projectDir = makeProjectDir()
+    writeFileSync(
+      join(projectDir, '.claude', 'settings.json'),
+      JSON.stringify({
+        kairos: { skillLearning: { enabled: true, rateLimitMs: 3600000 } },
+      }),
+    )
+    const cfg = readSkillLearningConfig(projectDir)
+    expect(cfg.rateLimitMs).toBe(3600000)
+  })
+})

--- a/src 2/services/skillLearning/skillLearningConfig.ts
+++ b/src 2/services/skillLearning/skillLearningConfig.ts
@@ -1,0 +1,92 @@
+// Read `settings.kairos.skillLearning.*` across the three settings files
+// (user / project / project.local) without going through the zod schema.
+//
+// This mirrors daemon/kairos/tier3.ts: the settings type-system lives in the
+// trunk-guarded schemas, but this is a leaf feature, so we walk raw JSON.
+// Later-written files override earlier ones, same precedence as tier3.
+
+import { join } from 'path'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+import { parseSettingsFile } from '../../utils/settings/settings.js'
+import { clearCachedParsedFile } from '../../utils/settings/settingsCache.js'
+
+export type SkillLearningConfig = {
+  enabled: boolean
+  /** Cost ceiling for a single distillation child run (USD). */
+  costCeilingUSD: number
+  /** Short token budget; surfaced to the child via maxTurns. */
+  maxTurns: number
+  /** Hard wall-clock cap so a runaway child can't block the daemon. */
+  timeoutMs: number
+  /** Minimum ms between two distillations of the same skill. */
+  rateLimitMs: number
+}
+
+const DEFAULT_CONFIG: SkillLearningConfig = {
+  enabled: false,
+  costCeilingUSD: 0.05,
+  maxTurns: 3,
+  timeoutMs: 90_000,
+  rateLimitMs: 24 * 60 * 60 * 1000,
+}
+
+function getSettingsPaths(projectDir: string): string[] {
+  return [
+    join(getClaudeConfigHomeDir(), 'settings.json'),
+    join(projectDir, '.claude', 'settings.json'),
+    join(projectDir, '.claude', 'settings.local.json'),
+  ]
+}
+
+function readPartial(settings: unknown): Partial<SkillLearningConfig> {
+  if (!settings || typeof settings !== 'object') return {}
+  const kairos = (settings as Record<string, unknown>).kairos
+  if (!kairos || typeof kairos !== 'object') return {}
+  const skill = (kairos as Record<string, unknown>).skillLearning
+  if (!skill || typeof skill !== 'object') return {}
+  const rec = skill as Record<string, unknown>
+  const out: Partial<SkillLearningConfig> = {}
+  if (typeof rec.enabled === 'boolean') out.enabled = rec.enabled
+  if (
+    typeof rec.costCeilingUSD === 'number' &&
+    Number.isFinite(rec.costCeilingUSD) &&
+    rec.costCeilingUSD > 0
+  ) {
+    out.costCeilingUSD = rec.costCeilingUSD
+  }
+  if (
+    typeof rec.maxTurns === 'number' &&
+    Number.isInteger(rec.maxTurns) &&
+    rec.maxTurns > 0
+  ) {
+    out.maxTurns = rec.maxTurns
+  }
+  if (
+    typeof rec.timeoutMs === 'number' &&
+    Number.isFinite(rec.timeoutMs) &&
+    rec.timeoutMs > 0
+  ) {
+    out.timeoutMs = rec.timeoutMs
+  }
+  if (
+    typeof rec.rateLimitMs === 'number' &&
+    Number.isFinite(rec.rateLimitMs) &&
+    rec.rateLimitMs >= 0
+  ) {
+    out.rateLimitMs = rec.rateLimitMs
+  }
+  return out
+}
+
+export function readSkillLearningConfig(
+  projectDir: string,
+): SkillLearningConfig {
+  let merged: SkillLearningConfig = { ...DEFAULT_CONFIG }
+  for (const path of getSettingsPaths(projectDir)) {
+    clearCachedParsedFile(path)
+    const { settings } = parseSettingsFile(path)
+    const partial = readPartial(settings)
+    merged = { ...merged, ...partial }
+  }
+  return merged
+}

--- a/src 2/services/skillLearning/skillUseObserver.test.ts
+++ b/src 2/services/skillLearning/skillUseObserver.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { ChildEvent } from '../../daemon/kairos/childRunner.js'
+import {
+  createRunSkillUseObserver,
+  createSkillUseObserver,
+  extractSkillName,
+  getSkillsUsedPath,
+} from './skillUseObserver.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  for (const d of TEMP_DIRS.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+function makeProjectDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'kairos-sl-obs-'))
+  TEMP_DIRS.push(d)
+  return d
+}
+
+function toolUsed(
+  name: string,
+  input: unknown,
+  t = '2026-04-22T12:00:00.000Z',
+): ChildEvent {
+  return {
+    kind: 'tool_used',
+    t,
+    runId: 'r1',
+    toolName: name,
+    toolInput: input,
+  }
+}
+
+describe('extractSkillName', () => {
+  test('accepts {skill}', () => {
+    expect(extractSkillName({ skill: 'investigate' })).toBe('investigate')
+  })
+  test('accepts {skill_name}', () => {
+    expect(extractSkillName({ skill_name: 'debug' })).toBe('debug')
+  })
+  test('rejects empty and non-string', () => {
+    expect(extractSkillName({ skill: '' })).toBeNull()
+    expect(extractSkillName({ skill: 42 })).toBeNull()
+    expect(extractSkillName(null)).toBeNull()
+  })
+})
+
+describe('createSkillUseObserver', () => {
+  test('records one skill invocation', async () => {
+    const obs = createSkillUseObserver('task-1')
+    await obs.onEvent(toolUsed('Skill', { skill: 'investigate' }))
+    expect(obs.hasSkillUse()).toBe(true)
+    expect(obs.getSkills()).toEqual([
+      {
+        name: 'investigate',
+        firstAt: '2026-04-22T12:00:00.000Z',
+        count: 1,
+      },
+    ])
+  })
+
+  test('counts multiple invocations of same skill, preserves first-seen order', async () => {
+    const obs = createSkillUseObserver('task-2')
+    await obs.onEvent(toolUsed('Skill', { skill: 'alpha' }, '2026-04-22T12:00:00Z'))
+    await obs.onEvent(toolUsed('Skill', { skill: 'beta' }, '2026-04-22T12:00:05Z'))
+    await obs.onEvent(toolUsed('Skill', { skill: 'alpha' }, '2026-04-22T12:00:10Z'))
+    const skills = obs.getSkills()
+    expect(skills).toHaveLength(2)
+    expect(skills[0]).toMatchObject({ name: 'alpha', count: 2 })
+    expect(skills[1]).toMatchObject({ name: 'beta', count: 1 })
+  })
+
+  test('ignores tool_used with toolName !== Skill', async () => {
+    const obs = createSkillUseObserver('task-3')
+    await obs.onEvent(toolUsed('Read', { file_path: '/x' }))
+    expect(obs.hasSkillUse()).toBe(false)
+  })
+
+  test('ignores Skill tool_use without a valid skill name', async () => {
+    const obs = createSkillUseObserver('task-4')
+    await obs.onEvent(toolUsed('Skill', {}))
+    await obs.onEvent(toolUsed('Skill', { skill: 42 }))
+    expect(obs.hasSkillUse()).toBe(false)
+  })
+
+  test('chains to a provided onEvent', async () => {
+    const seen: ChildEvent[] = []
+    const obs = createSkillUseObserver('task-5', {
+      onEvent: e => {
+        seen.push(e)
+      },
+    })
+    const ev = toolUsed('Skill', { skill: 'x' })
+    await obs.onEvent(ev)
+    expect(seen).toEqual([ev])
+  })
+})
+
+describe('createRunSkillUseObserver.finalize', () => {
+  test('returns null and writes nothing when no skill invoked', async () => {
+    const projectDir = makeProjectDir()
+    const obs = createRunSkillUseObserver('task-none', 'run-none')
+    await obs.onEvent(toolUsed('Read', { file_path: '/x' }))
+    const path = await obs.finalize(projectDir)
+    expect(path).toBeNull()
+    expect(existsSync(getSkillsUsedPath(projectDir, 'run-none'))).toBe(false)
+  })
+
+  test('writes marker file with recorded skills', async () => {
+    const projectDir = makeProjectDir()
+    const obs = createRunSkillUseObserver('task-7', 'run-7')
+    await obs.onEvent(toolUsed('Skill', { skill: 'investigate' }))
+    await obs.onEvent(toolUsed('Skill', { skill: 'debug' }))
+    const path = await obs.finalize(projectDir)
+    expect(path).not.toBeNull()
+    expect(existsSync(path!)).toBe(true)
+    const body = JSON.parse(readFileSync(path!, 'utf-8'))
+    expect(body.runId).toBe('run-7')
+    expect(body.taskId).toBe('task-7')
+    expect(body.skills).toHaveLength(2)
+    expect(body.skills[0].name).toBe('investigate')
+  })
+})

--- a/src 2/services/skillLearning/skillUseObserver.ts
+++ b/src 2/services/skillLearning/skillUseObserver.ts
@@ -1,0 +1,134 @@
+// Wraps the child-run onEvent callback, watches for tool_use of the Skill
+// tool, and writes a per-run marker file listing the skills the child
+// actually invoked. The marker is the authoritative source for later
+// distillation — no transcript parsing, no heuristics.
+//
+// Marker path: `<projectDir>/.claude/kairos/runs/<runId>/skills-used.json`
+// Shape:       { runId, taskId, skills: [{ name, firstAt, count }] }
+//
+// File is only written if at least one Skill invocation was seen. A run with
+// no skill use leaves the directory empty, which the enqueue step interprets
+// as "nothing to distill."
+
+import { mkdir, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
+import type { ChildEvent } from '../../daemon/kairos/childRunner.js'
+
+export type SkillUseRecord = {
+  /** Canonical skill identifier passed to the Skill tool (e.g. "investigate"). */
+  name: string
+  /** ISO timestamp of the first invocation in this run. */
+  firstAt: string
+  /** Number of times the skill was invoked in this run. */
+  count: number
+}
+
+export type SkillsUsedMarker = {
+  runId: string
+  taskId: string
+  skills: SkillUseRecord[]
+}
+
+export type SkillUseObserverDeps = {
+  /** Optional existing onEvent to chain into (e.g. the stateWriter sink). */
+  onEvent?: (event: ChildEvent) => Promise<void> | void
+  /** Override for tests. */
+  writeMarker?: (path: string, body: string) => Promise<void>
+}
+
+export type SkillUseObserver = {
+  /** Wrapped event handler — pass this to `runChild`'s deps.onEvent. */
+  onEvent: (event: ChildEvent) => Promise<void>
+  /** True if the observer saw at least one Skill invocation. */
+  hasSkillUse(): boolean
+  /** Snapshot of recorded skills (ordered by first-seen). */
+  getSkills(): SkillUseRecord[]
+}
+
+const SKILL_TOOL_NAME = 'Skill'
+
+export function getSkillsUsedPath(projectDir: string, runId: string): string {
+  return join(projectDir, '.claude', 'kairos', 'runs', runId, 'skills-used.json')
+}
+
+/**
+ * Extract the skill identifier from a Skill tool_use input. Accepts either
+ * `{ skill }` (claude-agent-sdk shape) or `{ skill_name }` (Claude.ai shape)
+ * — defensive because the exact SDK convention isn't stable across versions.
+ * Returns null for anything else so we don't pollute the marker with junk.
+ */
+export function extractSkillName(input: unknown): string | null {
+  if (!input || typeof input !== 'object') return null
+  const rec = input as Record<string, unknown>
+  const candidate =
+    (typeof rec.skill === 'string' ? rec.skill : null) ??
+    (typeof rec.skill_name === 'string' ? rec.skill_name : null) ??
+    (typeof rec.name === 'string' ? rec.name : null)
+  if (!candidate) return null
+  const trimmed = candidate.trim()
+  return trimmed.length === 0 ? null : trimmed
+}
+
+export function createSkillUseObserver(
+  _taskId: string,
+  deps: SkillUseObserverDeps = {},
+): SkillUseObserver {
+  const seen = new Map<string, SkillUseRecord>()
+  return {
+    async onEvent(event: ChildEvent) {
+      if (event.kind === 'tool_used' && event.toolName === SKILL_TOOL_NAME) {
+        const name = extractSkillName(event.toolInput)
+        if (name) {
+          const existing = seen.get(name)
+          if (existing) {
+            existing.count += 1
+          } else {
+            seen.set(name, { name, firstAt: event.t, count: 1 })
+          }
+        }
+      }
+      if (deps.onEvent) await deps.onEvent(event)
+    },
+    hasSkillUse() {
+      return seen.size > 0
+    },
+    getSkills() {
+      return [...seen.values()]
+    },
+  }
+}
+
+/**
+ * Bind a runId to an observer for a single child run. Returns a `finalize`
+ * callback that writes the marker file (if any skill was invoked) and yields
+ * the path.
+ */
+export function createRunSkillUseObserver(
+  taskId: string,
+  runId: string,
+  deps: SkillUseObserverDeps = {},
+): SkillUseObserver & {
+  finalize: (projectDir: string) => Promise<string | null>
+} {
+  const observer = createSkillUseObserver(taskId, deps)
+  const writeImpl =
+    deps.writeMarker ??
+    (async (path: string, body: string) => {
+      await mkdir(dirname(path), { recursive: true })
+      await writeFile(path, body, 'utf-8')
+    })
+  return {
+    ...observer,
+    async finalize(projectDir: string) {
+      if (!observer.hasSkillUse()) return null
+      const path = getSkillsUsedPath(projectDir, runId)
+      const body: SkillsUsedMarker = {
+        runId,
+        taskId,
+        skills: observer.getSkills(),
+      }
+      await writeImpl(path, `${JSON.stringify(body, null, 2)}\n`)
+      return path
+    },
+  }
+}

--- a/src 2/utils/cronTasks.ts
+++ b/src 2/utils/cronTasks.ts
@@ -56,6 +56,18 @@ export type CronTask = {
    */
   permanent?: boolean
   /**
+   * Optional discriminator for daemon-originated tasks. Lets the worker
+   * route a task by structural kind instead of sniffing the prompt. Only
+   * the daemon sets this; user-authored cron tasks leave it undefined so
+   * a docs copy-paste of a reserved prompt prefix can never masquerade
+   * as a daemon-internal task.
+   *
+   * Known kinds:
+   *   - `skill_distillation` — one-shot task enqueued by the skill-learning
+   *     loop; worker skips the skill-use observer to prevent re-entrancy.
+   */
+  kind?: string
+  /**
    * Runtime-only flag. false → session-scoped (never written to disk).
    * File-backed tasks leave this undefined; writeCronTasks strips it so
    * the on-disk shape stays { id, cron, prompt, createdAt, lastFiredAt?, recurring?, permanent? }.
@@ -134,6 +146,9 @@ export async function readCronTasks(dir?: string): Promise<CronTask[]> {
         : {}),
       ...(t.recurring ? { recurring: true } : {}),
       ...(t.permanent ? { permanent: true } : {}),
+      ...(typeof t.kind === 'string' && t.kind.length > 0
+        ? { kind: t.kind }
+        : {}),
     })
   }
   return out
@@ -197,16 +212,18 @@ export async function addCronTask(
   recurring: boolean,
   durable: boolean,
   agentId?: string,
+  kind?: string,
 ): Promise<string> {
   // Short ID — 8 hex chars is plenty for MAX_JOBS=50, avoids slice/prefix
   // juggling between the tool layer (shows short IDs) and disk.
   const id = randomUUID().slice(0, 8)
-  const task = {
+  const task: CronTask = {
     id,
     cron,
     prompt,
     createdAt: Date.now(),
     ...(recurring ? { recurring: true } : {}),
+    ...(kind ? { kind } : {}),
   }
   if (!durable) {
     addSessionCronTask({ ...task, ...(agentId ? { agentId } : {}) })


### PR DESCRIPTION
## Summary
After a successful daemon-fired run that used a Skill, KAIROS now enqueues a durable distillation cron task; when it fires, a short-lived child Claude run emits a structured JSON patch into `~/.claude/skills/.pending-improvements/`, reviewed via `/kairos skill-improvements {list|diff|accept|reject}`. Skill use is detected by a Phase-3 child-event observer that writes `<projectDir>/.claude/kairos/runs/<runId>/skills-used.json` (no transcript scraping, no trunk touches). v1 scope is daemon-originated runs only; interactive sessions are intentionally out of scope. The feature is off by default (`settings.kairos.skillLearning.enabled`) and reuses the Phase-3 cost ceiling and cap-hit handler; distillation cron tasks self-gate via a `<!-- kairos-skill-learning -->` sentinel to prevent re-entrancy.

## Test plan
- [x] `bun run typecheck` / `bun run lint`
- [x] `bun test` — 209/209 passing
- [x] Integration test (`skillLearning.integration.test.ts`) covers happy path, re-entrancy guard, and feature-flag off

🤖 Generated with [Claude Code](https://claude.com/claude-code)