### PR TITLE
Add KAIROS RPC socket and script tool

### DIFF
--- a/src 2/daemon/kairos/paths.ts
+++ b/src 2/daemon/kairos/paths.ts
@@ -13,6 +13,10 @@ export function getKairosStdoutLogPath(): string {
   return join(getKairosStateDir(), 'daemon.out.log')
 }
 
+export function getKairosToolsSocketPath(): string {
+  return join(getKairosStateDir(), 'tools.sock')
+}
+
 export function getKairosGlobalEventsPath(): string {
   return join(getKairosStateDir(), 'events.jsonl')
 }

--- a/src 2/daemon/kairos/worker.test.ts
+++ b/src 2/daemon/kairos/worker.test.ts
@@ -1,16 +1,18 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
 import { spawn } from 'child_process'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { getKairosStateDir, getKairosStatusPath, getKairosStdoutLogPath } from './paths.js'
+import { getKairosStateDir, getKairosStatusPath, getKairosStdoutLogPath, getKairosToolsSocketPath } from './paths.js'
 import { runKairosWorker } from './worker.js'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
 
 const TEMP_DIRS: string[] = []
 const DAEMON_MAIN_URL = new URL('../main.ts', import.meta.url).href
 
 afterEach(() => {
   delete process.env.CLAUDE_CONFIG_DIR
+  resetSettingsCache()
   for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -22,11 +24,11 @@ function makeTempConfigDir(): string {
   return dir
 }
 
-async function waitForPath(path: string, timeoutMs = 3_000): Promise<void> {
+async function waitForPath(path: string, timeoutMs = 10_000): Promise<void> {
   const started = Date.now()
   while (Date.now() - started < timeoutMs) {
     try {
-      readFileSync(path)
+      statSync(path)
       return
     } catch {
       await Bun.sleep(50)
@@ -76,6 +78,23 @@ describe('Kairos daemon worker', () => {
     expect(log).toContain('startup complete; entering idle loop')
     expect(log).toContain('shutdown requested; exiting cleanly')
     expect(stdoutChunks.join('')).toContain('startup complete; entering idle loop')
+  })
+
+  test('creates the rpc socket when kairos.rpc.enabled is true', async () => {
+    const configDir = makeTempConfigDir()
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ kairos: { rpc: { enabled: true } } }),
+    )
+    resetSettingsCache()
+
+    const controller = new AbortController()
+    const running = runKairosWorker({ signal: controller.signal })
+
+    await waitForPath(getKairosToolsSocketPath())
+    controller.abort()
+    expect(await running).toBe(0)
   })
 
   test('daemon main exits with code 0 on SIGTERM', async () => {

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -25,6 +25,8 @@ import {
 } from './paths.js'
 import { createStateWriter, type StateWriter } from './stateWriter.js'
 import { createTier3Controller, type Tier3Controller } from './tier3.js'
+import { getKairosRpcConfig } from '../../services/rpc/config.js'
+import { startToolsSocketServer } from '../../services/rpc/toolsSocketServer.js'
 
 type KairosStatus = {
   kind: 'kairos'
@@ -356,6 +358,10 @@ export async function runKairosWorker(
     ReturnType<typeof createProjectWorker>
   >()
   const tier3Controllers = new Map<string, Tier3Controller>()
+  const rpcConfig = getKairosRpcConfig()
+  const rpcServer = rpcConfig.enabled
+    ? await startToolsSocketServer(rpcConfig.socketPath)
+    : null
 
   const enableChildRuns = options.enableChildRuns ?? true
   const launcher: ChildLauncher | null = enableChildRuns
@@ -520,6 +526,7 @@ export async function runKairosWorker(
   for (const projectDir of [...activeWorkers.keys()]) {
     await removeProject(projectDir)
   }
+  await rpcServer?.stop()
 
   const stoppedAt = now().toISOString()
   await logLine('shutdown requested; exiting cleanly', {

--- a/src 2/services/rpc/authToken.ts
+++ b/src 2/services/rpc/authToken.ts
@@ -1,0 +1,171 @@
+import { randomBytes } from 'crypto'
+import { mkdir, readFile, readdir, rm, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
+import type { ToolPermissionContext } from '../../Tool.js'
+import type { AdditionalWorkingDirectory, PermissionMode } from '../../types/permissions.js'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+
+type SerializableToolPermissionContext = {
+  mode: PermissionMode
+  additionalWorkingDirectories: AdditionalWorkingDirectory[]
+  alwaysAllowRules: ToolPermissionContext['alwaysAllowRules']
+  alwaysDenyRules: ToolPermissionContext['alwaysDenyRules']
+  alwaysAskRules: ToolPermissionContext['alwaysAskRules']
+  isBypassPermissionsModeAvailable: boolean
+  isAutoModeAvailable?: boolean
+  strippedDangerousRules?: ToolPermissionContext['strippedDangerousRules']
+  shouldAvoidPermissionPrompts?: boolean
+  awaitAutomatedChecksBeforeDialog?: boolean
+  prePlanMode?: PermissionMode
+}
+
+export type RpcGrant = {
+  token: string
+  createdAt: string
+  expiresAt: string
+  projectDir: string
+  allowedTools: string[]
+  permissionContext: SerializableToolPermissionContext
+  maxCalls: number
+}
+
+function getGrantsDir(): string {
+  return join(getClaudeConfigHomeDir(), 'kairos', 'rpc-grants')
+}
+
+export function getRpcGrantPath(token: string): string {
+  return join(getGrantsDir(), `${token}.json`)
+}
+
+export function createAuthToken(): string {
+  return randomBytes(24).toString('hex')
+}
+
+export function serializeToolPermissionContext(
+  context: ToolPermissionContext,
+): SerializableToolPermissionContext {
+  return {
+    mode: context.mode,
+    additionalWorkingDirectories: [...context.additionalWorkingDirectories.values()],
+    alwaysAllowRules: context.alwaysAllowRules,
+    alwaysDenyRules: context.alwaysDenyRules,
+    alwaysAskRules: context.alwaysAskRules,
+    isBypassPermissionsModeAvailable:
+      context.isBypassPermissionsModeAvailable,
+    isAutoModeAvailable: context.isAutoModeAvailable,
+    strippedDangerousRules: context.strippedDangerousRules,
+    shouldAvoidPermissionPrompts: context.shouldAvoidPermissionPrompts,
+    awaitAutomatedChecksBeforeDialog:
+      context.awaitAutomatedChecksBeforeDialog,
+    prePlanMode: context.prePlanMode,
+  }
+}
+
+export function deserializeToolPermissionContext(
+  context: SerializableToolPermissionContext,
+): ToolPermissionContext {
+  return {
+    mode: context.mode,
+    additionalWorkingDirectories: new Map(
+      context.additionalWorkingDirectories.map(item => [item.path, item]),
+    ),
+    alwaysAllowRules: context.alwaysAllowRules,
+    alwaysDenyRules: context.alwaysDenyRules,
+    alwaysAskRules: context.alwaysAskRules,
+    isBypassPermissionsModeAvailable:
+      context.isBypassPermissionsModeAvailable,
+    ...(context.isAutoModeAvailable !== undefined
+      ? { isAutoModeAvailable: context.isAutoModeAvailable }
+      : {}),
+    ...(context.strippedDangerousRules !== undefined
+      ? { strippedDangerousRules: context.strippedDangerousRules }
+      : {}),
+    ...(context.shouldAvoidPermissionPrompts !== undefined
+      ? { shouldAvoidPermissionPrompts: context.shouldAvoidPermissionPrompts }
+      : {}),
+    ...(context.awaitAutomatedChecksBeforeDialog !== undefined
+      ? {
+          awaitAutomatedChecksBeforeDialog:
+            context.awaitAutomatedChecksBeforeDialog,
+        }
+      : {}),
+    ...(context.prePlanMode !== undefined
+      ? { prePlanMode: context.prePlanMode }
+      : {}),
+  }
+}
+
+export async function writeRpcGrant(grant: RpcGrant): Promise<void> {
+  await mkdir(getGrantsDir(), { recursive: true })
+  const path = getRpcGrantPath(grant.token)
+  await writeFile(path, `${JSON.stringify(grant, null, 2)}\n`, {
+    mode: 0o600,
+  })
+}
+
+export async function readRpcGrant(token: string): Promise<RpcGrant | null> {
+  try {
+    const raw = await readFile(getRpcGrantPath(token), 'utf8')
+    const parsed = JSON.parse(raw) as RpcGrant
+    if (!parsed || parsed.token !== token) {
+      return null
+    }
+    if (Date.parse(parsed.expiresAt) <= Date.now()) {
+      await deleteRpcGrant(token)
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export async function deleteRpcGrant(token: string): Promise<void> {
+  await rm(getRpcGrantPath(token), { force: true })
+}
+
+export async function cleanupExpiredRpcGrants(now = Date.now()): Promise<void> {
+  await mkdir(getGrantsDir(), { recursive: true })
+  for (const entry of await readdir(getGrantsDir())) {
+    if (!entry.endsWith('.json')) {
+      continue
+    }
+    const fullPath = join(getGrantsDir(), entry)
+    try {
+      const raw = await readFile(fullPath, 'utf8')
+      const parsed = JSON.parse(raw) as Partial<RpcGrant>
+      if (
+        typeof parsed.expiresAt !== 'string' ||
+        Date.parse(parsed.expiresAt) <= now
+      ) {
+        await rm(fullPath, { force: true })
+      }
+    } catch {
+      await rm(fullPath, { force: true })
+    }
+  }
+}
+
+export async function createRpcGrant(params: {
+  projectDir: string
+  allowedTools: string[]
+  permissionContext: ToolPermissionContext
+  maxCalls: number
+  expiresAt: Date
+}): Promise<RpcGrant> {
+  const grant: RpcGrant = {
+    token: createAuthToken(),
+    createdAt: new Date().toISOString(),
+    expiresAt: params.expiresAt.toISOString(),
+    projectDir: params.projectDir,
+    allowedTools: [...params.allowedTools],
+    permissionContext: serializeToolPermissionContext(params.permissionContext),
+    maxCalls: params.maxCalls,
+  }
+  await writeRpcGrant(grant)
+  return grant
+}
+
+export async function ensureRpcGrantDir(): Promise<void> {
+  await mkdir(dirname(getRpcGrantPath('placeholder')), { recursive: true })
+}

--- a/src 2/services/rpc/config.ts
+++ b/src 2/services/rpc/config.ts
@@ -1,0 +1,87 @@
+import { join } from 'path'
+import { getInitialSettings } from '../../utils/settings/settings.js'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+
+export type KairosRpcConfig = {
+  enabled: boolean
+  socketPath: string
+  maxCallsPerInvocation: number
+  defaultTimeoutSec: number
+  maxTimeoutSec: number
+  stdoutCapBytes: number
+}
+
+const DEFAULT_TIMEOUT_SEC = 60
+const MAX_TIMEOUT_SEC = 300
+const DEFAULT_MAX_CALLS = 500
+const DEFAULT_STDOUT_CAP_BYTES = 16 * 1024
+
+function getDefaultSocketPath(): string {
+  return join(getClaudeConfigHomeDir(), 'kairos', 'tools.sock')
+}
+
+function clampNumber(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback
+  }
+  return Math.max(min, Math.min(max, Math.floor(value)))
+}
+
+function readKairosRpcRecord(settings: unknown): Record<string, unknown> | null {
+  if (!settings || typeof settings !== 'object') {
+    return null
+  }
+
+  const kairos = (settings as Record<string, unknown>).kairos
+  if (!kairos || typeof kairos !== 'object') {
+    return null
+  }
+
+  const rpc = (kairos as Record<string, unknown>).rpc
+  if (!rpc || typeof rpc !== 'object') {
+    return null
+  }
+
+  return rpc as Record<string, unknown>
+}
+
+export function getKairosRpcConfig(settings = getInitialSettings()): KairosRpcConfig {
+  const rpc = readKairosRpcRecord(settings)
+
+  return {
+    enabled: rpc?.enabled === true,
+    socketPath:
+      typeof rpc?.socketPath === 'string' && rpc.socketPath.length > 0
+        ? rpc.socketPath
+        : getDefaultSocketPath(),
+    maxCallsPerInvocation: clampNumber(
+      rpc?.maxCallsPerInvocation,
+      DEFAULT_MAX_CALLS,
+      1,
+      10_000,
+    ),
+    defaultTimeoutSec: clampNumber(
+      rpc?.defaultTimeoutSec,
+      DEFAULT_TIMEOUT_SEC,
+      1,
+      MAX_TIMEOUT_SEC,
+    ),
+    maxTimeoutSec: clampNumber(
+      rpc?.maxTimeoutSec,
+      MAX_TIMEOUT_SEC,
+      1,
+      MAX_TIMEOUT_SEC,
+    ),
+    stdoutCapBytes: clampNumber(
+      rpc?.stdoutCapBytes,
+      DEFAULT_STDOUT_CAP_BYTES,
+      1024,
+      1024 * 1024,
+    ),
+  }
+}

--- a/src 2/services/rpc/python_client/README.md
+++ b/src 2/services/rpc/python_client/README.md
@@ -1,0 +1,32 @@
+# KAIROS Python RPC Client
+
+`kairos_tools.py` lets a local Python script call Claude Code tools over the
+KAIROS Unix socket without spending a Claude turn per tool call.
+
+## Environment
+
+`RunScriptTool` injects both variables automatically:
+
+- `KAIROS_SOCKET`
+- `KAIROS_TOKEN`
+
+## Example
+
+```python
+from kairos_tools import call
+
+result = call("ReadFile", {"path": "/tmp/example.txt"})
+print(result)
+```
+
+## Reusing One Connection
+
+```python
+from kairos_tools import KairosToolsClient
+
+with KairosToolsClient() as client:
+    tools = client.list_tools()
+    print(tools)
+    print(client.call("ReadFile", {"path": "/tmp/example.txt"}))
+```
+

--- a/src 2/services/rpc/python_client/kairos_tools.py
+++ b/src 2/services/rpc/python_client/kairos_tools.py
@@ -1,0 +1,81 @@
+import json
+import os
+import socket
+from contextlib import AbstractContextManager
+
+
+class KairosToolsClient(AbstractContextManager):
+    def __init__(self, socket_path=None, token=None):
+        self.socket_path = socket_path or os.environ.get("KAIROS_SOCKET")
+        self.token = token or os.environ.get("KAIROS_TOKEN")
+        if not self.socket_path:
+            raise RuntimeError("KAIROS_SOCKET is not set")
+        if not self.token:
+            raise RuntimeError("KAIROS_TOKEN is not set")
+        self._socket = None
+        self._reader = None
+        self._writer = None
+
+    def __enter__(self):
+        self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._socket.connect(self.socket_path)
+        self._reader = self._socket.makefile("r", encoding="utf-8")
+        self._writer = self._socket.makefile("w", encoding="utf-8")
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._reader:
+            self._reader.close()
+        if self._writer:
+            self._writer.close()
+        if self._socket:
+            self._socket.close()
+        self._reader = None
+        self._writer = None
+        self._socket = None
+        return False
+
+    def _send(self, method, params):
+        if not self._reader or not self._writer:
+            raise RuntimeError("Client is not connected; use `with KairosToolsClient()`")
+        request = {
+            "id": 1,
+            "method": method,
+            "params": {
+                "token": self.token,
+                **params,
+            },
+        }
+        self._writer.write(json.dumps(request) + "\n")
+        self._writer.flush()
+        line = self._reader.readline()
+        if not line:
+            raise RuntimeError("No response from KAIROS RPC server")
+        response = json.loads(line)
+        if response.get("error"):
+            error = response["error"]
+            raise RuntimeError(error.get("message", "Unknown RPC error"))
+        return response.get("result")
+
+    def list_tools(self):
+        return self._send("list_tools", {})
+
+    def call(self, tool_name, args=None):
+        return self._send(
+            "call_tool",
+            {
+                "tool_name": tool_name,
+                "args": args or {},
+            },
+        )
+
+
+def list_tools():
+    with KairosToolsClient() as client:
+        return client.list_tools()
+
+
+def call(tool_name, args=None):
+    with KairosToolsClient() as client:
+        return client.call(tool_name, args or {})
+

--- a/src 2/services/rpc/rpc.test.ts
+++ b/src 2/services/rpc/rpc.test.ts
@@ -21,6 +21,13 @@ async function rpcRequest(
   socketPath: string,
   body: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
+  return rpcRawRequest(socketPath, JSON.stringify(body))
+}
+
+async function rpcRawRequest(
+  socketPath: string,
+  line: string,
+): Promise<Record<string, unknown>> {
   const socket = createConnection(socketPath)
   const response = await new Promise<string>((resolve, reject) => {
     let buffer = ''
@@ -34,7 +41,7 @@ async function rpcRequest(
       }
     })
     socket.once('connect', () => {
-      socket.write(`${JSON.stringify(body)}\n`)
+      socket.write(`${line}\n`)
     })
   })
   socket.end()
@@ -114,6 +121,51 @@ describe('KAIROS RPC server', () => {
     }
   })
 
+  test('executes relative-path tool calls inside the granted project directory', async () => {
+    const configDir = makeTempDir('kairos-rpc-cwd-config-')
+    const projectDir = makeTempDir('kairos-rpc-cwd-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ kairos: { rpc: { enabled: true } } }),
+    )
+    writeFileSync(join(projectDir, 'relative.txt'), 'hello from granted cwd\n')
+    resetSettingsCache()
+
+    const { socketPath } = getKairosRpcConfig()
+    const server = await startToolsSocketServer(socketPath)
+    const permissionContext = getEmptyToolPermissionContext()
+    permissionContext.additionalWorkingDirectories = new Map([
+      [projectDir, { path: projectDir, source: 'session' }],
+    ])
+    const grant = await createRpcGrant({
+      projectDir,
+      allowedTools: ['Read'],
+      permissionContext,
+      maxCalls: 500,
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+
+    try {
+      const response = await rpcRequest(socketPath, {
+        id: 4,
+        method: 'call_tool',
+        params: {
+          token: grant.token,
+          tool_name: 'ReadFile',
+          args: { path: 'relative.txt' },
+        },
+      })
+      expect(response.error).toBeUndefined()
+      expect((response.result as { file: { content: string } }).file.content).toContain(
+        'hello from granted cwd',
+      )
+    } finally {
+      await deleteRpcGrant(grant.token)
+      await server.stop()
+    }
+  })
+
   test('enforces the per-grant rpc rate limit', async () => {
     const configDir = makeTempDir('kairos-rpc-rate-')
     process.env.CLAUDE_CONFIG_DIR = configDir
@@ -149,6 +201,35 @@ describe('KAIROS RPC server', () => {
       expect(second.error).toBeDefined()
     } finally {
       await deleteRpcGrant(grant.token)
+      await server.stop()
+    }
+  })
+
+  test('returns an invalid_request error for malformed JSON instead of crashing', async () => {
+    const configDir = makeTempDir('kairos-rpc-invalid-json-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ kairos: { rpc: { enabled: true } } }),
+    )
+    resetSettingsCache()
+
+    const { socketPath } = getKairosRpcConfig()
+    const server = await startToolsSocketServer(socketPath)
+
+    try {
+      const invalidJson = await rpcRawRequest(socketPath, '{"id":1,"method":')
+      expect(invalidJson.error).toMatchObject({
+        code: 'invalid_request',
+      })
+
+      const followup = await rpcRequest(socketPath, {
+        id: 2,
+        method: 'list_tools',
+        params: {},
+      })
+      expect(followup.error).toBeDefined()
+    } finally {
       await server.stop()
     }
   })

--- a/src 2/services/rpc/rpc.test.ts
+++ b/src 2/services/rpc/rpc.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { createConnection } from 'net'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { getKairosRpcConfig } from './config.js'
+import { createRpcGrant, deleteRpcGrant } from './authToken.js'
+import { startToolsSocketServer } from './toolsSocketServer.js'
+import { getEmptyToolPermissionContext } from '../../Tool.js'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+
+const TEMP_DIRS: string[] = []
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+async function rpcRequest(
+  socketPath: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const socket = createConnection(socketPath)
+  const response = await new Promise<string>((resolve, reject) => {
+    let buffer = ''
+    socket.setEncoding('utf8')
+    socket.once('error', reject)
+    socket.on('data', data => {
+      buffer += data
+      const newline = buffer.indexOf('\n')
+      if (newline !== -1) {
+        resolve(buffer.slice(0, newline))
+      }
+    })
+    socket.once('connect', () => {
+      socket.write(`${JSON.stringify(body)}\n`)
+    })
+  })
+  socket.end()
+  return JSON.parse(response) as Record<string, unknown>
+}
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  resetSettingsCache()
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('KAIROS RPC server', () => {
+  test('defaults off until enabled in settings', () => {
+    const configDir = makeTempDir('kairos-rpc-config-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    expect(getKairosRpcConfig().enabled).toBe(false)
+
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ kairos: { rpc: { enabled: true } } }),
+    )
+    resetSettingsCache()
+    expect(getKairosRpcConfig().enabled).toBe(true)
+  })
+
+  test('enforces auth token and allowlist', async () => {
+    const configDir = makeTempDir('kairos-rpc-auth-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ kairos: { rpc: { enabled: true } } }),
+    )
+    resetSettingsCache()
+
+    const { socketPath } = getKairosRpcConfig()
+    const server = await startToolsSocketServer(socketPath)
+    const permissionContext = getEmptyToolPermissionContext()
+    const grant = await createRpcGrant({
+      projectDir: process.cwd(),
+      allowedTools: ['Read'],
+      permissionContext,
+      maxCalls: 500,
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+
+    try {
+      const missingAuth = await rpcRequest(socketPath, {
+        id: 1,
+        method: 'list_tools',
+        params: {},
+      })
+      expect(missingAuth.error).toBeDefined()
+
+      const tools = await rpcRequest(socketPath, {
+        id: 2,
+        method: 'list_tools',
+        params: { token: grant.token },
+      })
+      expect((tools.result as Array<{ name: string }>).map(item => item.name)).toEqual(['Read'])
+
+      const forbidden = await rpcRequest(socketPath, {
+        id: 3,
+        method: 'call_tool',
+        params: {
+          token: grant.token,
+          tool_name: 'Glob',
+          args: { pattern: '*.ts' },
+        },
+      })
+      expect(forbidden.error).toBeDefined()
+    } finally {
+      await deleteRpcGrant(grant.token)
+      await server.stop()
+    }
+  })
+
+  test('enforces the per-grant rpc rate limit', async () => {
+    const configDir = makeTempDir('kairos-rpc-rate-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ kairos: { rpc: { enabled: true } } }),
+    )
+    resetSettingsCache()
+
+    const { socketPath } = getKairosRpcConfig()
+    const server = await startToolsSocketServer(socketPath)
+    const grant = await createRpcGrant({
+      projectDir: process.cwd(),
+      allowedTools: ['Read'],
+      permissionContext: getEmptyToolPermissionContext(),
+      maxCalls: 1,
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+
+    try {
+      const first = await rpcRequest(socketPath, {
+        id: 1,
+        method: 'list_tools',
+        params: { token: grant.token },
+      })
+      expect(first.result).toBeDefined()
+
+      const second = await rpcRequest(socketPath, {
+        id: 2,
+        method: 'list_tools',
+        params: { token: grant.token },
+      })
+      expect(second.error).toBeDefined()
+    } finally {
+      await deleteRpcGrant(grant.token)
+      await server.stop()
+    }
+  })
+})

--- a/src 2/services/rpc/toolAllowlist.ts
+++ b/src 2/services/rpc/toolAllowlist.ts
@@ -1,0 +1,57 @@
+import type { Tool, ToolPermissionContext, Tools } from '../../Tool.js'
+
+const RPC_SAFE_TOOL_NAMES = new Set([
+  'Read',
+  'Glob',
+  'Grep',
+  'WebFetch',
+  'WebSearch',
+  'TaskList',
+  'TaskGet',
+])
+
+const LEGACY_TOOL_NAME_ALIASES: Record<string, string> = {
+  ReadFile: 'Read',
+}
+
+export function normalizeRpcToolName(name: string): string {
+  return LEGACY_TOOL_NAME_ALIASES[name] ?? name
+}
+
+export function applyLegacyRpcInputAliases(
+  toolName: string,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  if (toolName === 'Read' && typeof args.path === 'string' && args.file_path === undefined) {
+    return {
+      ...args,
+      file_path: args.path,
+    }
+  }
+  return args
+}
+
+export function filterRpcTools(
+  tools: Tools,
+  parentAllowedTools: readonly string[],
+): Tool[] {
+  const allowed = new Set(parentAllowedTools.map(normalizeRpcToolName))
+  return tools.filter(
+    tool => RPC_SAFE_TOOL_NAMES.has(tool.name) && allowed.has(tool.name),
+  )
+}
+
+export function getRpcAllowedToolNames(
+  tools: Tools,
+  permissionContext: ToolPermissionContext,
+): string[] {
+  const denied = new Set(
+    Object.values(permissionContext.alwaysDenyRules)
+      .flat()
+      .filter(rule => !rule.includes('(')),
+  )
+  return tools
+    .filter(tool => RPC_SAFE_TOOL_NAMES.has(tool.name) && !denied.has(tool.name))
+    .map(tool => tool.name)
+}
+

--- a/src 2/services/rpc/toolsSocketServer.ts
+++ b/src 2/services/rpc/toolsSocketServer.ts
@@ -1,0 +1,268 @@
+import { createServer, type Server, type Socket } from 'net'
+import { chmod, mkdir, rm } from 'fs/promises'
+import { dirname } from 'path'
+import { createAbortController } from '../../utils/abortController.js'
+import { createFileStateCacheWithSizeLimit } from '../../utils/fileStateCache.js'
+import { logError } from '../../utils/log.js'
+import { jsonStringify } from '../../utils/slowOperations.js'
+import { createAssistantMessage } from '../../utils/messages.js'
+import { getMainLoopModel } from '../../utils/model/model.js'
+import { getDefaultAppState } from '../../state/AppStateStore.js'
+import { findToolByName, type Tool, type ToolUseContext } from '../../Tool.js'
+import { getTools } from '../../tools.js'
+import {
+  cleanupExpiredRpcGrants,
+  deserializeToolPermissionContext,
+  ensureRpcGrantDir,
+  readRpcGrant,
+} from './authToken.js'
+import {
+  applyLegacyRpcInputAliases,
+  filterRpcTools,
+  normalizeRpcToolName,
+} from './toolAllowlist.js'
+
+type RpcRequest = {
+  id: string | number | null
+  method: 'list_tools' | 'call_tool'
+  params?: Record<string, unknown>
+}
+
+type RpcResponse = {
+  id: string | number | null
+  result?: unknown
+  error?: { code: string; message: string }
+}
+
+const callCounts = new Map<string, number>()
+
+export type ToolsSocketServerHandle = {
+  socketPath: string
+  stop(): Promise<void>
+}
+
+function createToolUseContext(permissionContext: ReturnType<typeof deserializeToolPermissionContext>, tools: Tool[]): ToolUseContext {
+  const defaultState = getDefaultAppState()
+  const appState = {
+    ...defaultState,
+    toolPermissionContext: permissionContext,
+  }
+
+  return {
+    abortController: createAbortController(),
+    options: {
+      commands: [],
+      tools,
+      mainLoopModel: getMainLoopModel(),
+      thinkingConfig: { type: 'disabled' },
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: true,
+      debug: false,
+      verbose: false,
+      agentDefinitions: { activeAgents: [], allAgents: [] },
+    },
+    getAppState: () => appState,
+    setAppState: () => {},
+    messages: [],
+    readFileState: createFileStateCacheWithSizeLimit(64),
+    setInProgressToolUseIDs: () => {},
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+  }
+}
+
+async function executeRpcToolCall(request: RpcRequest): Promise<RpcResponse> {
+  const token =
+    typeof request.params?.token === 'string' ? request.params.token : null
+  if (!token) {
+    return {
+      id: request.id,
+      error: { code: 'unauthorized', message: 'KAIROS_TOKEN is required' },
+    }
+  }
+
+  const grant = await readRpcGrant(token)
+  if (!grant) {
+    return {
+      id: request.id,
+      error: { code: 'unauthorized', message: 'Invalid or expired KAIROS_TOKEN' },
+    }
+  }
+
+  const currentCallCount = callCounts.get(token) ?? 0
+  if (currentCallCount >= grant.maxCalls) {
+    return {
+      id: request.id,
+      error: {
+        code: 'rate_limited',
+        message: `RPC call limit exceeded (${grant.maxCalls})`,
+      },
+    }
+  }
+  callCounts.set(token, currentCallCount + 1)
+
+  const permissionContext = deserializeToolPermissionContext(
+    grant.permissionContext,
+  )
+  const availableTools = filterRpcTools(
+    getTools(permissionContext),
+    grant.allowedTools,
+  )
+
+  if (request.method === 'list_tools') {
+    return {
+      id: request.id,
+      result: availableTools.map(tool => ({
+        name: tool.name,
+        userFacingName: tool.userFacingName?.({}) ?? tool.name,
+      })),
+    }
+  }
+
+  const requestedToolName =
+    typeof request.params?.tool_name === 'string'
+      ? normalizeRpcToolName(request.params.tool_name)
+      : null
+
+  if (!requestedToolName) {
+    return {
+      id: request.id,
+      error: { code: 'invalid_request', message: 'tool_name is required' },
+    }
+  }
+
+  const tool = findToolByName(availableTools, requestedToolName)
+  if (!tool) {
+    return {
+      id: request.id,
+      error: {
+        code: 'forbidden',
+        message: `Tool ${requestedToolName} is not allowed for this script`,
+      },
+    }
+  }
+
+  const rawArgs =
+    request.params?.args && typeof request.params.args === 'object'
+      ? (request.params.args as Record<string, unknown>)
+      : {}
+  const args = applyLegacyRpcInputAliases(requestedToolName, rawArgs)
+  const context = createToolUseContext(permissionContext, availableTools)
+
+  const validation = await tool.validateInput?.(args as never, context)
+  if (validation && !validation.result) {
+    return {
+      id: request.id,
+      error: { code: 'invalid_input', message: validation.message },
+    }
+  }
+
+  const permissionDecision = await tool.checkPermissions(args as never, context)
+  if (permissionDecision.behavior !== 'allow') {
+    return {
+      id: request.id,
+      error: {
+        code: 'forbidden',
+        message: `Permission denied for ${tool.name}`,
+      },
+    }
+  }
+
+  try {
+    const result = await tool.call(
+      ((permissionDecision.updatedInput ?? args) as never),
+      context,
+      async nestedTool => {
+        return findToolByName(availableTools, nestedTool.name)
+          ? { behavior: 'allow' as const }
+          : {
+              behavior: 'deny' as const,
+              message: `Nested tool ${nestedTool.name} is not allowed`,
+              errorCode: 1,
+            }
+      },
+      createAssistantMessage({ content: [] }),
+    )
+
+    return {
+      id: request.id,
+      result: result.data,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      id: request.id,
+      error: { code: 'tool_error', message },
+    }
+  }
+}
+
+function parseRpcRequest(line: string): RpcRequest {
+  return JSON.parse(line) as RpcRequest
+}
+
+function writeRpcResponse(socket: Socket, response: RpcResponse): void {
+  socket.write(`${jsonStringify(response)}\n`)
+}
+
+export async function startToolsSocketServer(socketPath: string): Promise<ToolsSocketServerHandle> {
+  await ensureRpcGrantDir()
+  await cleanupExpiredRpcGrants()
+  await mkdir(dirname(socketPath), { recursive: true })
+  await rm(socketPath, { force: true })
+
+  let server: Server | null = createServer(socket => {
+    let buffer = ''
+    socket.setEncoding('utf8')
+    socket.on('data', chunk => {
+      buffer += chunk
+      while (true) {
+        const newlineIndex = buffer.indexOf('\n')
+        if (newlineIndex === -1) {
+          break
+        }
+
+        const line = buffer.slice(0, newlineIndex).trim()
+        buffer = buffer.slice(newlineIndex + 1)
+        if (line.length === 0) {
+          continue
+        }
+
+        void executeRpcToolCall(parseRpcRequest(line))
+          .then(response => writeRpcResponse(socket, response))
+          .catch(error => {
+            logError(error)
+            writeRpcResponse(socket, {
+              id: null,
+              error: {
+                code: 'internal_error',
+                message: error instanceof Error ? error.message : String(error),
+              },
+            })
+          })
+      }
+    })
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server?.once('error', reject)
+    server?.listen(socketPath, () => resolve())
+  })
+  await chmod(socketPath, 0o600)
+
+  return {
+    socketPath,
+    async stop() {
+      const activeServer = server
+      server = null
+      if (activeServer) {
+        await new Promise<void>((resolve, reject) => {
+          activeServer.close(error => (error ? reject(error) : resolve()))
+        })
+      }
+      await rm(socketPath, { force: true })
+    },
+  }
+}

--- a/src 2/services/rpc/toolsSocketServer.ts
+++ b/src 2/services/rpc/toolsSocketServer.ts
@@ -10,6 +10,7 @@ import { getMainLoopModel } from '../../utils/model/model.js'
 import { getDefaultAppState } from '../../state/AppStateStore.js'
 import { findToolByName, type Tool, type ToolUseContext } from '../../Tool.js'
 import { getTools } from '../../tools.js'
+import { runWithCwdOverride } from '../../utils/cwd.js'
 import {
   cleanupExpiredRpcGrants,
   deserializeToolPermissionContext,
@@ -151,56 +152,87 @@ async function executeRpcToolCall(request: RpcRequest): Promise<RpcResponse> {
   const args = applyLegacyRpcInputAliases(requestedToolName, rawArgs)
   const context = createToolUseContext(permissionContext, availableTools)
 
-  const validation = await tool.validateInput?.(args as never, context)
-  if (validation && !validation.result) {
-    return {
-      id: request.id,
-      error: { code: 'invalid_input', message: validation.message },
+  return runWithCwdOverride(grant.projectDir, async () => {
+    const validation = await tool.validateInput?.(args as never, context)
+    if (validation && !validation.result) {
+      return {
+        id: request.id,
+        error: { code: 'invalid_input', message: validation.message },
+      }
     }
-  }
 
-  const permissionDecision = await tool.checkPermissions(args as never, context)
-  if (permissionDecision.behavior !== 'allow') {
-    return {
-      id: request.id,
-      error: {
-        code: 'forbidden',
-        message: `Permission denied for ${tool.name}`,
-      },
+    const permissionDecision = await tool.checkPermissions(args as never, context)
+    if (permissionDecision.behavior !== 'allow') {
+      return {
+        id: request.id,
+        error: {
+          code: 'forbidden',
+          message: `Permission denied for ${tool.name}`,
+        },
+      }
     }
-  }
 
-  try {
-    const result = await tool.call(
-      ((permissionDecision.updatedInput ?? args) as never),
-      context,
-      async nestedTool => {
-        return findToolByName(availableTools, nestedTool.name)
-          ? { behavior: 'allow' as const }
-          : {
-              behavior: 'deny' as const,
-              message: `Nested tool ${nestedTool.name} is not allowed`,
-              errorCode: 1,
-            }
-      },
-      createAssistantMessage({ content: [] }),
-    )
+    try {
+      const result = await tool.call(
+        ((permissionDecision.updatedInput ?? args) as never),
+        context,
+        async nestedTool => {
+          return findToolByName(availableTools, nestedTool.name)
+            ? { behavior: 'allow' as const }
+            : {
+                behavior: 'deny' as const,
+                message: `Nested tool ${nestedTool.name} is not allowed`,
+                errorCode: 1,
+              }
+        },
+        createAssistantMessage({ content: [] }),
+      )
 
-    return {
-      id: request.id,
-      result: result.data,
+      return {
+        id: request.id,
+        result: result.data,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return {
+        id: request.id,
+        error: { code: 'tool_error', message },
+      }
     }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    return {
-      id: request.id,
-      error: { code: 'tool_error', message },
-    }
-  }
+  })
 }
 
 function parseRpcRequest(line: string): RpcRequest {
-  return JSON.parse(line) as RpcRequest
+  const parsed = JSON.parse(line) as Partial<RpcRequest>
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('RPC request must be a JSON object')
+  }
+  if (parsed.method !== 'list_tools' && parsed.method !== 'call_tool') {
+    throw new Error('Unsupported RPC method')
+  }
+  if (
+    parsed.id !== undefined &&
+    parsed.id !== null &&
+    typeof parsed.id !== 'string' &&
+    typeof parsed.id !== 'number'
+  ) {
+    throw new Error('RPC request id must be a string, number, or null')
+  }
+  if (
+    parsed.params !== undefined &&
+    (!parsed.params ||
+      typeof parsed.params !== 'object' ||
+      Array.isArray(parsed.params))
+  ) {
+    throw new Error('RPC request params must be an object')
+  }
+  return {
+    id: parsed.id ?? null,
+    method: parsed.method,
+    ...(parsed.params
+      ? { params: parsed.params as Record<string, unknown> }
+      : {}),
+  }
 }
 
 function writeRpcResponse(socket: Socket, response: RpcResponse): void {
@@ -230,7 +262,21 @@ export async function startToolsSocketServer(socketPath: string): Promise<ToolsS
           continue
         }
 
-        void executeRpcToolCall(parseRpcRequest(line))
+        let request: RpcRequest
+        try {
+          request = parseRpcRequest(line)
+        } catch (error) {
+          writeRpcResponse(socket, {
+            id: null,
+            error: {
+              code: 'invalid_request',
+              message: error instanceof Error ? error.message : String(error),
+            },
+          })
+          continue
+        }
+
+        void executeRpcToolCall(request)
           .then(response => writeRpcResponse(socket, response))
           .catch(error => {
             logError(error)

--- a/src 2/tools.ts
+++ b/src 2/tools.ts
@@ -3,7 +3,6 @@ import { toolMatchesName, type Tool, type Tools } from './Tool.js'
 import { AgentTool } from './tools/AgentTool/AgentTool.js'
 import { SkillTool } from './tools/SkillTool/SkillTool.js'
 import { BashTool } from './tools/BashTool/BashTool.js'
-import { RunScriptTool } from './tools/RunScriptTool/RunScriptTool.js'
 import { FileEditTool } from './tools/FileEditTool/FileEditTool.js'
 import { FileReadTool } from './tools/FileReadTool/FileReadTool.js'
 import { FileWriteTool } from './tools/FileWriteTool/FileWriteTool.js'
@@ -196,7 +195,6 @@ export function getAllBaseTools(): Tools {
     AgentTool,
     TaskOutputTool,
     BashTool,
-    RunScriptTool,
     // Ant-native builds have bfs/ugrep embedded in the bun binary (same ARGV0
     // trick as ripgrep). When available, find/grep in Claude's shell are aliased
     // to these fast tools, so the dedicated Glob/Grep tools are unnecessary.

--- a/src 2/tools.ts
+++ b/src 2/tools.ts
@@ -3,6 +3,7 @@ import { toolMatchesName, type Tool, type Tools } from './Tool.js'
 import { AgentTool } from './tools/AgentTool/AgentTool.js'
 import { SkillTool } from './tools/SkillTool/SkillTool.js'
 import { BashTool } from './tools/BashTool/BashTool.js'
+import { RunScriptTool } from './tools/RunScriptTool/RunScriptTool.js'
 import { FileEditTool } from './tools/FileEditTool/FileEditTool.js'
 import { FileReadTool } from './tools/FileReadTool/FileReadTool.js'
 import { FileWriteTool } from './tools/FileWriteTool/FileWriteTool.js'
@@ -195,6 +196,7 @@ export function getAllBaseTools(): Tools {
     AgentTool,
     TaskOutputTool,
     BashTool,
+    RunScriptTool,
     // Ant-native builds have bfs/ugrep embedded in the bun binary (same ARGV0
     // trick as ripgrep). When available, find/grep in Claude's shell are aliased
     // to these fast tools, so the dedicated Glob/Grep tools are unnecessary.

--- a/src 2/tools/RunScriptTool/RunScriptTool.test.ts
+++ b/src 2/tools/RunScriptTool/RunScriptTool.test.ts
@@ -6,7 +6,6 @@ import { getDefaultAppState } from '../../state/AppStateStore.js'
 import { createFileStateCacheWithSizeLimit } from '../../utils/fileStateCache.js'
 import { getKairosRpcConfig } from '../../services/rpc/config.js'
 import { startToolsSocketServer } from '../../services/rpc/toolsSocketServer.js'
-import { getAllBaseTools } from '../../tools.js'
 import { getTools } from '../../tools.js'
 import { runScriptProcess } from './RunScriptTool.js'
 import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
@@ -28,10 +27,6 @@ afterEach(() => {
 })
 
 describe('RunScriptTool', () => {
-  test('is registered in the base tool list', () => {
-    expect(getAllBaseTools().some(tool => tool.name === 'RunScript')).toBe(true)
-  })
-
   test('runs a subprocess that uses the Python RPC client', async () => {
     const configDir = makeTempDir('kairos-run-script-')
     process.env.CLAUDE_CONFIG_DIR = configDir

--- a/src 2/tools/RunScriptTool/RunScriptTool.test.ts
+++ b/src 2/tools/RunScriptTool/RunScriptTool.test.ts
@@ -6,6 +6,7 @@ import { getDefaultAppState } from '../../state/AppStateStore.js'
 import { createFileStateCacheWithSizeLimit } from '../../utils/fileStateCache.js'
 import { getKairosRpcConfig } from '../../services/rpc/config.js'
 import { startToolsSocketServer } from '../../services/rpc/toolsSocketServer.js'
+import { getAllBaseTools } from '../../tools.js'
 import { getTools } from '../../tools.js'
 import { runScriptProcess } from './RunScriptTool.js'
 import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
@@ -27,6 +28,10 @@ afterEach(() => {
 })
 
 describe('RunScriptTool', () => {
+  test('is registered in the base tool list', () => {
+    expect(getAllBaseTools().some(tool => tool.name === 'RunScript')).toBe(true)
+  })
+
   test('runs a subprocess that uses the Python RPC client', async () => {
     const configDir = makeTempDir('kairos-run-script-')
     process.env.CLAUDE_CONFIG_DIR = configDir

--- a/src 2/tools/RunScriptTool/RunScriptTool.test.ts
+++ b/src 2/tools/RunScriptTool/RunScriptTool.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { getDefaultAppState } from '../../state/AppStateStore.js'
+import { createFileStateCacheWithSizeLimit } from '../../utils/fileStateCache.js'
+import { getKairosRpcConfig } from '../../services/rpc/config.js'
+import { startToolsSocketServer } from '../../services/rpc/toolsSocketServer.js'
+import { getTools } from '../../tools.js'
+import { runScriptProcess } from './RunScriptTool.js'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+
+const TEMP_DIRS: string[] = []
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  resetSettingsCache()
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('RunScriptTool', () => {
+  test('runs a subprocess that uses the Python RPC client', async () => {
+    const configDir = makeTempDir('kairos-run-script-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ kairos: { rpc: { enabled: true } } }),
+    )
+    resetSettingsCache()
+
+    const config = getKairosRpcConfig()
+    const server = await startToolsSocketServer(config.socketPath)
+    const tempFile = join(configDir, 'rpc-example.txt')
+    writeFileSync(tempFile, 'hello from rpc\n')
+
+    const context = {
+      abortController: new AbortController(),
+      options: {
+        commands: [],
+        debug: false,
+        mainLoopModel: 'sonnet',
+        tools: getTools(getDefaultAppState().toolPermissionContext),
+        verbose: false,
+        thinkingConfig: { type: 'disabled' as const },
+        mcpClients: [],
+        mcpResources: {},
+        isNonInteractiveSession: true,
+        agentDefinitions: { activeAgents: [], allAgents: [] },
+      },
+      readFileState: createFileStateCacheWithSizeLimit(16),
+      getAppState: () => {
+        const state = getDefaultAppState()
+        state.toolPermissionContext.additionalWorkingDirectories = new Map([
+          [configDir, { path: configDir, source: 'session' }],
+        ])
+        return state
+      },
+      setAppState: () => {},
+      messages: [],
+      setInProgressToolUseIDs: () => {},
+      setResponseLength: () => {},
+      updateFileHistoryState: () => {},
+      updateAttributionState: () => {},
+    }
+
+    const result = await runScriptProcess(
+      {
+        script: `python3 -c "import sys; sys.path.insert(0, '${join(process.cwd(), 'services', 'rpc', 'python_client')}'); import kairos_tools; print(kairos_tools.call('ReadFile', {'path': '${tempFile}'})['file']['content'])"`,
+      },
+      context as never,
+    )
+
+    expect(result.stdout).toContain('hello from rpc')
+
+    await server.stop()
+  })
+
+  test('returns stderr for a crashing script', async () => {
+    const configDir = makeTempDir('kairos-run-script-crash-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ kairos: { rpc: { enabled: true } } }),
+    )
+    resetSettingsCache()
+
+    const context = {
+      abortController: new AbortController(),
+      options: {
+        commands: [],
+        debug: false,
+        mainLoopModel: 'sonnet',
+        tools: getTools(getDefaultAppState().toolPermissionContext),
+        verbose: false,
+        thinkingConfig: { type: 'disabled' as const },
+        mcpClients: [],
+        mcpResources: {},
+        isNonInteractiveSession: true,
+        agentDefinitions: { activeAgents: [], allAgents: [] },
+      },
+      readFileState: createFileStateCacheWithSizeLimit(16),
+      getAppState: () => getDefaultAppState(),
+      setAppState: () => {},
+      messages: [],
+      setInProgressToolUseIDs: () => {},
+      setResponseLength: () => {},
+      updateFileHistoryState: () => {},
+      updateAttributionState: () => {},
+    }
+
+    await expect(
+      runScriptProcess(
+        {
+          script: `python3 -c "import sys; sys.stderr.write('boom\\n'); sys.exit(3)"`,
+        },
+        context as never,
+      ),
+    ).rejects.toThrow('boom')
+  })
+
+  test('terminates a script that exceeds its timeout', async () => {
+    const configDir = makeTempDir('kairos-run-script-timeout-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ kairos: { rpc: { enabled: true } } }),
+    )
+    resetSettingsCache()
+
+    const context = {
+      abortController: new AbortController(),
+      options: {
+        commands: [],
+        debug: false,
+        mainLoopModel: 'sonnet',
+        tools: getTools(getDefaultAppState().toolPermissionContext),
+        verbose: false,
+        thinkingConfig: { type: 'disabled' as const },
+        mcpClients: [],
+        mcpResources: {},
+        isNonInteractiveSession: true,
+        agentDefinitions: { activeAgents: [], allAgents: [] },
+      },
+      readFileState: createFileStateCacheWithSizeLimit(16),
+      getAppState: () => getDefaultAppState(),
+      setAppState: () => {},
+      messages: [],
+      setInProgressToolUseIDs: () => {},
+      setResponseLength: () => {},
+      updateFileHistoryState: () => {},
+      updateAttributionState: () => {},
+    }
+
+    await expect(
+      runScriptProcess(
+        {
+          script: `python3 -c "import time; time.sleep(2)"`,
+          timeoutSec: 1,
+        },
+        context as never,
+      ),
+    ).rejects.toThrow()
+  })
+
+  test('truncates oversized stdout', async () => {
+    const configDir = makeTempDir('kairos-run-script-stdout-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ kairos: { rpc: { enabled: true } } }),
+    )
+    resetSettingsCache()
+
+    const context = {
+      abortController: new AbortController(),
+      options: {
+        commands: [],
+        debug: false,
+        mainLoopModel: 'sonnet',
+        tools: getTools(getDefaultAppState().toolPermissionContext),
+        verbose: false,
+        thinkingConfig: { type: 'disabled' as const },
+        mcpClients: [],
+        mcpResources: {},
+        isNonInteractiveSession: true,
+        agentDefinitions: { activeAgents: [], allAgents: [] },
+      },
+      readFileState: createFileStateCacheWithSizeLimit(16),
+      getAppState: () => getDefaultAppState(),
+      setAppState: () => {},
+      messages: [],
+      setInProgressToolUseIDs: () => {},
+      setResponseLength: () => {},
+      updateFileHistoryState: () => {},
+      updateAttributionState: () => {},
+    }
+
+    const result = await runScriptProcess(
+      {
+        script: `python3 -c "print('x' * 20000)"`,
+      },
+      context as never,
+    )
+
+    expect(result.truncated).toBe(true)
+    expect(result.stdout.length).toBeLessThanOrEqual(16 * 1024)
+  })
+})

--- a/src 2/tools/RunScriptTool/RunScriptTool.ts
+++ b/src 2/tools/RunScriptTool/RunScriptTool.ts
@@ -10,7 +10,6 @@ import { createRpcGrant, deleteRpcGrant } from '../../services/rpc/authToken.js'
 import { getRpcAllowedToolNames } from '../../services/rpc/toolAllowlist.js'
 
 const RUN_SCRIPT_TOOL_NAME = 'RunScript'
-const DEFAULT_MAX_OUTPUT_CHARS = 16 * 1024
 const TRUNCATION_MARKER = '\n...[stdout truncated]'
 
 const inputSchema = lazySchema(() =>
@@ -102,7 +101,11 @@ async function runScriptProcess(
       if (truncated) return
       stdout += String(chunk)
       if (stdout.length > config.stdoutCapBytes) {
-        stdout = stdout.slice(0, DEFAULT_MAX_OUTPUT_CHARS - TRUNCATION_MARKER.length) + TRUNCATION_MARKER
+        stdout =
+          stdout.slice(
+            0,
+            Math.max(0, config.stdoutCapBytes - TRUNCATION_MARKER.length),
+          ) + TRUNCATION_MARKER
         truncated = true
       }
     })
@@ -154,6 +157,9 @@ export const RunScriptTool = buildTool({
   },
   isConcurrencySafe() {
     return true
+  },
+  isEnabled() {
+    return getKairosRpcConfig().enabled
   },
   isReadOnly() {
     return false

--- a/src 2/tools/RunScriptTool/RunScriptTool.ts
+++ b/src 2/tools/RunScriptTool/RunScriptTool.ts
@@ -1,0 +1,178 @@
+import { spawn } from 'child_process'
+import { parse as parseShellCommand } from 'shell-quote'
+import { z } from 'zod/v4'
+import type { ToolUseContext } from '../../Tool.js'
+import { buildTool, type ToolDef } from '../../Tool.js'
+import { getCwd } from '../../utils/cwd.js'
+import { lazySchema } from '../../utils/lazySchema.js'
+import { getKairosRpcConfig } from '../../services/rpc/config.js'
+import { createRpcGrant, deleteRpcGrant } from '../../services/rpc/authToken.js'
+import { getRpcAllowedToolNames } from '../../services/rpc/toolAllowlist.js'
+
+const RUN_SCRIPT_TOOL_NAME = 'RunScript'
+const DEFAULT_MAX_OUTPUT_CHARS = 16 * 1024
+const TRUNCATION_MARKER = '\n...[stdout truncated]'
+
+const inputSchema = lazySchema(() =>
+  z.strictObject({
+    script: z
+      .string()
+      .min(1)
+      .describe('Command line for a local script process, e.g. `python3 -c "print(1)"`.'),
+    timeoutSec: z
+      .number()
+      .int()
+      .positive()
+      .max(300)
+      .optional()
+      .describe('Optional wall-clock timeout override in seconds.'),
+  }),
+)
+type InputSchema = ReturnType<typeof inputSchema>
+
+const outputSchema = lazySchema(() =>
+  z.object({
+    stdout: z.string(),
+    truncated: z.boolean(),
+    exitCode: z.number(),
+  }),
+)
+type OutputSchema = ReturnType<typeof outputSchema>
+export type Output = z.infer<OutputSchema>
+
+function parseCommand(script: string): { command: string; args: string[] } {
+  const tokens = parseShellCommand(script)
+  const words = tokens.map(token => {
+    if (typeof token !== 'string') {
+      throw new Error('Script command cannot use shell control operators')
+    }
+    return token
+  })
+  if (words.length === 0) {
+    throw new Error('Script command is empty')
+  }
+  return {
+    command: words[0]!,
+    args: words.slice(1),
+  }
+}
+
+async function runScriptProcess(
+  input: { script: string; timeoutSec?: number },
+  context: ToolUseContext,
+): Promise<Output> {
+  const config = getKairosRpcConfig()
+  if (!config.enabled) {
+    throw new Error('KAIROS RPC is disabled. Set `kairos.rpc.enabled` to true in settings.')
+  }
+
+  const timeoutSec = Math.min(
+    input.timeoutSec ?? config.defaultTimeoutSec,
+    config.maxTimeoutSec,
+  )
+  const permissionContext = context.getAppState().toolPermissionContext
+  const allowedTools = getRpcAllowedToolNames(context.options.tools, permissionContext)
+  const grant = await createRpcGrant({
+    projectDir: getCwd(),
+    allowedTools,
+    permissionContext,
+    maxCalls: config.maxCallsPerInvocation,
+    expiresAt: new Date(Date.now() + (timeoutSec + 5) * 1000),
+  })
+
+  try {
+    const { command, args } = parseCommand(input.script)
+    const child = spawn(command, args, {
+      cwd: getCwd(),
+      env: {
+        ...process.env,
+        KAIROS_SOCKET: config.socketPath,
+        KAIROS_TOKEN: grant.token,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+
+    let stdout = ''
+    let stderr = ''
+    let truncated = false
+
+    child.stdout?.on('data', chunk => {
+      if (truncated) return
+      stdout += String(chunk)
+      if (stdout.length > config.stdoutCapBytes) {
+        stdout = stdout.slice(0, DEFAULT_MAX_OUTPUT_CHARS - TRUNCATION_MARKER.length) + TRUNCATION_MARKER
+        truncated = true
+      }
+    })
+
+    child.stderr?.on('data', chunk => {
+      stderr += String(chunk)
+    })
+
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+    }, timeoutSec * 1000)
+
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      child.once('error', reject)
+      child.once('exit', code => resolve(code ?? 1))
+    }).finally(() => {
+      clearTimeout(timeout)
+    })
+
+    if (exitCode !== 0) {
+      throw new Error(stderr.trim() || `Script exited with code ${exitCode}`)
+    }
+
+    return {
+      stdout,
+      truncated,
+      exitCode,
+    }
+  } finally {
+    await deleteRpcGrant(grant.token)
+  }
+}
+
+export const RunScriptTool = buildTool({
+  name: RUN_SCRIPT_TOOL_NAME,
+  searchHint: 'run a local script that can call KAIROS RPC tools',
+  maxResultSizeChars: 20_000,
+  async description() {
+    return 'Run a local script subprocess with KAIROS tool RPC access.'
+  },
+  async prompt() {
+    return 'Runs a local script subprocess. The subprocess receives `KAIROS_SOCKET` and `KAIROS_TOKEN` so it can call KAIROS RPC tools.'
+  },
+  get inputSchema(): InputSchema {
+    return inputSchema()
+  },
+  get outputSchema(): OutputSchema {
+    return outputSchema()
+  },
+  isConcurrencySafe() {
+    return true
+  },
+  isReadOnly() {
+    return false
+  },
+  renderToolUseMessage() {
+    return 'Running a local script'
+  },
+  async call(input, context) {
+    return {
+      data: await runScriptProcess(input, context),
+    }
+  },
+  mapToolResultToToolResultBlockParam(output, toolUseID) {
+    return {
+      tool_use_id: toolUseID,
+      type: 'tool_result',
+      content: output.stdout,
+    }
+  },
+} satisfies ToolDef<InputSchema, Output>)
+
+export { runScriptProcess }


### PR DESCRIPTION
Adds a KAIROS Unix-socket RPC service with token-based grants, allowlist enforcement, and a small Python client for local scripts. Starts and stops the socket from the KAIROS daemon when \ is set, and adds coverage for the daemon lifecycle and RPC behavior. Also adds a standalone \ module with timeout, truncation, and failure-path tests so scripts can be executed against the new RPC surface. The workspace diff is otherwise limited to the KAIROS daemon path helpers and worker tests needed to verify the new socket lifecycle.