### PR TITLE
feat(kairos): register /kairos in commands.ts (Phase 5B, closes #17)

### DIFF
--- a/src 2/commands.ts
+++ b/src 2/commands.ts
@@ -72,6 +72,9 @@ const briefCommand =
 const assistantCommand = feature('KAIROS')
   ? require('./commands/assistant/index.js').default
   : null
+const kairosCommand = feature('KAIROS')
+  ? require('./commands/kairos.js').default
+  : null
 const bridge = feature('BRIDGE_MODE')
   ? require('./commands/bridge/index.js').default
   : null
@@ -327,6 +330,7 @@ const COMMANDS = memoize((): Command[] => [
   ...(proactive ? [proactive] : []),
   ...(briefCommand ? [briefCommand] : []),
   ...(assistantCommand ? [assistantCommand] : []),
+  ...(kairosCommand ? [kairosCommand] : []),
   ...(bridge ? [bridge] : []),
   ...(remoteControlServerCommand ? [remoteControlServerCommand] : []),
   ...(voiceCommand ? [voiceCommand] : []),


### PR DESCRIPTION
## Summary
Phase 5B trunk carveout per epic #11. Adds the two additive, KAIROS-gated lines required for `/kairos` to be picked up by the command registry — a gated require and a conditional spread inside `COMMANDS()`. No existing command is modified, and OFF builds dead-code-eliminate the require (proven by the OFF vs. `--feature=KAIROS` transpile diff: `const kairosCommand = null;` → `const kairosCommand = require("./commands/kairos.js").default;`).

## Test plan
- [x] `git diff --stat` shows only `src 2/commands.ts | 4 ++++`
- [x] Default `bun run build` succeeds (5963 modules, DCE strips the KAIROS require)
- [x] `bun build ./commands.ts --no-bundle --feature=KAIROS` flips `kairosCommand` from `null` to `require("./commands/kairos.js").default`; spread wiring present in both builds
- [ ] Apply `trunk-change-approved` label before merge
- [ ] Live `/kairos` recording requires the internal KAIROS build pipeline; deterministic transpile proof attached in lieu (file follow-up if reviewer requires the live recording)

🤖 Generated with [Claude Code](https://claude.com/claude-code)