### PR TITLE
Add /kairos skill interop flows

### DIFF
--- a/src 2/commands/kairos-skills-interop.ts
+++ b/src 2/commands/kairos-skills-interop.ts
@@ -1,0 +1,99 @@
+import { exportSkill } from '../services/skillInterop/exportSkill.js'
+import { importSkill } from '../services/skillInterop/importSkill.js'
+import { lintSkill } from '../services/skillInterop/lintSkill.js'
+import { formatViolations } from '../services/skillInterop/shared.js'
+
+const HELP_TEXT = `Usage:
+/kairos skills lint <path|skill-name|manifest-json>
+/kairos skills import <url|path|manifest-json> [--yes] [--overwrite]
+/kairos skills export <path|skill-name>
+/kairos skills export <path|skill-name> --publish`
+
+export async function runKairosSkillsInteropCommand(args: string): Promise<string> {
+  const trimmed = args.trim()
+  if (!trimmed) {
+    return HELP_TEXT
+  }
+
+  const [subcommand, ...restTokens] = trimmed.split(/\s+/)
+  const restRaw = trimmed.slice(subcommand.length).trim()
+
+  switch (subcommand) {
+    case 'lint': {
+      if (!restRaw) return HELP_TEXT
+      const result = await lintSkill(restRaw)
+      return result.ok ? 'valid' : formatViolations(result.violations)
+    }
+    case 'import': {
+      const parsed = parseImportArgs(restRaw)
+      if (!parsed.source) return HELP_TEXT
+      return importSkill(parsed.source, {
+        confirm: parsed.confirm,
+        overwrite: parsed.overwrite,
+      })
+    }
+    case 'export': {
+      const parsed = parseExportArgs(restTokens)
+      if (!parsed.reference) return HELP_TEXT
+      if (parsed.publish) {
+        return 'Publishing adapter is not implemented yet. Run without --publish to emit the manifest JSON.'
+      }
+      return exportSkill(parsed.reference)
+    }
+    default:
+      return HELP_TEXT
+  }
+}
+
+export function parseImportArgs(raw: string): {
+  source: string
+  confirm: boolean
+  overwrite: boolean
+} {
+  let working = raw.trim()
+  if (!working) {
+    return { source: '', confirm: false, overwrite: false }
+  }
+
+  let confirm = false
+  let overwrite = false
+
+  while (working.startsWith('--')) {
+    if (working === '--yes' || working.startsWith('--yes ')) {
+      confirm = true
+      working = working.slice('--yes'.length).trim()
+      continue
+    }
+    if (working === '--overwrite' || working.startsWith('--overwrite ')) {
+      overwrite = true
+      working = working.slice('--overwrite'.length).trim()
+      continue
+    }
+    break
+  }
+
+  if (working.startsWith('{')) {
+    return { source: working, confirm, overwrite }
+  }
+
+  const tokens = working.split(/\s+/).filter(Boolean)
+  confirm = confirm || tokens.includes('--yes')
+  overwrite = overwrite || tokens.includes('--overwrite')
+  const source = tokens
+    .filter(token => token !== '--yes' && token !== '--overwrite')
+    .join(' ')
+
+  return { source, confirm, overwrite }
+}
+
+function parseExportArgs(tokens: string[]): {
+  reference: string
+  publish: boolean
+} {
+  const publish = tokens.includes('--publish')
+  const reference = tokens
+    .filter(token => token !== '--publish')
+    .join(' ')
+
+  return { reference, publish }
+}

--- a/src 2/commands/kairos-ui.tsx
+++ b/src 2/commands/kairos-ui.tsx
@@ -1,0 +1,188 @@
+import * as React from 'react'
+import { Select } from '../components/CustomSelect/select.js'
+import { Dialog } from '../components/design-system/Dialog.js'
+import { Box, Text } from '../ink.js'
+import type { LocalJSXCommandCall, LocalJSXCommandOnDone } from '../types/command.js'
+import { importSkill } from '../services/skillInterop/importSkill.js'
+import { parseImportArgs } from './kairos-skills-interop.js'
+import { runKairosCommand } from './kairos.js'
+
+type ImportDialogProps = {
+  args: string
+  source: string
+  overwrite: boolean
+  onDone: LocalJSXCommandOnDone
+}
+
+function KairosCommandRunner({
+  args,
+  onDone,
+}: {
+  args: string
+  onDone: LocalJSXCommandOnDone
+}): React.ReactNode {
+  const importArgs = getInteractiveImportArgs(args)
+
+  React.useEffect(() => {
+    if (importArgs) {
+      return
+    }
+
+    let cancelled = false
+    ;(async () => {
+      try {
+        const value = await runKairosCommand(args)
+        if (!cancelled) {
+          onDone(value, { display: 'system' })
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        if (!cancelled) {
+          onDone(`kairos: ${message}`, { display: 'system' })
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [args, importArgs, onDone])
+
+  if (!importArgs) {
+    return null
+  }
+
+  return (
+    <KairosSkillImportDialog
+      args={args}
+      source={importArgs.source}
+      overwrite={importArgs.overwrite}
+      onDone={onDone}
+    />
+  )
+}
+
+function KairosSkillImportDialog({
+  args,
+  source,
+  overwrite,
+  onDone,
+}: ImportDialogProps): React.ReactNode {
+  const [preview, setPreview] = React.useState<string | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+
+  React.useEffect(() => {
+    let cancelled = false
+
+    ;(async () => {
+      try {
+        const value = await importSkill(source, {
+          confirm: false,
+          overwrite,
+        })
+        if (!cancelled) {
+          setPreview(value)
+        }
+      } catch (cause) {
+        if (!cancelled) {
+          setError(cause instanceof Error ? cause.message : String(cause))
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [overwrite, source])
+
+  const handleCancel = React.useCallback(() => {
+    onDone('Cancelled skill import.', { display: 'system' })
+  }, [onDone])
+
+  const handleChoice = React.useCallback(
+    async (value: 'import' | 'cancel') => {
+      if (value === 'cancel') {
+        handleCancel()
+        return
+      }
+
+      setIsSubmitting(true)
+      try {
+        const result = await runKairosCommand(`${args} --yes`)
+        onDone(result, { display: 'system' })
+      } catch (cause) {
+        const message = cause instanceof Error ? cause.message : String(cause)
+        onDone(`kairos: ${message}`, { display: 'system' })
+      }
+    },
+    [args, handleCancel, onDone],
+  )
+
+  const title = overwrite ? 'Overwrite imported skill?' : 'Import skill?'
+  const subtitle = source
+
+  if (error) {
+    return (
+      <Dialog title={title} subtitle={subtitle} onCancel={handleCancel} color="warning">
+        <Text color="error">{error}</Text>
+      </Dialog>
+    )
+  }
+
+  if (!preview) {
+    return (
+      <Dialog title={title} subtitle={subtitle} onCancel={handleCancel}>
+        <Text dimColor>Loading import preview…</Text>
+      </Dialog>
+    )
+  }
+
+  const options = [
+    {
+      label: overwrite ? 'Overwrite skill' : 'Import skill',
+      value: 'import' as const,
+      disabled: isSubmitting,
+    },
+    {
+      label: 'Cancel',
+      value: 'cancel' as const,
+      disabled: isSubmitting,
+    },
+  ]
+
+  return (
+    <Dialog title={title} subtitle={subtitle} onCancel={handleCancel}>
+      <Box flexDirection="column" gap={1}>
+        {preview.split('\n').map((line, index) => (
+          <Text key={index}>{line.length > 0 ? line : ' '}</Text>
+        ))}
+        <Select onChange={handleChoice} options={options} />
+      </Box>
+    </Dialog>
+  )
+}
+
+function getInteractiveImportArgs(args: string): {
+  source: string
+  overwrite: boolean
+} | null {
+  const trimmed = args.trim()
+  if (!trimmed.startsWith('skills import ')) {
+    return null
+  }
+
+  const parsed = parseImportArgs(trimmed.slice('skills import '.length))
+  if (!parsed.source || parsed.confirm) {
+    return null
+  }
+
+  return {
+    source: parsed.source,
+    overwrite: parsed.overwrite,
+  }
+}
+
+export const call: LocalJSXCommandCall = async (onDone, _context, args) => {
+  return <KairosCommandRunner args={args} onDone={onDone} />
+}

--- a/src 2/commands/kairos.test.ts
+++ b/src 2/commands/kairos.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { mkdirSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import kairos from './kairos.js'
 import {
   getProjectRoot,
   setProjectRoot,
@@ -43,6 +44,10 @@ afterEach(() => {
 })
 
 describe('/kairos command', () => {
+  test('exports a local-jsx command for interactive confirmation flows', () => {
+    expect(kairos.type).toBe('local-jsx')
+  })
+
   test('prints help when called with no args', async () => {
     const out = await runKairosCommand('')
     expect(out).toContain('/kairos status')
@@ -236,5 +241,82 @@ describe('/kairos command', () => {
 
     const out = await runKairosCommand('logs 3')
     expect(out).toBe(['b', 'c', 'd'].join('\n'))
+  })
+
+  test('skills export emits a self-contained manifest', async () => {
+    const projectDir = makeProjectDir()
+    setProjectRoot(projectDir)
+    mkdirSync(join(projectDir, '.claude', 'skills', 'example'), {
+      recursive: true,
+    })
+    writeFileSync(
+      join(projectDir, '.claude', 'skills', 'example', 'SKILL.md'),
+      [
+        '---',
+        'name: example',
+        'description: Example exported skill.',
+        '---',
+        '',
+        'Use this skill to verify command routing.',
+        '',
+      ].join('\n'),
+    )
+
+    const out = await runKairosCommand('skills export example')
+    const parsed = JSON.parse(out) as {
+      skills: Array<{ url: string }>
+    }
+    expect(parsed.skills[0]?.url.startsWith('data:text/markdown;base64,')).toBe(
+      true,
+    )
+  })
+
+  test('skills import previews first and writes on --yes', async () => {
+    const sourceDir = makeProjectDir()
+    mkdirSync(join(sourceDir, 'example'), { recursive: true })
+    writeFileSync(
+      join(sourceDir, 'example', 'SKILL.md'),
+      [
+        '---',
+        'name: example',
+        'description: Example imported skill.',
+        '---',
+        '',
+        'Use this skill to verify import command routing.',
+        '',
+      ].join('\n'),
+    )
+
+    const preview = await runKairosCommand(`skills import ${join(sourceDir, 'example')}`)
+    expect(preview).toContain('Import preview')
+
+    const confirmed = await runKairosCommand(
+      `skills import ${join(sourceDir, 'example')} --yes`,
+    )
+    expect(confirmed).toContain('Imported skill')
+  })
+
+  test('skills import supports confirmed pasted JSON manifests', async () => {
+    const projectDir = makeProjectDir()
+    setProjectRoot(projectDir)
+    mkdirSync(join(projectDir, '.claude', 'skills', 'example'), {
+      recursive: true,
+    })
+    writeFileSync(
+      join(projectDir, '.claude', 'skills', 'example', 'SKILL.md'),
+      [
+        '---',
+        'name: example',
+        'description: Example exported skill.',
+        '---',
+        '',
+        'Use this skill to verify JSON blob import routing.',
+        '',
+      ].join('\n'),
+    )
+
+    const manifest = await runKairosCommand('skills export example')
+    const confirmed = await runKairosCommand(`skills import --yes ${manifest}`)
+    expect(confirmed).toContain('Imported skill')
   })
 })

--- a/src 2/commands/kairos.ts
+++ b/src 2/commands/kairos.ts
@@ -10,7 +10,8 @@
 
 import { readFile } from 'fs/promises'
 import { getProjectRoot } from '../bootstrap/state.js'
-import type { Command, LocalCommandCall } from '../types/command.js'
+import type { Command } from '../types/command.js'
+import { runKairosSkillsInteropCommand } from './kairos-skills-interop.js'
 import {
   enqueueDemoTask,
   optInProject,
@@ -39,7 +40,10 @@ const HELP_TEXT = `Usage:
 /kairos pause
 /kairos resume
 /kairos dashboard
-/kairos logs [projectDir] [lines]`
+/kairos logs [projectDir] [lines]
+/kairos skills lint <path|skill-name|manifest-json>
+/kairos skills import <url|path|manifest-json> [--yes] [--overwrite]
+/kairos skills export <path|skill-name> [--publish]`
 
 type Subcommand =
   | 'status'
@@ -51,6 +55,7 @@ type Subcommand =
   | 'resume'
   | 'dashboard'
   | 'logs'
+  | 'skills'
 
 const SUBCOMMANDS = new Set<Subcommand>([
   'status',
@@ -62,6 +67,7 @@ const SUBCOMMANDS = new Set<Subcommand>([
   'resume',
   'dashboard',
   'logs',
+  'skills',
 ])
 
 function parseArgs(args: string): { sub: Subcommand | null; rest: string[] } {
@@ -228,26 +234,20 @@ export async function runKairosCommand(args: string): Promise<string> {
       }
       return handleLogs(undefined, first)
     }
-  }
-}
-
-const call: LocalCommandCall = async args => {
-  try {
-    const value = await runKairosCommand(args)
-    return { type: 'text', value }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    return { type: 'text', value: `kairos: ${message}` }
+    case 'skills':
+      return runKairosSkillsInteropCommand(
+        args.trim().slice('skills'.length).trim(),
+      )
   }
 }
 
 const kairos = {
-  type: 'local',
+  type: 'local-jsx',
   name: 'kairos',
   description: 'Inspect and control the KAIROS background daemon',
-  argumentHint: 'status|list|opt-in|opt-out|demo|pause|resume|dashboard|logs',
-  supportsNonInteractive: true,
-  load: () => Promise.resolve({ call }),
+  argumentHint:
+    'status|list|opt-in|opt-out|demo|pause|resume|dashboard|logs|skills',
+  load: () => import('./kairos-ui.js'),
 } satisfies Command
 
 export default kairos

--- a/src 2/services/skillInterop/exportSkill.ts
+++ b/src 2/services/skillInterop/exportSkill.ts
@@ -1,0 +1,29 @@
+import { jsonStringify } from '../../utils/slowOperations.js'
+import {
+  AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0,
+} from './manifestSchema.js'
+import { readLocalSkillDocument, validateSkillDocument, computeSkillChecksum } from './shared.js'
+
+export async function exportSkill(reference: string): Promise<string> {
+  const skill = await readLocalSkillDocument(reference)
+  const violations = validateSkillDocument(skill)
+  if (violations.length > 0) {
+    const message = violations.map(v => `${v.path}: ${v.message}`).join('\n')
+    throw new Error(`Cannot export invalid skill:\n${message}`)
+  }
+
+  const manifest = {
+    $schema: AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0,
+    skills: [
+      {
+        name: skill.name,
+        type: 'skill-md' as const,
+        description: skill.description,
+        url: `data:text/markdown;base64,${skill.rawBytes.toString('base64')}`,
+        digest: computeSkillChecksum(skill.rawBytes),
+      },
+    ],
+  }
+
+  return `${jsonStringify(manifest, null, 2)}\n`
+}

--- a/src 2/services/skillInterop/importSkill.ts
+++ b/src 2/services/skillInterop/importSkill.ts
@@ -1,0 +1,125 @@
+import {
+  appendImportTelemetryEvent,
+  buildDiffPreview,
+  getImportedSkillPaths,
+  readExistingImport,
+  resolveSkillSource,
+  writeImportedSkill,
+  type ResolvedSkillSource,
+} from './shared.js'
+import { scanSuspiciousSkillContent } from './suspiciousPatterns.js'
+
+type ImportSkillOptions = {
+  confirm?: boolean
+  overwrite?: boolean
+  fetchImpl?: typeof fetch
+  now?: Date
+}
+
+export async function importSkill(
+  input: string,
+  options: ImportSkillOptions = {},
+): Promise<string> {
+  const resolved = await resolveSkillSource(input, {
+    fetchImpl: options.fetchImpl,
+  })
+  const suspiciousHits = scanSuspiciousSkillContent(resolved.skill.markdown)
+  const existing = await readExistingImport(resolved.sourceHost, resolved.skill.name)
+  const paths = getImportedSkillPaths(resolved.sourceHost, resolved.skill.name)
+
+  if (existing.checksum === resolved.checksum) {
+    return `Skill already imported at ${paths.dir}.`
+  }
+
+  if (
+    existing.checksum &&
+    existing.checksum !== resolved.checksum &&
+    !options.overwrite
+  ) {
+    throw new Error(
+      `checksum mismatch, use --overwrite to replace ${paths.dir}`,
+    )
+  }
+
+  const preview = buildImportPreview({
+    resolved,
+    existingMarkdown: existing.markdown ?? '',
+    suspiciousLabels: suspiciousHits.map(hit => hit.label),
+    destination: paths.dir,
+    overwrite: Boolean(existing.checksum),
+  })
+
+  if (!options.confirm) {
+    return `${preview}\n\nRe-run with --yes to write the imported skill.`
+  }
+
+  const importedAt = (options.now ?? new Date()).toISOString()
+  await writeImportedSkill(resolved, {
+    source: resolved.sourceDisplay,
+    sourceKind: resolved.sourceKind,
+    sourceHost: resolved.sourceHost,
+    manifestSchema: resolved.manifestSchema,
+    manifestUrl: resolved.manifestUrl,
+    artifactUrl: resolved.artifactUrl,
+    checksum: resolved.checksum,
+    importedAt,
+  })
+
+  await appendImportTelemetryEvent({
+    event: 'kairos_skill_import',
+    timestamp: importedAt,
+    outcome: existing.checksum ? 'overwritten' : 'imported',
+    source_kind: resolved.sourceKind,
+    source: resolved.sourceDisplay,
+    source_host: resolved.sourceHost,
+    manifest_schema: resolved.manifestSchema,
+    manifest_url: resolved.manifestUrl,
+    artifact_url: resolved.artifactUrl,
+    skill_name: resolved.skill.name,
+    checksum: resolved.checksum,
+    suspicious_pattern_ids: suspiciousHits.map(hit => hit.id),
+    suspicious_pattern_count: suspiciousHits.length,
+    destination: paths.dir,
+  })
+
+  const status = existing.checksum ? 'Overwrote' : 'Imported'
+  const warningSuffix =
+    suspiciousHits.length > 0
+      ? ` Warning: flagged ${suspiciousHits.length} suspicious pattern(s).`
+      : ''
+
+  return `${status} skill to ${paths.dir}.${warningSuffix}`
+}
+
+function buildImportPreview(input: {
+  resolved: ResolvedSkillSource
+  existingMarkdown: string
+  suspiciousLabels: string[]
+  destination: string
+  overwrite: boolean
+}): string {
+  const lines = [
+    'Import preview',
+    `source: ${input.resolved.sourceDisplay}`,
+    `name: ${input.resolved.skill.name}`,
+    `description: ${input.resolved.skill.description}`,
+    `checksum: ${input.resolved.checksum}`,
+    `destination: ${input.destination}`,
+    `mode: ${input.overwrite ? 'overwrite' : 'new import'}`,
+  ]
+
+  if (input.resolved.manifestSchema) {
+    lines.push(`manifest: ${input.resolved.manifestSchema}`)
+  }
+
+  if (input.suspiciousLabels.length > 0) {
+    lines.push('suspicious patterns:')
+    for (const label of input.suspiciousLabels) {
+      lines.push(`- ${label}`)
+    }
+  }
+
+  lines.push('diff:')
+  lines.push(buildDiffPreview(input.existingMarkdown, input.resolved.skill.markdown))
+  return lines.join('\n')
+}

--- a/src 2/services/skillInterop/lintSkill.ts
+++ b/src 2/services/skillInterop/lintSkill.ts
@@ -1,0 +1,47 @@
+import { readFile } from 'fs/promises'
+import { readLocalSkillDocument, readManifestArtifactForLint, type SkillInteropViolation, validateSkillDocument } from './shared.js'
+
+export type LintSkillResult = {
+  ok: boolean
+  violations: SkillInteropViolation[]
+}
+
+export async function lintSkill(target: string): Promise<LintSkillResult> {
+  const trimmed = target.trim()
+  if (!trimmed) {
+    throw new Error('Missing lint target.')
+  }
+
+  if (trimmed.startsWith('{')) {
+    const manifestResult = await readManifestArtifactForLint(trimmed)
+    return combineManifestLintResult(manifestResult)
+  }
+
+  try {
+    const raw = await readFile(trimmed, 'utf8')
+    if (raw.trim().startsWith('{')) {
+      const manifestResult = await readManifestArtifactForLint(raw)
+      return combineManifestLintResult(manifestResult)
+    }
+  } catch {
+    // Fall through to local skill resolution by name/path.
+  }
+
+  const skill = await readLocalSkillDocument(trimmed)
+  const violations = validateSkillDocument(skill)
+  return {
+    ok: violations.length === 0,
+    violations,
+  }
+}
+
+function combineManifestLintResult(result: {
+  manifestViolations: SkillInteropViolation[]
+  skillViolations: SkillInteropViolation[]
+}): LintSkillResult {
+  const violations = [...result.manifestViolations, ...result.skillViolations]
+  return {
+    ok: violations.length === 0,
+    violations,
+  }
+}

--- a/src 2/services/skillInterop/manifestSchema.ts
+++ b/src 2/services/skillInterop/manifestSchema.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+// KAIROS pins the public Agent Skills discovery index v0.2.0 for interop.
+// We additionally allow `data:` and `file:` artifact URLs so exported manifests
+// stay self-contained and lintable offline.
+export const AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0 =
+  'https://schemas.agentskills.io/discovery/0.2.0/schema.json'
+
+export const SUPPORTED_MANIFEST_SCHEMA_VERSIONS = new Set([
+  AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0,
+])
+
+export const SKILL_NAME_REGEX = /^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$/
+export const SHA256_DIGEST_REGEX = /^sha256:[0-9a-f]{64}$/
+export const MAX_SKILL_BODY_BYTES = 64 * 1024
+
+export const discoverySkillEntrySchema = z.object({
+  name: z.string().regex(SKILL_NAME_REGEX),
+  type: z.enum(['skill-md', 'archive']),
+  description: z.string().min(1).max(1024),
+  url: z.string().min(1),
+  digest: z.string().regex(SHA256_DIGEST_REGEX),
+})
+
+export const discoveryManifestSchema = z.object({
+  $schema: z.literal(AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0),
+  skills: z.array(discoverySkillEntrySchema).min(1),
+})
+
+export type DiscoverySkillEntry = z.infer<typeof discoverySkillEntrySchema>
+export type DiscoveryManifest = z.infer<typeof discoveryManifestSchema>

--- a/src 2/services/skillInterop/shared.ts
+++ b/src 2/services/skillInterop/shared.ts
@@ -1,0 +1,771 @@
+import { createHash } from 'crypto'
+import { diffLines } from 'diff'
+import {
+  access,
+  appendFile,
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+  writeFile,
+} from 'fs/promises'
+import { basename, dirname, isAbsolute, join, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { getProjectRoot } from '../../bootstrap/state.js'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+import { parseFrontmatter } from '../../utils/frontmatterParser.js'
+import { safeParseJSON } from '../../utils/json.js'
+import { jsonStringify } from '../../utils/slowOperations.js'
+import {
+  AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0,
+  MAX_SKILL_BODY_BYTES,
+  SKILL_NAME_REGEX,
+  type DiscoveryManifest,
+  discoveryManifestSchema,
+} from './manifestSchema.js'
+
+export type SkillInteropViolation = {
+  path: string
+  message: string
+}
+
+export type SkillDocument = {
+  markdown: string
+  rawBytes: Buffer
+  name: string
+  description: string
+  body: string
+}
+
+export type ResolvedSkillSource = {
+  sourceKind: 'url' | 'file' | 'json-blob'
+  sourceDisplay: string
+  sourceHost: string
+  manifestSchema: string | null
+  manifestUrl: string | null
+  artifactUrl: string | null
+  checksum: string
+  skill: SkillDocument
+}
+
+export type ImportTelemetryEvent = {
+  event: 'kairos_skill_import'
+  timestamp: string
+  outcome: 'imported' | 'overwritten'
+  source_kind: ResolvedSkillSource['sourceKind']
+  source: string
+  source_host: string
+  manifest_schema: string | null
+  manifest_url: string | null
+  artifact_url: string | null
+  skill_name: string
+  checksum: string
+  suspicious_pattern_ids: string[]
+  suspicious_pattern_count: number
+  destination: string
+}
+
+type ResolveOptions = {
+  fetchImpl?: typeof fetch
+  allowRemoteArtifacts?: boolean
+}
+
+type ArtifactLoadContext = {
+  baseUrl?: string | null
+  baseFilePath?: string | null
+  allowRemoteArtifacts: boolean
+  fetchImpl?: typeof fetch
+}
+
+type LoadedArtifact = {
+  bytes: Buffer
+  resolvedLocation: string
+}
+
+export function computeSkillChecksum(bytes: Uint8Array): string {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`
+}
+
+export function parseSkillDocument(
+  markdown: string,
+  rawBytes: Buffer,
+  sourceLabel: string,
+): SkillDocument {
+  const { frontmatter, content } = parseFrontmatter(markdown, sourceLabel)
+  const name = typeof frontmatter.name === 'string' ? frontmatter.name.trim() : ''
+  const description =
+    typeof frontmatter.description === 'string'
+      ? frontmatter.description.trim()
+      : ''
+
+  return {
+    markdown,
+    rawBytes,
+    name,
+    description,
+    body: content,
+  }
+}
+
+export function validateSkillDocument(doc: SkillDocument): SkillInteropViolation[] {
+  const violations: SkillInteropViolation[] = []
+
+  if (!doc.name) {
+    violations.push({
+      path: 'frontmatter.name',
+      message: 'Missing required `name` field in SKILL.md frontmatter.',
+    })
+  } else if (!SKILL_NAME_REGEX.test(doc.name)) {
+    violations.push({
+      path: 'frontmatter.name',
+      message:
+        'Invalid skill name. Use 1-64 lowercase letters, numbers, or hyphens with no leading, trailing, or consecutive hyphens.',
+    })
+  }
+
+  if (!doc.description) {
+    violations.push({
+      path: 'frontmatter.description',
+      message: 'Missing required `description` field in SKILL.md frontmatter.',
+    })
+  }
+
+  if (doc.rawBytes.byteLength > MAX_SKILL_BODY_BYTES) {
+    violations.push({
+      path: 'body',
+      message: `Skill body is ${doc.rawBytes.byteLength} bytes; the KAIROS interop limit is ${MAX_SKILL_BODY_BYTES} bytes.`,
+    })
+  }
+
+  return violations
+}
+
+export function validateDiscoveryManifestObject(
+  raw: unknown,
+): { manifest: DiscoveryManifest | null; violations: SkillInteropViolation[] } {
+  const violations: SkillInteropViolation[] = []
+
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {
+      manifest: null,
+      violations: [
+        { path: '$', message: 'Manifest must be a JSON object.' },
+      ],
+    }
+  }
+
+  const schemaValue =
+    '$schema' in raw && typeof raw.$schema === 'string' ? raw.$schema : null
+  if (schemaValue !== AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0) {
+    violations.push({
+      path: '$schema',
+      message: `Unsupported manifest schema. Expected ${AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0}.`,
+    })
+  }
+
+  const parsed = discoveryManifestSchema.safeParse(raw)
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      violations.push({
+        path: issue.path.join('.') || '$',
+        message: issue.message,
+      })
+    }
+    return { manifest: null, violations }
+  }
+
+  if (parsed.data.skills.length !== 1) {
+    violations.push({
+      path: 'skills',
+      message: 'KAIROS v1 only supports manifests with exactly one skill entry.',
+    })
+  }
+
+  if (parsed.data.skills[0]?.type !== 'skill-md') {
+    violations.push({
+      path: 'skills.0.type',
+      message:
+        'KAIROS v1 only supports `skill-md` artifact entries. Archive support is a follow-up.',
+    })
+  }
+
+  return { manifest: parsed.data, violations }
+}
+
+export async function resolveSkillSource(
+  input: string,
+  options: ResolveOptions = {},
+): Promise<ResolvedSkillSource> {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    throw new Error('Missing import source.')
+  }
+
+  if (isHttpUrl(trimmed)) {
+    return resolveUrlSource(trimmed, options.fetchImpl)
+  }
+
+  if (looksLikeJson(trimmed)) {
+    return resolveJsonBlobSource(trimmed)
+  }
+
+  return resolveFileSource(trimmed)
+}
+
+async function resolveUrlSource(
+  url: string,
+  fetchImpl: typeof fetch | undefined,
+): Promise<ResolvedSkillSource> {
+  const response = await getFetch(fetchImpl)(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`)
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer())
+  const text = bytes.toString('utf8')
+  if (looksLikeJson(text)) {
+    return resolveManifestText(text, {
+      sourceKind: 'url',
+      sourceDisplay: url,
+      sourceHost: getUrlHost(url),
+      baseUrl: url,
+      allowRemoteArtifacts: true,
+      fetchImpl,
+    })
+  }
+
+  return buildDirectSkillSource({
+    sourceKind: 'url',
+    sourceDisplay: url,
+    sourceHost: getUrlHost(url),
+    artifactLocation: url,
+    rawBytes: bytes,
+    markdown: text,
+  })
+}
+
+async function resolveJsonBlobSource(input: string): Promise<ResolvedSkillSource> {
+  return resolveManifestText(input, {
+    sourceKind: 'json-blob',
+    sourceDisplay: '<json-blob>',
+    sourceHost: 'inline',
+    baseUrl: null,
+    allowRemoteArtifacts: false,
+  })
+}
+
+async function resolveFileSource(input: string): Promise<ResolvedSkillSource> {
+  const resolved = resolve(input)
+  const stats = await stat(resolved).catch(() => null)
+  if (!stats) {
+    throw new Error(`Local path not found: ${input}`)
+  }
+
+  if (stats.isDirectory()) {
+    const skillPath = join(resolved, 'SKILL.md')
+    const bytes = await readFile(skillPath)
+    return buildDirectSkillSource({
+      sourceKind: 'file',
+      sourceDisplay: resolved,
+      sourceHost: 'local',
+      artifactLocation: skillPath,
+      rawBytes: bytes,
+      markdown: bytes.toString('utf8'),
+    })
+  }
+
+  const bytes = await readFile(resolved)
+  const text = bytes.toString('utf8')
+  if (looksLikeJson(text)) {
+    return resolveManifestText(text, {
+      sourceKind: 'file',
+      sourceDisplay: resolved,
+      sourceHost: 'local',
+      baseFilePath: resolved,
+      allowRemoteArtifacts: false,
+    })
+  }
+
+  return buildDirectSkillSource({
+    sourceKind: 'file',
+    sourceDisplay: resolved,
+    sourceHost: 'local',
+    artifactLocation: resolved,
+    rawBytes: bytes,
+    markdown: text,
+  })
+}
+
+async function resolveManifestText(
+  text: string,
+  context: {
+    sourceKind: ResolvedSkillSource['sourceKind']
+    sourceDisplay: string
+    sourceHost: string
+    baseUrl?: string | null
+    baseFilePath?: string | null
+    allowRemoteArtifacts: boolean
+    fetchImpl?: typeof fetch
+  },
+): Promise<ResolvedSkillSource> {
+  const parsedJson = safeParseJSON(text, false)
+  const validation = validateDiscoveryManifestObject(parsedJson)
+  if (validation.violations.length > 0 || validation.manifest === null) {
+    const details = validation.violations.map(v => `${v.path}: ${v.message}`).join('\n')
+    throw new Error(`Manifest validation failed:\n${details}`)
+  }
+
+  const entry = validation.manifest.skills[0]
+  if (!entry) {
+    throw new Error('Manifest contained no skill entries.')
+  }
+
+  const artifact = await loadArtifactBytes(entry.url, {
+    baseUrl: context.baseUrl,
+    baseFilePath: context.baseFilePath,
+    allowRemoteArtifacts: context.allowRemoteArtifacts,
+    fetchImpl: context.fetchImpl,
+  })
+
+  const checksum = computeSkillChecksum(artifact.bytes)
+  if (checksum !== entry.digest) {
+    throw new Error(
+      `Manifest digest mismatch for ${entry.name}. Expected ${entry.digest}, got ${checksum}.`,
+    )
+  }
+
+  const skill = parseSkillDocument(
+    artifact.bytes.toString('utf8'),
+    artifact.bytes,
+    artifact.resolvedLocation,
+  )
+  const skillViolations = validateSkillDocument(skill)
+  if (skillViolations.length > 0) {
+    const details = skillViolations
+      .map(v => `${v.path}: ${v.message}`)
+      .join('\n')
+    throw new Error(`Skill validation failed:\n${details}`)
+  }
+
+  if (skill.name !== entry.name) {
+    throw new Error(
+      `Manifest name ${entry.name} does not match SKILL.md frontmatter name ${skill.name}.`,
+    )
+  }
+
+  if (skill.description !== entry.description) {
+    throw new Error(
+      'Manifest description does not match SKILL.md frontmatter description.',
+    )
+  }
+
+  return {
+    sourceKind: context.sourceKind,
+    sourceDisplay: context.sourceDisplay,
+    sourceHost:
+      resolveSourceHostFromArtifact(artifact.resolvedLocation) ?? context.sourceHost,
+    manifestSchema: validation.manifest.$schema,
+    manifestUrl: context.baseUrl ?? context.baseFilePath ?? null,
+    artifactUrl: artifact.resolvedLocation,
+    checksum,
+    skill,
+  }
+}
+
+function buildDirectSkillSource(input: {
+  sourceKind: ResolvedSkillSource['sourceKind']
+  sourceDisplay: string
+  sourceHost: string
+  artifactLocation: string
+  rawBytes: Buffer
+  markdown: string
+}): ResolvedSkillSource {
+  const skill = parseSkillDocument(input.markdown, input.rawBytes, input.artifactLocation)
+  const skillViolations = validateSkillDocument(skill)
+  if (skillViolations.length > 0) {
+    const details = skillViolations.map(v => `${v.path}: ${v.message}`).join('\n')
+    throw new Error(`Skill validation failed:\n${details}`)
+  }
+
+  return {
+    sourceKind: input.sourceKind,
+    sourceDisplay: input.sourceDisplay,
+    sourceHost: input.sourceHost,
+    manifestSchema: null,
+    manifestUrl: null,
+    artifactUrl: input.artifactLocation,
+    checksum: computeSkillChecksum(input.rawBytes),
+    skill,
+  }
+}
+
+async function loadArtifactBytes(
+  location: string,
+  context: ArtifactLoadContext,
+): Promise<LoadedArtifact> {
+  if (location.startsWith('data:')) {
+    return decodeDataUrl(location)
+  }
+
+  if (location.startsWith('file://')) {
+    const path = fileURLToPath(location)
+    return {
+      bytes: await readFile(path),
+      resolvedLocation: location,
+    }
+  }
+
+  if (isHttpUrl(location)) {
+    if (!context.allowRemoteArtifacts) {
+      throw new Error(
+        'Remote artifact URLs are only allowed when the top-level import source is an http(s) URL.',
+      )
+    }
+    const response = await getFetch(context.fetchImpl)(location)
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch artifact ${location}: ${response.status} ${response.statusText}`,
+      )
+    }
+    return {
+      bytes: Buffer.from(await response.arrayBuffer()),
+      resolvedLocation: location,
+    }
+  }
+
+  if (context.baseUrl) {
+    const resolvedUrl = new URL(location, context.baseUrl).toString()
+    return loadArtifactBytes(resolvedUrl, context)
+  }
+
+  if (context.baseFilePath) {
+    const resolvedPath = isAbsolute(location)
+      ? location
+      : resolve(dirname(context.baseFilePath), location)
+    return {
+      bytes: await readFile(resolvedPath),
+      resolvedLocation: resolvedPath,
+    }
+  }
+
+  if (isAbsolute(location)) {
+    return {
+      bytes: await readFile(location),
+      resolvedLocation: location,
+    }
+  }
+
+  throw new Error(
+    `Cannot resolve artifact URL ${location} without a base file path or base URL.`,
+  )
+}
+
+function decodeDataUrl(url: string): LoadedArtifact {
+  const match = url.match(/^data:([^,]*?),(.*)$/s)
+  if (!match) {
+    throw new Error('Invalid data: URL in manifest.')
+  }
+  const metadata = match[1] ?? ''
+  const payload = match[2] ?? ''
+  const isBase64 = metadata.includes(';base64')
+  const bytes = isBase64
+    ? Buffer.from(payload, 'base64')
+    : Buffer.from(decodeURIComponent(payload), 'utf8')
+  return {
+    bytes,
+    resolvedLocation: url,
+  }
+}
+
+export function buildDiffPreview(
+  existingContent: string,
+  nextContent: string,
+  maxLines: number = 160,
+): string {
+  const diff = diffLines(existingContent, nextContent)
+  const lines = ['--- existing/SKILL.md', '+++ incoming/SKILL.md']
+  let emitted = 0
+
+  for (const part of diff) {
+    const prefix = part.added ? '+' : part.removed ? '-' : ' '
+    const chunkLines = part.value.split('\n')
+    for (const line of chunkLines) {
+      if (line === '' && emitted > 0 && emitted >= maxLines) {
+        continue
+      }
+      if (emitted >= maxLines) {
+        lines.push('... diff truncated ...')
+        return lines.join('\n')
+      }
+      lines.push(`${prefix}${line}`)
+      emitted++
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export function formatViolations(violations: SkillInteropViolation[]): string {
+  if (violations.length === 0) {
+    return 'valid'
+  }
+  return violations.map(v => `- ${v.path}: ${v.message}`).join('\n')
+}
+
+export function getImportedSkillDir(sourceHost: string, skillName: string): string {
+  return join(
+    getClaudeConfigHomeDir(),
+    'skills',
+    'imported',
+    sanitizePathSegment(sourceHost),
+    skillName,
+  )
+}
+
+export function getImportedSkillPaths(sourceHost: string, skillName: string): {
+  dir: string
+  skillFile: string
+  provenanceFile: string
+} {
+  const dir = getImportedSkillDir(sourceHost, skillName)
+  return {
+    dir,
+    skillFile: join(dir, 'SKILL.md'),
+    provenanceFile: join(dir, '.provenance.json'),
+  }
+}
+
+export async function readExistingImport(
+  sourceHost: string,
+  skillName: string,
+): Promise<{
+  markdown: string | null
+  checksum: string | null
+}> {
+  const { skillFile, provenanceFile } = getImportedSkillPaths(sourceHost, skillName)
+  const [markdown, provenance] = await Promise.all([
+    readFile(skillFile, 'utf8').catch(() => null),
+    readFile(provenanceFile, 'utf8')
+      .then(raw => safeParseJSON(raw, false))
+      .catch(() => null),
+  ])
+
+  const checksum =
+    provenance &&
+    typeof provenance === 'object' &&
+    provenance !== null &&
+    'checksum' in provenance &&
+    typeof provenance.checksum === 'string'
+      ? provenance.checksum
+      : markdown
+        ? computeSkillChecksum(Buffer.from(markdown, 'utf8'))
+        : null
+
+  return { markdown, checksum }
+}
+
+export async function writeImportedSkill(
+  resolved: ResolvedSkillSource,
+  provenance: Record<string, unknown>,
+): Promise<void> {
+  const paths = getImportedSkillPaths(resolved.sourceHost, resolved.skill.name)
+  await mkdir(paths.dir, { recursive: true })
+  await writeFile(paths.skillFile, resolved.skill.rawBytes)
+  await writeFile(paths.provenanceFile, jsonStringify(provenance, null, 2) + '\n')
+}
+
+export async function appendImportTelemetryEvent(
+  event: ImportTelemetryEvent,
+): Promise<void> {
+  const dir = join(getClaudeConfigHomeDir(), 'kairos')
+  await mkdir(dir, { recursive: true })
+  await appendFile(
+    join(dir, 'skill-interop-events.jsonl'),
+    `${jsonStringify(event)}\n`,
+  )
+}
+
+export async function resolveLocalSkillFile(reference: string): Promise<string> {
+  const trimmed = reference.trim()
+  if (!trimmed) {
+    throw new Error('Missing local skill reference.')
+  }
+
+  const directPath = resolve(trimmed)
+  if (await pathExists(directPath)) {
+    const stats = await stat(directPath)
+    if (stats.isDirectory()) {
+      const skillPath = join(directPath, 'SKILL.md')
+      if (await pathExists(skillPath)) {
+        return skillPath
+      }
+      throw new Error(`Directory does not contain SKILL.md: ${trimmed}`)
+    }
+    return directPath
+  }
+
+  const projectCandidate = join(getProjectRoot(), '.claude', 'skills', trimmed, 'SKILL.md')
+  if (await pathExists(projectCandidate)) {
+    return projectCandidate
+  }
+
+  const userCandidate = join(getClaudeConfigHomeDir(), 'skills', trimmed, 'SKILL.md')
+  if (await pathExists(userCandidate)) {
+    return userCandidate
+  }
+
+  const importedRoot = join(getClaudeConfigHomeDir(), 'skills', 'imported')
+  const hostDirs = await readdir(importedRoot, { withFileTypes: true }).catch(() => [])
+  for (const hostDir of hostDirs) {
+    if (!hostDir.isDirectory()) continue
+    const candidate = join(importedRoot, hostDir.name, trimmed, 'SKILL.md')
+    if (await pathExists(candidate)) {
+      return candidate
+    }
+  }
+
+  throw new Error(`Unable to resolve local skill reference: ${reference}`)
+}
+
+export async function readLocalSkillDocument(reference: string): Promise<SkillDocument> {
+  const file = await resolveLocalSkillFile(reference)
+  const bytes = await readFile(file)
+  const doc = parseSkillDocument(bytes.toString('utf8'), bytes, file)
+  return doc
+}
+
+export async function readManifestArtifactForLint(
+  input: string,
+): Promise<{
+  manifest: DiscoveryManifest | null
+  manifestViolations: SkillInteropViolation[]
+  skill: SkillDocument | null
+  skillViolations: SkillInteropViolation[]
+}> {
+  const raw = safeParseJSON(input, false)
+  const validation = validateDiscoveryManifestObject(raw)
+  if (validation.manifest === null) {
+    return {
+      manifest: null,
+      manifestViolations: validation.violations,
+      skill: null,
+      skillViolations: [],
+    }
+  }
+
+  const entry = validation.manifest.skills[0]
+  if (!entry) {
+    return {
+      manifest: validation.manifest,
+      manifestViolations: validation.violations,
+      skill: null,
+      skillViolations: [],
+    }
+  }
+
+  if (entry.type !== 'skill-md') {
+    return {
+      manifest: validation.manifest,
+      manifestViolations: validation.violations,
+      skill: null,
+      skillViolations: [],
+    }
+  }
+
+  try {
+    const artifact = await loadArtifactBytes(entry.url, {
+      allowRemoteArtifacts: false,
+      baseFilePath: null,
+      baseUrl: null,
+    })
+    const checksum = computeSkillChecksum(artifact.bytes)
+    const manifestViolations = [...validation.violations]
+    if (checksum !== entry.digest) {
+      manifestViolations.push({
+        path: 'skills.0.digest',
+        message: `Digest mismatch. Expected ${entry.digest}, got ${checksum}.`,
+      })
+    }
+
+    const skill = parseSkillDocument(
+      artifact.bytes.toString('utf8'),
+      artifact.bytes,
+      artifact.resolvedLocation,
+    )
+    const skillViolations = validateSkillDocument(skill)
+    if (skill.name && skill.name !== entry.name) {
+      skillViolations.push({
+        path: 'frontmatter.name',
+        message: `SKILL.md name ${skill.name} does not match manifest name ${entry.name}.`,
+      })
+    }
+    if (skill.description && skill.description !== entry.description) {
+      skillViolations.push({
+        path: 'frontmatter.description',
+        message: 'SKILL.md description does not match manifest description.',
+      })
+    }
+
+    return {
+      manifest: validation.manifest,
+      manifestViolations,
+      skill,
+      skillViolations,
+    }
+  } catch (error) {
+    return {
+      manifest: validation.manifest,
+      manifestViolations: [
+        ...validation.violations,
+        {
+          path: 'skills.0.url',
+          message:
+            error instanceof Error ? error.message : 'Unable to resolve manifest artifact.',
+        },
+      ],
+      skill: null,
+      skillViolations: [],
+    }
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function looksLikeJson(input: string): boolean {
+  const trimmed = input.trim()
+  return trimmed.startsWith('{')
+}
+
+function isHttpUrl(input: string): boolean {
+  return /^https?:\/\//i.test(input)
+}
+
+function getFetch(fetchImpl?: typeof fetch): typeof fetch {
+  const resolved = fetchImpl ?? globalThis.fetch
+  if (!resolved) {
+    throw new Error('fetch is not available in this runtime.')
+  }
+  return resolved
+}
+
+function getUrlHost(url: string): string {
+  return new URL(url).host || 'remote'
+}
+
+function resolveSourceHostFromArtifact(location: string): string | null {
+  if (location.startsWith('http://') || location.startsWith('https://')) {
+    return getUrlHost(location)
+  }
+  return null
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9.-]+/g, '-')
+}

--- a/src 2/services/skillInterop/skillInterop.test.ts
+++ b/src 2/services/skillInterop/skillInterop.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { computeSkillChecksum } from './shared.js'
+import { exportSkill } from './exportSkill.js'
+import { importSkill } from './importSkill.js'
+import { lintSkill } from './lintSkill.js'
+import {
+  AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0,
+  MAX_SKILL_BODY_BYTES,
+} from './manifestSchema.js'
+import { getProjectRoot, setProjectRoot } from '../../bootstrap/state.js'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const TEMP_DIRS: string[] = []
+let originalProjectRoot: string
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function writeSkill(
+  rootDir: string,
+  name: string,
+  description: string,
+  body: string,
+): string {
+  const skillDir = join(rootDir, name)
+  mkdirSync(skillDir, { recursive: true })
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n${body}\n`,
+  )
+  return skillDir
+}
+
+beforeEach(() => {
+  originalProjectRoot = getProjectRoot()
+  process.env.CLAUDE_CONFIG_DIR = makeTempDir('kairos-skill-config-')
+})
+
+afterEach(() => {
+  setProjectRoot(originalProjectRoot)
+  delete process.env.CLAUDE_CONFIG_DIR
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('skill interop services', () => {
+  test('export emits a self-contained discovery manifest that passes lint', async () => {
+    const projectDir = makeTempDir('kairos-skill-project-')
+    setProjectRoot(projectDir)
+    writeSkill(
+      join(projectDir, '.claude', 'skills'),
+      'example-skill',
+      'Example exported skill.',
+      'Use this skill to verify export round trips.',
+    )
+
+    const manifestText = await exportSkill('example-skill')
+    const manifest = JSON.parse(manifestText) as {
+      $schema: string
+      skills: Array<{ url: string }>
+    }
+
+    expect(manifest.$schema).toBe(AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0)
+    expect(manifest.skills[0]?.url.startsWith('data:text/markdown;base64,')).toBe(
+      true,
+    )
+
+    const lintResult = await lintSkill(manifestText)
+    expect(lintResult.ok).toBe(true)
+  })
+
+  test('local import previews suspicious patterns, then writes provenance and telemetry on confirmation', async () => {
+    const sourceRoot = makeTempDir('kairos-skill-source-')
+    const skillDir = writeSkill(
+      sourceRoot,
+      'danger-skill',
+      'Demonstrates suspicious pattern warnings.',
+      'Run `sudo ls` before checking files.',
+    )
+
+    const preview = await importSkill(skillDir)
+    expect(preview).toContain('Import preview')
+    expect(preview).toContain('Contains `sudo`')
+
+    const importedDir = join(
+      process.env.CLAUDE_CONFIG_DIR as string,
+      'skills',
+      'imported',
+      'local',
+      'danger-skill',
+    )
+    expect(existsSync(join(importedDir, 'SKILL.md'))).toBe(false)
+
+    const result = await importSkill(skillDir, {
+      confirm: true,
+      now: new Date('2026-04-22T15:00:00Z'),
+    })
+    expect(result).toContain('Imported skill')
+    expect(existsSync(join(importedDir, 'SKILL.md'))).toBe(true)
+
+    const provenance = JSON.parse(
+      readFileSync(join(importedDir, '.provenance.json'), 'utf8'),
+    ) as {
+      checksum: string
+      importedAt: string
+      source: string
+    }
+    expect(provenance.checksum).toMatch(/^sha256:/)
+    expect(provenance.importedAt).toBe('2026-04-22T15:00:00.000Z')
+    expect(provenance.source).toContain(skillDir)
+
+    const telemetry = readFileSync(
+      join(
+        process.env.CLAUDE_CONFIG_DIR as string,
+        'kairos',
+        'skill-interop-events.jsonl',
+      ),
+      'utf8',
+    )
+    expect(telemetry).toContain('"event":"kairos_skill_import"')
+    expect(telemetry).toContain('"skill_name":"danger-skill"')
+  })
+
+  test('re-import with changed content errors until overwrite is requested', async () => {
+    const sourceRoot = makeTempDir('kairos-skill-overwrite-')
+    const skillDir = writeSkill(
+      sourceRoot,
+      'replace-me',
+      'Skill to exercise overwrite flow.',
+      'Initial content.',
+    )
+
+    await importSkill(skillDir, {
+      confirm: true,
+      now: new Date('2026-04-22T15:00:00Z'),
+    })
+
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      [
+        '---',
+        'name: replace-me',
+        'description: Skill to exercise overwrite flow.',
+        '---',
+        '',
+        'Updated content with a different body.',
+        '',
+      ].join('\n'),
+    )
+
+    await expect(
+      importSkill(skillDir, {
+        confirm: true,
+      }),
+    ).rejects.toThrow('checksum mismatch')
+
+    const preview = await importSkill(skillDir, { overwrite: true })
+    expect(preview).toContain('mode: overwrite')
+    expect(preview).toContain('Updated content with a different body.')
+
+    const confirmed = await importSkill(skillDir, {
+      confirm: true,
+      overwrite: true,
+      now: new Date('2026-04-22T15:10:00Z'),
+    })
+    expect(confirmed).toContain('Overwrote')
+
+    const importedSkill = readFileSync(
+      join(
+        process.env.CLAUDE_CONFIG_DIR as string,
+        'skills',
+        'imported',
+        'local',
+        'replace-me',
+        'SKILL.md',
+      ),
+      'utf8',
+    )
+    expect(importedSkill).toContain('Updated content with a different body.')
+  })
+
+  test('remote manifest import supports stubbed http fetches', async () => {
+    const markdown = [
+      '---',
+      'name: example',
+      'description: Example remote skill.',
+      '---',
+      '',
+      'Use this skill when testing URL imports.',
+      '',
+    ].join('\n')
+    const manifestUrl = 'https://agentskills.io/skills/example.json'
+    const artifactUrl = 'https://agentskills.io/skills/example/SKILL.md'
+    const manifest = JSON.stringify({
+      $schema: AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0,
+      skills: [
+        {
+          name: 'example',
+          type: 'skill-md',
+          description: 'Example remote skill.',
+          url: '/skills/example/SKILL.md',
+          digest: computeSkillChecksum(Buffer.from(markdown)),
+        },
+      ],
+    })
+
+    const fetchImpl: typeof fetch = async input => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url
+
+      if (url === manifestUrl) {
+        return new Response(manifest, { status: 200 })
+      }
+      if (url === artifactUrl) {
+        return new Response(markdown, { status: 200 })
+      }
+      return new Response('not found', { status: 404 })
+    }
+
+    const preview = await importSkill(manifestUrl, { fetchImpl })
+    expect(preview).toContain(`source: ${manifestUrl}`)
+    expect(preview).toContain(`manifest: ${AGENTSKILLS_DISCOVERY_SCHEMA_V0_2_0}`)
+
+    const result = await importSkill(manifestUrl, {
+      confirm: true,
+      fetchImpl,
+      now: new Date('2026-04-22T15:15:00Z'),
+    })
+    expect(result).toContain('Imported skill')
+
+    const importedPath = join(
+      process.env.CLAUDE_CONFIG_DIR as string,
+      'skills',
+      'imported',
+      'agentskills.io',
+      'example',
+      'SKILL.md',
+    )
+    expect(existsSync(importedPath)).toBe(true)
+  })
+
+  test('lint reports invalid local skill metadata and oversized bodies', async () => {
+    const sourceRoot = makeTempDir('kairos-skill-lint-')
+    const skillDir = join(sourceRoot, 'broken-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: Bad Name\n---\n\n${'x'.repeat(MAX_SKILL_BODY_BYTES + 1)}\n`,
+    )
+
+    const result = await lintSkill(skillDir)
+    expect(result.ok).toBe(false)
+    const messages = result.violations.map(v => v.message).join('\n')
+    expect(messages).toContain('Invalid skill name')
+    expect(messages).toContain('Missing required `description` field')
+    expect(messages).toContain('interop limit')
+  })
+
+  test('lint rejects unsupported manifest schema versions', async () => {
+    const result = await lintSkill(
+      JSON.stringify({
+        $schema: 'https://schemas.agentskills.io/discovery/9.9.9/schema.json',
+        skills: [],
+      }),
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.violations.map(v => v.message).join('\n')).toContain(
+      'Unsupported manifest schema',
+    )
+  })
+})

--- a/src 2/services/skillInterop/suspiciousPatterns.ts
+++ b/src 2/services/skillInterop/suspiciousPatterns.ts
@@ -1,0 +1,62 @@
+export type SuspiciousPatternHit = {
+  id: string
+  label: string
+}
+
+const SUSPICIOUS_PATTERNS: Array<{
+  id: string
+  label: string
+  pattern: RegExp
+}> = [
+  {
+    id: 'rm-rf-root',
+    label: 'Contains destructive `rm -rf` command',
+    pattern: /\brm\s+-rf\s+(\/|~\/|\$HOME\b)/i,
+  },
+  {
+    id: 'sudo',
+    label: 'Contains `sudo`',
+    pattern: /\bsudo\b/i,
+  },
+  {
+    id: 'curl-pipe-shell',
+    label: 'Pipes `curl` output into a shell',
+    pattern: /\bcurl\b[^\n|]*\|\s*(sh|bash|zsh)\b/i,
+  },
+  {
+    id: 'wget-pipe-shell',
+    label: 'Pipes `wget` output into a shell',
+    pattern: /\bwget\b[^\n|]*\|\s*(sh|bash|zsh)\b/i,
+  },
+  {
+    id: 'powershell-iex',
+    label: 'Contains PowerShell `iex` / `Invoke-Expression` execution',
+    pattern: /\b(iex|invoke-expression)\b/i,
+  },
+  {
+    id: 'mkfs',
+    label: 'Contains filesystem formatting command',
+    pattern: /\bmkfs(\.[a-z0-9]+)?\b/i,
+  },
+  {
+    id: 'dd-disk',
+    label: 'Contains raw disk copy command',
+    pattern: /\bdd\s+if=/i,
+  },
+  {
+    id: 'chmod-777',
+    label: 'Contains broad `chmod 777` permission change',
+    pattern: /\bchmod\s+777\b/i,
+  },
+]
+
+export function scanSuspiciousSkillContent(
+  content: string,
+): SuspiciousPatternHit[] {
+  return SUSPICIOUS_PATTERNS.filter(entry => entry.pattern.test(content)).map(
+    entry => ({
+      id: entry.id,
+      label: entry.label,
+    }),
+  )
+}


### PR DESCRIPTION
Adds a non-trunk Agent Skills interop layer for KAIROS with manifest schema validation, local/URL/JSON import, export, linting, provenance, suspicious-pattern scanning, and import telemetry. Moves /kairos to a local-jsx command so interactive skill imports can show a confirm/cancel dialog while preserving runKairosCommand() for noninteractive use. Includes command and service tests covering export round-trip, file/URL/blob imports, overwrite mismatch handling, and lint failures.