### PR TITLE
feat(kairos): add Telegram delivery gateway (closes #37)

### DIFF
--- a/src 2/commands/kairos.ts
+++ b/src 2/commands/kairos.ts
@@ -24,6 +24,12 @@ import {
   getKairosStdoutLogPath,
   getProjectKairosLogPath,
 } from '../daemon/kairos/paths.js'
+import {
+  readGatewayStatus,
+  setupTelegram,
+  startPairing,
+  unpairTelegram,
+} from '../daemon/gateway/telegram/cli.js'
 import { safeParseJSON } from '../utils/json.js'
 import type { GlobalStatus, PauseState } from '../daemon/kairos/stateWriter.js'
 
@@ -39,7 +45,11 @@ const HELP_TEXT = `Usage:
 /kairos pause
 /kairos resume
 /kairos dashboard
-/kairos logs [projectDir] [lines]`
+/kairos logs [projectDir] [lines]
+/kairos gateway telegram setup <bot-token>
+/kairos gateway telegram pair
+/kairos gateway telegram status
+/kairos gateway telegram unpair [chatId|all]`
 
 type Subcommand =
   | 'status'
@@ -51,6 +61,7 @@ type Subcommand =
   | 'resume'
   | 'dashboard'
   | 'logs'
+  | 'gateway'
 
 const SUBCOMMANDS = new Set<Subcommand>([
   'status',
@@ -62,6 +73,7 @@ const SUBCOMMANDS = new Set<Subcommand>([
   'resume',
   'dashboard',
   'logs',
+  'gateway',
 ])
 
 function parseArgs(args: string): { sub: Subcommand | null; rest: string[] } {
@@ -195,6 +207,63 @@ async function handleLogs(
   return tail.join('\n')
 }
 
+async function handleGatewayTelegram(args: string[]): Promise<string> {
+  const [action, ...rest] = args
+  if (!action) {
+    return 'Usage: /kairos gateway telegram <setup|pair|status|unpair> [...]'
+  }
+  switch (action) {
+    case 'setup': {
+      const token = rest.join(' ').trim()
+      if (!token) return 'Usage: /kairos gateway telegram setup <bot-token>'
+      const result = await setupTelegram(token)
+      if (!result.ok) return `Setup failed: ${result.reason}`
+      const who = result.botUsername ? ` as @${result.botUsername}` : ''
+      return `Telegram gateway configured${who}. Now run \`/kairos gateway telegram pair\` to link your chat.`
+    }
+    case 'pair': {
+      const result = await startPairing()
+      if (!result.ok) return result.reason
+      const who = result.botUsername ? `@${result.botUsername}` : 'your bot'
+      return [
+        `Pair code: ${result.code}`,
+        `On your phone, open Telegram, DM ${who}, and send the code above.`,
+        'The code expires in 15 minutes.',
+      ].join('\n')
+    }
+    case 'status': {
+      const s = await readGatewayStatus()
+      if (!s.configured) {
+        return `Telegram gateway: not configured (${s.configPath} missing). Run \`/kairos gateway telegram setup <bot-token>\` to start.`
+      }
+      const who = s.botUsername ? `@${s.botUsername}` : '(unknown username)'
+      const paired = s.pairedChatIds.length === 0 ? 'none' : s.pairedChatIds.join(', ')
+      return `Telegram gateway: bot=${who}, paired chat IDs=${paired}`
+    }
+    case 'unpair': {
+      const target = rest[0]
+      if (!target || target === 'all') {
+        const r = await unpairTelegram('all')
+        if (!r.ok) return r.reason
+        return `Unpaired ${r.removed.length} chat(s). Allowlist cleared.`
+      }
+      const chatId = Number(target)
+      if (!Number.isInteger(chatId)) return `Not a numeric chat id: ${target}`
+      const r = await unpairTelegram(chatId)
+      if (!r.ok) return r.reason
+      return `Unpaired chat ${chatId}. Remaining: ${r.remaining.join(', ') || 'none'}`
+    }
+    default:
+      return `Unknown gateway telegram action: ${action}`
+  }
+}
+
+async function handleGateway(rest: string[]): Promise<string> {
+  const [channel, ...args] = rest
+  if (channel === 'telegram') return handleGatewayTelegram(args)
+  return 'Usage: /kairos gateway telegram <setup|pair|status|unpair> [...]'
+}
+
 export async function runKairosCommand(args: string): Promise<string> {
   const { sub, rest } = parseArgs(args)
   if (sub === null) {
@@ -217,6 +286,8 @@ export async function runKairosCommand(args: string): Promise<string> {
       return handleResume()
     case 'dashboard':
       return handleDashboard()
+    case 'gateway':
+      return handleGateway(rest)
     case 'logs': {
       const first = rest[0]
       // A bare number is always a line count; anything else (including

--- a/src 2/daemon/gateway/telegram/allowlist.ts
+++ b/src 2/daemon/gateway/telegram/allowlist.ts
@@ -1,0 +1,53 @@
+// Paired chat-ID allowlist.
+//
+// Pairing writes a chat ID here; everything inbound consults
+// isPaired() before acting. Keeping the allowlist in the same
+// telegram.json as the token means unpair + token-rotation use the same
+// atomic write, so there's no moment where the token is present but the
+// allowlist is stale.
+
+import { readTelegramConfig, writeTelegramConfig } from './config.js'
+import type { TelegramConfig } from './config.js'
+
+export async function isChatPaired(
+  chatId: number,
+  path?: string,
+): Promise<boolean> {
+  const config = await readTelegramConfig(path)
+  if (!config) return false
+  return config.pairedChatIds.includes(chatId)
+}
+
+export async function addPairedChat(
+  chatId: number,
+  path?: string,
+): Promise<TelegramConfig> {
+  const config = await readTelegramConfig(path)
+  if (!config) {
+    throw new Error('Cannot pair chat: telegram.json does not exist or has no token')
+  }
+  if (config.pairedChatIds.includes(chatId)) {
+    return config
+  }
+  const next: TelegramConfig = {
+    ...config,
+    pairedChatIds: [...config.pairedChatIds, chatId],
+  }
+  await writeTelegramConfig(next, path)
+  return next
+}
+
+export async function removePairedChat(
+  chatId: number,
+  path?: string,
+): Promise<TelegramConfig | null> {
+  const config = await readTelegramConfig(path)
+  if (!config) return null
+  if (!config.pairedChatIds.includes(chatId)) return config
+  const next: TelegramConfig = {
+    ...config,
+    pairedChatIds: config.pairedChatIds.filter(id => id !== chatId),
+  }
+  await writeTelegramConfig(next, path)
+  return next
+}

--- a/src 2/daemon/gateway/telegram/cli.test.ts
+++ b/src 2/daemon/gateway/telegram/cli.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  readGatewayStatus,
+  setupTelegram,
+  startPairing,
+  unpairTelegram,
+} from './cli.js'
+import { writeTelegramConfig } from './config.js'
+
+const TEMP_DIRS: string[] = []
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makePaths() {
+  const dir = mkdtempSync(join(tmpdir(), 'tg-cli-'))
+  TEMP_DIRS.push(dir)
+  return {
+    configPath: join(dir, 'telegram.json'),
+    pendingPath: join(dir, 'telegram.pending.json'),
+  }
+}
+
+function okFetcher(me: Record<string, unknown>): typeof fetch {
+  return async () =>
+    new Response(JSON.stringify({ ok: true, result: me }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+}
+
+describe('setupTelegram', () => {
+  test('rejects an obviously malformed token without hitting the API', async () => {
+    const { configPath } = makePaths()
+    const result = await setupTelegram('not-a-token', { configPath })
+    expect(result.ok).toBe(false)
+  })
+
+  test('writes the config (0600) and captures the bot username', async () => {
+    const { configPath } = makePaths()
+    const result = await setupTelegram('1234567:AAAAAAAAAAAAAAAAAAAAAA', {
+      configPath,
+      fetcher: okFetcher({ id: 1, is_bot: true, first_name: 'bot', username: 'magnus' }),
+    })
+    expect(result).toEqual({ ok: true, botUsername: 'magnus' })
+
+    const status = await readGatewayStatus({ configPath })
+    expect(status.configured).toBe(true)
+    expect(status.botUsername).toBe('magnus')
+  })
+
+  test('re-running setup preserves paired chat IDs', async () => {
+    const { configPath } = makePaths()
+    await writeTelegramConfig(
+      { token: 'old', pairedChatIds: [42] },
+      configPath,
+    )
+    const result = await setupTelegram('1234567:AAAAAAAAAAAAAAAAAAAAAA', {
+      configPath,
+      fetcher: okFetcher({ id: 1, is_bot: true, first_name: 'bot', username: 'magnus' }),
+    })
+    expect(result.ok).toBe(true)
+
+    const status = await readGatewayStatus({ configPath })
+    expect(status.pairedChatIds).toEqual([42])
+  })
+})
+
+describe('startPairing', () => {
+  test('fails when no config exists (user must setup first)', async () => {
+    const { configPath, pendingPath } = makePaths()
+    const result = await startPairing({ configPath, pendingPath })
+    expect(result.ok).toBe(false)
+  })
+
+  test('writes a 6-digit pending code', async () => {
+    const { configPath, pendingPath } = makePaths()
+    await writeTelegramConfig(
+      { token: 't', botUsername: 'magnus', pairedChatIds: [] },
+      configPath,
+    )
+    const result = await startPairing({ configPath, pendingPath })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.code).toMatch(/^\d{6}$/)
+    expect(result.botUsername).toBe('magnus')
+  })
+})
+
+describe('readGatewayStatus', () => {
+  test('reports unconfigured when file missing', async () => {
+    const { configPath } = makePaths()
+    const s = await readGatewayStatus({ configPath })
+    expect(s.configured).toBe(false)
+    expect(s.pairedChatIds).toEqual([])
+  })
+})
+
+describe('unpairTelegram', () => {
+  test('unpair all clears the allowlist and pending code', async () => {
+    const { configPath, pendingPath } = makePaths()
+    await writeTelegramConfig(
+      { token: 't', pairedChatIds: [1, 2, 3] },
+      configPath,
+    )
+    const r = await unpairTelegram('all', { configPath, pendingPath })
+    expect(r).toEqual({ ok: true, removed: [1, 2, 3], remaining: [] })
+  })
+
+  test('unpair single chat leaves the rest alone', async () => {
+    const { configPath } = makePaths()
+    await writeTelegramConfig(
+      { token: 't', pairedChatIds: [1, 2, 3] },
+      configPath,
+    )
+    const r = await unpairTelegram(2, { configPath })
+    expect(r).toEqual({ ok: true, removed: [2], remaining: [1, 3] })
+  })
+
+  test('unpair rejects unknown chat id', async () => {
+    const { configPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [1] }, configPath)
+    const r = await unpairTelegram(99, { configPath })
+    expect(r.ok).toBe(false)
+  })
+})

--- a/src 2/daemon/gateway/telegram/cli.ts
+++ b/src 2/daemon/gateway/telegram/cli.ts
@@ -1,0 +1,149 @@
+// CLI-side helpers for /kairos gateway telegram *. These run in the user's
+// interactive shell, not the daemon. They only touch the on-disk config
+// and pending-code files; the running daemon picks up changes on the
+// next inbound message.
+
+import { readTelegramConfig, writeTelegramConfig } from './config.js'
+import { getTelegramConfigPath } from './paths.js'
+import {
+  clearPendingPair,
+  generatePairCode,
+  writePendingPair,
+} from './pairing.js'
+import { removePairedChat } from './allowlist.js'
+import { createTelegramTransport } from './transport.js'
+
+const BOT_TOKEN_REGEX = /^\d{5,}:[A-Za-z0-9_-]{20,}$/
+
+export type SetupResult = {
+  ok: true
+  botUsername?: string
+} | {
+  ok: false
+  reason: string
+}
+
+/**
+ * Validate a token, hit the Bot API to resolve the username, and write
+ * ~/.claude/kairos/telegram.json (0600). Safe to re-run — rotating the
+ * token preserves the paired chat IDs.
+ */
+export async function setupTelegram(
+  token: string,
+  opts: { fetcher?: typeof fetch; configPath?: string } = {},
+): Promise<SetupResult> {
+  const trimmed = token.trim()
+  if (!BOT_TOKEN_REGEX.test(trimmed)) {
+    return {
+      ok: false,
+      reason:
+        'That does not look like a Telegram bot token. Expected format: `1234567:ABCDEF...` from @BotFather.',
+    }
+  }
+
+  let botUsername: string | undefined
+  try {
+    const transport = createTelegramTransport(trimmed, { fetcher: opts.fetcher })
+    const me = await transport.getMe()
+    botUsername = me.username
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `Could not reach Telegram with that token: ${(err as Error).message}`,
+    }
+  }
+
+  const existing = await readTelegramConfig(opts.configPath)
+  await writeTelegramConfig(
+    {
+      token: trimmed,
+      botUsername,
+      pairedChatIds: existing?.pairedChatIds ?? [],
+    },
+    opts.configPath,
+  )
+  return { ok: true, botUsername }
+}
+
+export type PairResult =
+  | {
+      ok: true
+      code: string
+      botUsername?: string
+    }
+  | { ok: false; reason: string }
+
+/**
+ * Generate a 6-digit pair code and write it to telegram.pending.json.
+ * The daemon's inbound loop will match it to the next DM from a chat
+ * and pair that chat ID. Returns the code so the CLI can print it.
+ */
+export async function startPairing(
+  opts: { configPath?: string; pendingPath?: string; now?: Date } = {},
+): Promise<PairResult> {
+  const config = await readTelegramConfig(opts.configPath)
+  if (!config) {
+    return {
+      ok: false,
+      reason:
+        'Run `/kairos gateway telegram setup <bot-token>` first — no token is configured.',
+    }
+  }
+  const code = generatePairCode()
+  const createdAt = (opts.now ?? new Date()).toISOString()
+  await writePendingPair({ code, createdAt }, opts.pendingPath)
+  return { ok: true, code, botUsername: config.botUsername }
+}
+
+export type StatusResult = {
+  configured: boolean
+  botUsername?: string
+  pairedChatIds: number[]
+  configPath: string
+}
+
+export async function readGatewayStatus(opts: { configPath?: string } = {}): Promise<StatusResult> {
+  const config = await readTelegramConfig(opts.configPath)
+  const configPath = opts.configPath ?? getTelegramConfigPath()
+  if (!config) {
+    return { configured: false, pairedChatIds: [], configPath }
+  }
+  return {
+    configured: true,
+    botUsername: config.botUsername,
+    pairedChatIds: [...config.pairedChatIds],
+    configPath,
+  }
+}
+
+export type UnpairResult =
+  | { ok: true; removed: number[]; remaining: number[] }
+  | { ok: false; reason: string }
+
+export async function unpairTelegram(
+  target: 'all' | number,
+  opts: { configPath?: string; pendingPath?: string } = {},
+): Promise<UnpairResult> {
+  const config = await readTelegramConfig(opts.configPath)
+  if (!config) return { ok: false, reason: 'No telegram.json to unpair from.' }
+
+  if (target === 'all') {
+    const removed = [...config.pairedChatIds]
+    await writeTelegramConfig(
+      { ...config, pairedChatIds: [] },
+      opts.configPath,
+    )
+    await clearPendingPair(opts.pendingPath)
+    return { ok: true, removed, remaining: [] }
+  }
+
+  if (!config.pairedChatIds.includes(target)) {
+    return { ok: false, reason: `chat id ${target} is not paired.` }
+  }
+  const next = await removePairedChat(target, opts.configPath)
+  return {
+    ok: true,
+    removed: [target],
+    remaining: next?.pairedChatIds ?? [],
+  }
+}

--- a/src 2/daemon/gateway/telegram/commands.test.ts
+++ b/src 2/daemon/gateway/telegram/commands.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  createDispatcher,
+  parseCommand,
+  parseReminderWhen,
+} from './commands.js'
+
+function makeDeps(overrides: Partial<Parameters<typeof createDispatcher>[0]> = {}) {
+  const calls: { setPause: boolean[]; skip: number } = { setPause: [], skip: 0 }
+  const deps = {
+    now: () => new Date('2026-04-22T12:00:00.000Z'),
+    readStatus: async () => ({ state: 'idle', pid: 1234 }),
+    readPause: async () => ({ paused: false }),
+    listProjects: async () => ['/tmp/project-a'],
+    setPause: async (p: boolean) => {
+      calls.setPause.push(p)
+    },
+    scheduleReminder: async (req: { projectDir: string; text: string; at: unknown }) => ({
+      ok: true as const,
+      status: 'scheduled' as const,
+      id: 'abc',
+      at: req.at as Date,
+      text: req.text,
+      projectDir: req.projectDir,
+      filePath: '',
+      message: `Reminder scheduled for ${String(req.at)}: "${req.text}".`,
+    }),
+    recordSkip: async () => {
+      calls.skip += 1
+    },
+    ...overrides,
+  }
+  const dispatcher = createDispatcher(deps as Parameters<typeof createDispatcher>[0])
+  return { dispatcher, calls, deps }
+}
+
+describe('parseCommand', () => {
+  test.each([
+    ['/status', 'status'],
+    ['/Status', 'status'],
+    ['/pause', 'pause'],
+    ['/resume', 'resume'],
+    ['/remind 2m hydrate', 'remind'],
+    ['/skip', 'skip'],
+    ['/help', 'help'],
+    ['/start', 'help'],
+    ['/status@magnus114bot', 'status'],
+  ] as const)('recognizes %s as %s', (input, expected) => {
+    expect(parseCommand(input).name).toBe(expected)
+  })
+
+  test('non-slash input returns unknown', () => {
+    expect(parseCommand('hello').name).toBe('unknown')
+  })
+
+  test('unrecognized slash command returns unknown', () => {
+    expect(parseCommand('/foo bar').name).toBe('unknown')
+  })
+
+  test('preserves argument rest', () => {
+    expect(parseCommand('/remind 2m drink water').rest).toBe('2m drink water')
+  })
+})
+
+describe('parseReminderWhen', () => {
+  const now = new Date('2026-04-22T12:00:00.000Z')
+
+  test.each([
+    ['2m', 2 * 60 * 1000],
+    ['90s', 90 * 1000],
+    ['1h', 60 * 60 * 1000],
+    ['2 hours', 2 * 60 * 60 * 1000],
+    ['1d', 24 * 60 * 60 * 1000],
+  ] as const)('%s resolves to +%dms', (token, expectedMs) => {
+    const result = parseReminderWhen(token, now)
+    expect(result?.getTime()).toBe(now.getTime() + expectedMs)
+  })
+
+  test('absolute ISO timestamp parses', () => {
+    const result = parseReminderWhen('2026-05-01T09:00:00.000Z', now)
+    expect(result?.toISOString()).toBe('2026-05-01T09:00:00.000Z')
+  })
+
+  test('returns null for free-form English (to avoid misreading)', () => {
+    expect(parseReminderWhen('tomorrow at 9', now)).toBeNull()
+  })
+
+  test('returns null for zero or negative durations', () => {
+    expect(parseReminderWhen('0m', now)).toBeNull()
+  })
+
+  test('returns null for empty input', () => {
+    expect(parseReminderWhen('', now)).toBeNull()
+  })
+})
+
+describe('createDispatcher', () => {
+  test('/status renders a compact summary', async () => {
+    const { dispatcher } = makeDeps()
+    const { reply } = await dispatcher.dispatch({ chatId: 1, text: '/status' })
+    expect(reply).toContain('daemon: idle')
+    expect(reply).toContain('paused: no')
+    expect(reply).toContain('projects: 1')
+  })
+
+  test('/pause flips state via setPause(true)', async () => {
+    const { dispatcher, calls } = makeDeps()
+    await dispatcher.dispatch({ chatId: 1, text: '/pause' })
+    expect(calls.setPause).toEqual([true])
+  })
+
+  test('/resume flips state via setPause(false)', async () => {
+    const { dispatcher, calls } = makeDeps()
+    await dispatcher.dispatch({ chatId: 1, text: '/resume' })
+    expect(calls.setPause).toEqual([false])
+  })
+
+  test('/remind with valid args schedules and echoes confirmation', async () => {
+    const { dispatcher } = makeDeps()
+    const { reply } = await dispatcher.dispatch({
+      chatId: 1,
+      text: '/remind 2m drink water',
+    })
+    expect(reply).toContain('Reminder scheduled for')
+    expect(reply).toContain('drink water')
+  })
+
+  test('/remind rejects missing "what"', async () => {
+    const { dispatcher } = makeDeps()
+    const { reply } = await dispatcher.dispatch({ chatId: 1, text: '/remind 2m' })
+    expect(reply.toLowerCase()).toContain('usage')
+  })
+
+  test('/remind rejects ambiguous "when"', async () => {
+    const { dispatcher } = makeDeps()
+    const { reply } = await dispatcher.dispatch({
+      chatId: 1,
+      text: '/remind later drink water',
+    })
+    expect(reply.toLowerCase()).toContain("couldn't parse")
+  })
+
+  test('/remind errors when no projects are opted in', async () => {
+    const { dispatcher } = makeDeps({ listProjects: async () => [] })
+    const { reply } = await dispatcher.dispatch({
+      chatId: 1,
+      text: '/remind 2m drink water',
+    })
+    expect(reply.toLowerCase()).toContain('opt-in')
+  })
+
+  test('/skip records and acknowledges', async () => {
+    const { dispatcher, calls } = makeDeps()
+    const { reply } = await dispatcher.dispatch({ chatId: 1, text: '/skip' })
+    expect(calls.skip).toBe(1)
+    expect(reply.toLowerCase()).toContain('dismissed')
+  })
+
+  test('/help lists available commands', async () => {
+    const { dispatcher } = makeDeps()
+    const { reply } = await dispatcher.dispatch({ chatId: 1, text: '/help' })
+    expect(reply).toContain('/status')
+    expect(reply).toContain('/remind')
+  })
+
+  test('unknown command returns help text', async () => {
+    const { dispatcher } = makeDeps()
+    const { reply } = await dispatcher.dispatch({ chatId: 1, text: '/foo' })
+    expect(reply.toLowerCase()).toContain('unknown')
+  })
+})

--- a/src 2/daemon/gateway/telegram/commands.ts
+++ b/src 2/daemon/gateway/telegram/commands.ts
@@ -1,0 +1,217 @@
+// Inbound command dispatcher.
+//
+// Parses the first whitespace-separated token of a DMed message. If it's
+// an allowlisted slash-command we dispatch, otherwise we return a "help"
+// reply so the user discovers what's available. Everything here is pure
+// functions + injected dependencies so the long-poll loop just wires
+// inputs through and does no policy decisions of its own.
+
+import { getKairosPausePath, getKairosStatusPath } from '../../kairos/paths.js'
+import { createReminderFromUserRequest } from '../../../services/reminders/createReminderFromUserRequest.js'
+import type { CreateReminderResult } from '../../../services/reminders/createReminderFromUserRequest.js'
+
+export type CommandName =
+  | 'status'
+  | 'pause'
+  | 'resume'
+  | 'remind'
+  | 'skip'
+  | 'help'
+  | 'unknown'
+
+const COMMAND_HELP = [
+  '/status — show daemon + pause state',
+  '/pause — pause KAIROS',
+  '/resume — resume KAIROS',
+  '/remind <when> <what> — e.g. `/remind 2m drink water`',
+  '/skip — dismiss the last surfaced message',
+].join('\n')
+
+export type ParsedCommand = {
+  name: CommandName
+  rest: string
+  raw: string
+}
+
+export function parseCommand(text: string): ParsedCommand {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith('/')) {
+    return { name: 'unknown', rest: trimmed, raw: trimmed }
+  }
+  const match = trimmed.match(/^\/([A-Za-z_]+)(?:@\S+)?(?:\s+([\s\S]*))?$/)
+  if (!match) {
+    return { name: 'unknown', rest: '', raw: trimmed }
+  }
+  const head = match[1].toLowerCase()
+  const rest = (match[2] ?? '').trim()
+  switch (head) {
+    case 'status':
+      return { name: 'status', rest, raw: trimmed }
+    case 'pause':
+      return { name: 'pause', rest, raw: trimmed }
+    case 'resume':
+      return { name: 'resume', rest, raw: trimmed }
+    case 'remind':
+      return { name: 'remind', rest, raw: trimmed }
+    case 'skip':
+      return { name: 'skip', rest, raw: trimmed }
+    case 'help':
+    case 'start':
+      return { name: 'help', rest, raw: trimmed }
+    default:
+      return { name: 'unknown', rest, raw: trimmed }
+  }
+}
+
+const DURATION_REGEX = /^(\d+)\s*(s|sec|secs|seconds|m|min|mins|minutes|h|hr|hrs|hours|d|day|days)$/i
+
+/**
+ * Parse the "when" token of /remind. Accepts durations like `2m`, `1h`,
+ * `90s`, `1 day` (relative to `now`) and absolute ISO 8601 timestamps.
+ * Returns null on anything ambiguous — callers surface a clear error so
+ * we don't guess and schedule the wrong minute.
+ */
+export function parseReminderWhen(token: string, now: Date): Date | null {
+  const normalized = token.trim()
+  if (!normalized) return null
+
+  const durationMatch = normalized.match(DURATION_REGEX)
+  if (durationMatch) {
+    const n = Number(durationMatch[1])
+    const unit = durationMatch[2].toLowerCase()
+    let ms = 0
+    if (unit.startsWith('s')) ms = n * 1000
+    else if (unit.startsWith('min') || unit === 'm') ms = n * 60 * 1000
+    else if (unit.startsWith('h')) ms = n * 60 * 60 * 1000
+    else if (unit.startsWith('d')) ms = n * 24 * 60 * 60 * 1000
+    if (ms <= 0) return null
+    return new Date(now.getTime() + ms)
+  }
+
+  // Absolute timestamp path — require something that looks like ISO 8601
+  // to avoid swallowing free-form English (which `new Date()` parses
+  // inconsistently across locales).
+  if (/^\d{4}-\d{2}-\d{2}/.test(normalized)) {
+    const parsed = new Date(normalized)
+    if (!Number.isNaN(parsed.getTime())) return parsed
+  }
+  return null
+}
+
+export type StatusSummary = {
+  daemonState: string
+  pid?: number
+  paused: boolean
+  pauseReason?: string
+  projectCount: number
+}
+
+export type DispatchDeps = {
+  now?: () => Date
+  readStatus: () => Promise<unknown>
+  readPause: () => Promise<unknown>
+  listProjects: () => Promise<string[]>
+  setPause: (paused: boolean) => Promise<void>
+  scheduleReminder: typeof createReminderFromUserRequest
+  recordSkip: (params: { chatId: number; now: Date }) => Promise<void>
+}
+
+export type DispatchInput = {
+  chatId: number
+  text: string
+}
+
+export type DispatchResult = {
+  reply: string
+}
+
+function formatStatus(
+  status: unknown,
+  pause: unknown,
+  projectCount: number,
+): string {
+  const lines: string[] = []
+  const s = status as Record<string, unknown> | null
+  if (s && typeof s.state === 'string') {
+    lines.push(`daemon: ${s.state}${s.pid ? ` (pid ${String(s.pid)})` : ''}`)
+  } else {
+    lines.push('daemon: not running')
+  }
+  const p = pause as Record<string, unknown> | null
+  if (p?.paused === true) {
+    const reason = typeof p.reason === 'string' ? ` [${p.reason}]` : ''
+    lines.push(`paused: yes${reason}`)
+  } else {
+    lines.push('paused: no')
+  }
+  lines.push(`projects: ${projectCount}`)
+  return lines.join('\n')
+}
+
+export function createDispatcher(deps: DispatchDeps) {
+  const now = deps.now ?? (() => new Date())
+
+  async function handleRemind(rest: string): Promise<string> {
+    if (!rest) return 'Usage: /remind <when> <what>  e.g. /remind 2m drink water'
+    const [whenToken, ...remaining] = rest.split(/\s+/)
+    const textRaw = remaining.join(' ').trim()
+    if (!textRaw) {
+      return 'Usage: /remind <when> <what>  e.g. /remind 2m drink water'
+    }
+    const at = parseReminderWhen(whenToken, now())
+    if (!at) {
+      return `Can't schedule reminder: couldn't parse "${whenToken}". Try \`2m\`, \`1h\`, or an ISO timestamp.`
+    }
+    const projects = await deps.listProjects()
+    if (projects.length === 0) {
+      return "Can't schedule reminder: no KAIROS projects opted in. Run `/kairos opt-in` first."
+    }
+    const projectDir = projects[0]
+    const result: CreateReminderResult = await deps.scheduleReminder(
+      { projectDir, text: textRaw, at },
+      { now: now() },
+    )
+    return result.message
+  }
+
+  async function dispatch(input: DispatchInput): Promise<DispatchResult> {
+    const parsed = parseCommand(input.text)
+    switch (parsed.name) {
+      case 'status': {
+        const [status, pause, projects] = await Promise.all([
+          deps.readStatus(),
+          deps.readPause(),
+          deps.listProjects(),
+        ])
+        return { reply: formatStatus(status, pause, projects.length) }
+      }
+      case 'pause':
+        await deps.setPause(true)
+        return { reply: 'Paused KAIROS. Fired tasks skipped until /resume.' }
+      case 'resume':
+        await deps.setPause(false)
+        return { reply: 'Resumed KAIROS.' }
+      case 'remind':
+        return { reply: await handleRemind(parsed.rest) }
+      case 'skip':
+        await deps.recordSkip({ chatId: input.chatId, now: now() })
+        return { reply: 'Noted. Last surfaced message dismissed.' }
+      case 'help':
+        return { reply: `KAIROS commands:\n${COMMAND_HELP}` }
+      case 'unknown':
+        return {
+          reply: `Unknown command. Try /help.\n\n${COMMAND_HELP}`,
+        }
+    }
+  }
+
+  return { dispatch }
+}
+
+export function getKairosPausePathExport(): string {
+  return getKairosPausePath()
+}
+
+export function getKairosStatusPathExport(): string {
+  return getKairosStatusPath()
+}

--- a/src 2/daemon/gateway/telegram/config.test.ts
+++ b/src 2/daemon/gateway/telegram/config.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, statSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { readTelegramConfig, writeTelegramConfig } from './config.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tg-config-'))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+describe('telegram config', () => {
+  test('read returns null when the file does not exist', async () => {
+    const dir = makeTempDir()
+    const path = join(dir, 'telegram.json')
+    expect(await readTelegramConfig(path)).toBeNull()
+  })
+
+  test('write + read round-trips token and pairedChatIds', async () => {
+    const dir = makeTempDir()
+    const path = join(dir, 'telegram.json')
+    await writeTelegramConfig(
+      { token: 'abc', botUsername: 'bot', pairedChatIds: [1, 2] },
+      path,
+    )
+
+    const read = await readTelegramConfig(path)
+    expect(read).toEqual({ token: 'abc', botUsername: 'bot', pairedChatIds: [1, 2] })
+  })
+
+  test('write sets mode 0600', async () => {
+    const dir = makeTempDir()
+    const path = join(dir, 'telegram.json')
+    await writeTelegramConfig({ token: 't', pairedChatIds: [] }, path)
+
+    const mode = statSync(path).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  test('read drops garbage / non-integer chat ids instead of throwing', async () => {
+    const dir = makeTempDir()
+    const path = join(dir, 'telegram.json')
+    await writeTelegramConfig(
+      { token: 't', pairedChatIds: [1, 2] },
+      path,
+    )
+    // Now overwrite with hand-crafted JSON that includes bad ids
+    const { writeFile } = await import('fs/promises')
+    await writeFile(
+      path,
+      JSON.stringify({ token: 't', pairedChatIds: [1, 'bad', -2, 3.5, 4] }),
+    )
+
+    const read = await readTelegramConfig(path)
+    expect(read).toEqual({ token: 't', pairedChatIds: [1, 4] })
+  })
+
+  test('read returns null for missing token (invalid config)', async () => {
+    const dir = makeTempDir()
+    const path = join(dir, 'telegram.json')
+    const { writeFile } = await import('fs/promises')
+    await writeFile(path, JSON.stringify({ pairedChatIds: [1] }))
+
+    expect(await readTelegramConfig(path)).toBeNull()
+  })
+})

--- a/src 2/daemon/gateway/telegram/config.ts
+++ b/src 2/daemon/gateway/telegram/config.ts
@@ -1,0 +1,68 @@
+// Read/write ~/.claude/kairos/telegram.json.
+//
+// Stores the bot token and the allowlist of paired chat IDs. The file is
+// written with mode 0600 so a shared machine doesn't leak the token. We
+// read the file on every check because the CLI can mutate it while the
+// daemon is running (pair / unpair) and the in-memory cost of a stat +
+// readFile per message is negligible.
+
+import { chmod, mkdir, readFile, rename, writeFile } from 'fs/promises'
+import { dirname } from 'path'
+import { getTelegramConfigPath } from './paths.js'
+
+export type TelegramConfig = {
+  token: string
+  botUsername?: string
+  pairedChatIds: number[]
+}
+
+const MODE_0600 = 0o600
+
+function isPositiveInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+function normalizeConfig(raw: unknown): TelegramConfig | null {
+  if (!raw || typeof raw !== 'object') return null
+  const record = raw as Record<string, unknown>
+  const token = record.token
+  if (typeof token !== 'string' || token.trim().length === 0) return null
+  const chatIdsRaw = Array.isArray(record.pairedChatIds) ? record.pairedChatIds : []
+  const pairedChatIds = chatIdsRaw.filter(isPositiveInt)
+  const botUsername =
+    typeof record.botUsername === 'string' && record.botUsername.length > 0
+      ? record.botUsername
+      : undefined
+  return { token, botUsername, pairedChatIds }
+}
+
+export async function readTelegramConfig(
+  path = getTelegramConfigPath(),
+): Promise<TelegramConfig | null> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    return normalizeConfig(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Atomically write the config with mode 0600. We `rename` over the final
+ * path so a concurrent reader never sees a half-written file, and `chmod`
+ * the temp file before rename so the permission bits are correct the
+ * instant the real file appears.
+ */
+export async function writeTelegramConfig(
+  config: TelegramConfig,
+  path = getTelegramConfigPath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tempPath = `${path}.tmp`
+  await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: MODE_0600,
+  })
+  await chmod(tempPath, MODE_0600)
+  await rename(tempPath, path)
+}

--- a/src 2/daemon/gateway/telegram/eventTail.test.ts
+++ b/src 2/daemon/gateway/telegram/eventTail.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createEventTail, formatEventForTelegram } from './eventTail.js'
+import type { OutboundQueue } from './outbound.js'
+import type { SendMessageParams, TelegramMessage } from './transport.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempPath(filename: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tg-tail-'))
+  TEMP_DIRS.push(dir)
+  mkdirSync(dir, { recursive: true })
+  return join(dir, filename)
+}
+
+function stubQueue(): { queue: OutboundQueue; sent: SendMessageParams[] } {
+  const sent: SendMessageParams[] = []
+  const queue: OutboundQueue = {
+    send: async params => {
+      sent.push(params)
+      return [] as TelegramMessage[]
+    },
+    drain: async () => {},
+  }
+  return { queue, sent }
+}
+
+async function wait(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms))
+}
+
+describe('formatEventForTelegram', () => {
+  test('tier3_surface formats with emoji prefix', () => {
+    const out = formatEventForTelegram({
+      kind: 'tier3_surface',
+      message: 'Take a break',
+    })
+    expect(out).toContain('Take a break')
+  })
+
+  test('cap_hit_notice shows cap and current', () => {
+    const out = formatEventForTelegram({
+      kind: 'cap_hit_notice',
+      scope: 'global',
+      cap: 10,
+      current: 11.25,
+    })
+    expect(out).toContain('$11.25')
+    expect(out).toContain('$10.00')
+  })
+
+  test('fired shows the task id', () => {
+    expect(formatEventForTelegram({ kind: 'fired', taskId: 'abc' })).toContain('abc')
+  })
+
+  test('unrecognized kinds return null', () => {
+    expect(formatEventForTelegram({ kind: 'project_registered' })).toBeNull()
+  })
+})
+
+describe('createEventTail', () => {
+  test('forwards newly appended tier3_surface events to every paired chat', async () => {
+    const path = makeTempPath('events.jsonl')
+    writeFileSync(path, '')
+
+    const { queue, sent } = stubQueue()
+    const tail = createEventTail({
+      path,
+      outboundChatIds: async () => [111, 222],
+      outbound: queue,
+      startAtOffset: 0,
+    })
+    await tail.start()
+
+    appendFileSync(
+      path,
+      `${JSON.stringify({ kind: 'tier3_surface', message: 'Drink water', t: '2026-04-22T12:00:00.000Z' })}\n`,
+    )
+
+    await tail.tick()
+    await tail.stop()
+
+    expect(sent.length).toBe(2)
+    expect(sent[0].text).toContain('Drink water')
+    expect(sent.map(s => s.chat_id).sort()).toEqual([111, 222])
+  })
+
+  test('skips events with unrecognized kinds', async () => {
+    const path = makeTempPath('events.jsonl')
+    writeFileSync(path, '')
+
+    const { queue, sent } = stubQueue()
+    const tail = createEventTail({
+      path,
+      outboundChatIds: async () => [111],
+      outbound: queue,
+      startAtOffset: 0,
+    })
+    await tail.start()
+
+    appendFileSync(
+      path,
+      `${JSON.stringify({ kind: 'project_registered', t: 't', projectDir: '/x' })}\n`,
+    )
+    await tail.tick()
+    await tail.stop()
+
+    expect(sent.length).toBe(0)
+  })
+
+  test('ignores history written before start when startAtOffset is omitted', async () => {
+    const path = makeTempPath('events.jsonl')
+    writeFileSync(
+      path,
+      `${JSON.stringify({ kind: 'tier3_surface', message: 'old' })}\n`,
+    )
+
+    const { queue, sent } = stubQueue()
+    const tail = createEventTail({
+      path,
+      outboundChatIds: async () => [111],
+      outbound: queue,
+    })
+    await tail.start()
+    await tail.tick()
+    await tail.stop()
+
+    expect(sent.length).toBe(0)
+  })
+
+  test('handles truncation (file size shrinks)', async () => {
+    const path = makeTempPath('events.jsonl')
+    writeFileSync(path, '')
+
+    const { queue, sent } = stubQueue()
+    const tail = createEventTail({
+      path,
+      outboundChatIds: async () => [111],
+      outbound: queue,
+      startAtOffset: 0,
+    })
+    await tail.start()
+
+    // Write, read, truncate (simulating log rotation), then write again.
+    appendFileSync(
+      path,
+      `${JSON.stringify({ kind: 'tier3_surface', message: 'a long first message to ensure truncation is smaller' })}\n`,
+    )
+    await tail.tick()
+    expect(sent.length).toBe(1)
+
+    writeFileSync(path, `${JSON.stringify({ kind: 'tier3_surface', message: 'after' })}\n`)
+    await tail.tick()
+    await tail.stop()
+
+    expect(sent.length).toBe(2)
+    expect(sent[1].text).toContain('after')
+  })
+})

--- a/src 2/daemon/gateway/telegram/eventTail.ts
+++ b/src 2/daemon/gateway/telegram/eventTail.ts
@@ -1,0 +1,187 @@
+// Tail ~/.claude/kairos/events.jsonl and forward interesting events to
+// Telegram.
+//
+// The issue specifies "a Tier 3 surfaced message should land in Telegram
+// without additional code in tier3.ts" — so rather than plumbing callbacks
+// through the worker, we tail the global event log. This keeps tier3.ts /
+// capHit / reminder-firing completely unaware of Telegram.
+//
+// We start tailing from the current end-of-file. Replaying the whole
+// history on gateway start would flood the user with stale surfaces after
+// every daemon restart.
+//
+// Implementation: simple poll loop. `fs.watch` is unreliable on macOS
+// (FSEvents coalesces / sometimes drops appends) so we read-from-offset
+// on a timer. The extra IO is negligible — the file appends once per
+// fire / surface.
+
+import { open, stat } from 'fs/promises'
+import type { OutboundQueue } from './outbound.js'
+
+const TAIL_BUFFER_LIMIT = 64 * 1024
+const DEFAULT_POLL_MS = 500
+
+export type EventKind =
+  | 'tier3_surface'
+  | 'cap_hit_notice'
+  | 'fired'
+  | 'finished'
+  | (string & {})
+
+export type TailableEvent = {
+  kind: EventKind
+  t?: string
+  message?: string
+  scope?: string
+  cap?: number
+  current?: number
+  projectDir?: string
+  taskId?: string
+  cron?: string
+}
+
+export function formatEventForTelegram(event: TailableEvent): string | null {
+  switch (event.kind) {
+    case 'tier3_surface':
+      if (!event.message) return null
+      return `💡 KAIROS: ${event.message}`
+    case 'cap_hit_notice': {
+      const scope = event.scope ?? 'global'
+      const cap = event.cap !== undefined ? `$${event.cap.toFixed(2)}` : '?'
+      const current =
+        event.current !== undefined ? `$${event.current.toFixed(2)}` : '?'
+      return `🛑 KAIROS cap hit (${scope}): ${current} / ${cap}. Daemon paused.`
+    }
+    case 'fired': {
+      const task = event.taskId ?? 'unknown'
+      return `⏰ KAIROS reminder fired: ${task}`
+    }
+    default:
+      return null
+  }
+}
+
+export type EventTailDeps = {
+  path: string
+  outboundChatIds: () => Promise<number[]>
+  outbound: OutboundQueue
+  pollMs?: number
+  onError?: (err: Error) => void
+  /** Override start offset — tests use 0 so they don't have to pre-seed. */
+  startAtOffset?: number
+}
+
+export type EventTail = {
+  start(): Promise<void>
+  stop(): Promise<void>
+  /** Force a read cycle. Tests use this to deterministically drain pending appends. */
+  tick(): Promise<void>
+}
+
+export function createEventTail(deps: EventTailDeps): EventTail {
+  let offset = deps.startAtOffset ?? 0
+  let partial = ''
+  let stopped = false
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let running: Promise<void> | null = null
+
+  async function setInitialOffset(): Promise<void> {
+    if (deps.startAtOffset !== undefined) return
+    try {
+      const s = await stat(deps.path)
+      offset = s.size
+    } catch {
+      offset = 0
+    }
+  }
+
+  async function readPass(): Promise<void> {
+    let handle
+    try {
+      handle = await open(deps.path, 'r')
+    } catch {
+      return
+    }
+    try {
+      while (true) {
+        const stats = await handle.stat()
+        if (stats.size < offset) {
+          offset = 0
+          partial = ''
+        }
+        if (stats.size === offset) return
+        const length = Math.min(stats.size - offset, TAIL_BUFFER_LIMIT)
+        const buf = Buffer.alloc(length)
+        await handle.read(buf, 0, length, offset)
+        offset += length
+        partial += buf.toString('utf8')
+
+        const lines = partial.split('\n')
+        partial = lines.pop() ?? ''
+
+        for (const line of lines) {
+          if (!line.trim()) continue
+          let event: TailableEvent | null = null
+          try {
+            event = JSON.parse(line) as TailableEvent
+          } catch (error) {
+            deps.onError?.(error as Error)
+            continue
+          }
+          const formatted = event ? formatEventForTelegram(event) : null
+          if (!formatted) continue
+          const chatIds = await deps.outboundChatIds()
+          for (const chatId of chatIds) {
+            try {
+              await deps.outbound.send({ chat_id: chatId, text: formatted })
+            } catch (error) {
+              deps.onError?.(error as Error)
+            }
+          }
+        }
+      }
+    } finally {
+      await handle.close()
+    }
+  }
+
+  async function tick(): Promise<void> {
+    if (running) {
+      await running
+      return
+    }
+    running = readPass().catch(err => {
+      deps.onError?.(err as Error)
+    })
+    try {
+      await running
+    } finally {
+      running = null
+    }
+  }
+
+  function scheduleNext(): void {
+    if (stopped) return
+    timer = setTimeout(async () => {
+      timer = null
+      await tick()
+      scheduleNext()
+    }, deps.pollMs ?? DEFAULT_POLL_MS)
+    timer.unref?.()
+  }
+
+  return {
+    async start() {
+      await setInitialOffset()
+      await tick()
+      scheduleNext()
+    },
+    async stop() {
+      stopped = true
+      if (timer) clearTimeout(timer)
+      timer = null
+      if (running) await running
+    },
+    tick,
+  }
+}

--- a/src 2/daemon/gateway/telegram/gateway.test.ts
+++ b/src 2/daemon/gateway/telegram/gateway.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { writeTelegramConfig } from './config.js'
+import { createGateway } from './gateway.js'
+import type { OutboundQueue } from './outbound.js'
+import {
+  TelegramTransportError,
+  type SendMessageParams,
+  type TelegramMessage,
+  type TelegramTransport,
+  type TelegramUpdate,
+} from './transport.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makePaths() {
+  const dir = mkdtempSync(join(tmpdir(), 'tg-gw-'))
+  TEMP_DIRS.push(dir)
+  const eventPath = join(dir, 'events.jsonl')
+  writeFileSync(eventPath, '')
+  return {
+    configPath: join(dir, 'telegram.json'),
+    pendingPath: join(dir, 'telegram.pending.json'),
+    eventPath,
+  }
+}
+
+type ProgrammedUpdate = TelegramUpdate | { throw: Error }
+
+function stubTransport(
+  queue: ProgrammedUpdate[][],
+  abortSignal?: AbortSignal,
+): {
+  transport: TelegramTransport
+  sends: SendMessageParams[]
+} {
+  const sends: SendMessageParams[] = []
+  let idx = 0
+  const transport: TelegramTransport = {
+    getMe: async () => ({ id: 1, is_bot: true, first_name: 'bot' }),
+    getUpdates: async () => {
+      const batch = queue[idx]
+      idx += 1
+      if (!batch) {
+        // Park until aborted so the loop can be stopped deterministically.
+        await new Promise<void>((_, reject) => {
+          if (abortSignal?.aborted) reject(new Error('aborted'))
+          abortSignal?.addEventListener('abort', () => reject(new Error('aborted')), {
+            once: true,
+          })
+        })
+        return []
+      }
+      const first = batch[0]
+      if (first && 'throw' in first) {
+        throw first.throw
+      }
+      return batch as TelegramUpdate[]
+    },
+    sendMessage: async params => {
+      sends.push(params)
+      return {
+        message_id: sends.length,
+        date: Math.floor(Date.now() / 1000),
+        chat: { id: params.chat_id, type: 'private' },
+        text: params.text,
+      } satisfies TelegramMessage
+    },
+  }
+  return { transport, sends }
+}
+
+function stubOutbound(transport: TelegramTransport): OutboundQueue {
+  return {
+    send: async params => {
+      const m = await transport.sendMessage(params)
+      return [m]
+    },
+    drain: async () => {},
+  }
+}
+
+function makeUpdate(
+  update_id: number,
+  chatId: number,
+  text: string,
+): TelegramUpdate {
+  return {
+    update_id,
+    message: {
+      message_id: update_id,
+      date: Math.floor(Date.now() / 1000),
+      chat: { id: chatId, type: 'private' },
+      text,
+    },
+  }
+}
+
+describe('createGateway', () => {
+  test('paired chat gets a dispatched reply', async () => {
+    const { configPath, pendingPath, eventPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [500] }, configPath)
+
+    const controller = new AbortController()
+    const { transport, sends } = stubTransport(
+      [[makeUpdate(1, 500, '/status')]],
+      controller.signal,
+    )
+    const outbound = stubOutbound(transport)
+
+    const gateway = createGateway({
+      token: 't',
+      configPath,
+      pendingPath,
+      eventPath,
+      dispatch: async () => ({ reply: 'daemon: idle' }),
+      transport,
+      outbound,
+      sleep: async () => {},
+      signal: controller.signal,
+    })
+    await gateway.start()
+    await new Promise(r => setTimeout(r, 50))
+    controller.abort()
+    await gateway.stop()
+
+    expect(sends.length).toBe(1)
+    expect(sends[0]).toEqual({ chat_id: 500, text: 'daemon: idle' })
+  })
+
+  test('unpaired chat gets a single rejection reply; subsequent messages are silent', async () => {
+    const { configPath, pendingPath, eventPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [] }, configPath)
+
+    const controller = new AbortController()
+    const { transport, sends } = stubTransport(
+      [[makeUpdate(1, 777, 'hi'), makeUpdate(2, 777, 'anyone home?')]],
+      controller.signal,
+    )
+    const outbound = stubOutbound(transport)
+
+    const gateway = createGateway({
+      token: 't',
+      configPath,
+      pendingPath,
+      eventPath,
+      dispatch: async () => ({ reply: 'n/a' }),
+      transport,
+      outbound,
+      sleep: async () => {},
+      signal: controller.signal,
+    })
+    await gateway.start()
+    await new Promise(r => setTimeout(r, 50))
+    controller.abort()
+    await gateway.stop()
+
+    expect(sends.length).toBe(1)
+    expect(sends[0].text.toLowerCase()).toContain('not yours')
+  })
+
+  test('group chats are silently ignored', async () => {
+    const { configPath, pendingPath, eventPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [123] }, configPath)
+
+    const controller = new AbortController()
+    const { transport, sends } = stubTransport(
+      [
+        [
+          {
+            update_id: 1,
+            message: {
+              message_id: 1,
+              date: 0,
+              chat: { id: 123, type: 'group' },
+              text: '/status',
+            },
+          },
+        ],
+      ],
+      controller.signal,
+    )
+    const outbound = stubOutbound(transport)
+
+    const gateway = createGateway({
+      token: 't',
+      configPath,
+      pendingPath,
+      eventPath,
+      dispatch: async () => ({ reply: 'daemon: idle' }),
+      transport,
+      outbound,
+      sleep: async () => {},
+      signal: controller.signal,
+    })
+    await gateway.start()
+    await new Promise(r => setTimeout(r, 50))
+    controller.abort()
+    await gateway.stop()
+
+    expect(sends.length).toBe(0)
+  })
+
+  test('network error triggers exponential backoff but the loop continues', async () => {
+    const { configPath, pendingPath, eventPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [888] }, configPath)
+
+    const controller = new AbortController()
+    const { transport, sends } = stubTransport(
+      [
+        [{ throw: new TelegramTransportError('boom') }],
+        [makeUpdate(10, 888, '/status')],
+      ],
+      controller.signal,
+    )
+    const outbound = stubOutbound(transport)
+    const sleeps: number[] = []
+
+    const gateway = createGateway({
+      token: 't',
+      configPath,
+      pendingPath,
+      eventPath,
+      dispatch: async () => ({ reply: 'ok' }),
+      transport,
+      outbound,
+      sleep: async ms => {
+        sleeps.push(ms)
+      },
+      signal: controller.signal,
+    })
+    await gateway.start()
+    await new Promise(r => setTimeout(r, 50))
+    controller.abort()
+    await gateway.stop()
+
+    expect(sleeps.length).toBeGreaterThan(0)
+    expect(sends.some(s => s.chat_id === 888)).toBe(true)
+  })
+
+  test('update_id advances so the same update is never replayed', async () => {
+    const { configPath, pendingPath, eventPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [1] }, configPath)
+
+    const controller = new AbortController()
+    const offsets: (number | undefined)[] = []
+    const transport: TelegramTransport = {
+      getMe: async () => ({ id: 1, is_bot: true, first_name: 'bot' }),
+      getUpdates: async params => {
+        offsets.push(params.offset)
+        if (offsets.length === 1) {
+          return [makeUpdate(50, 1, '/status')]
+        }
+        await new Promise<void>((_, reject) => {
+          if (controller.signal.aborted) reject(new Error('aborted'))
+          controller.signal.addEventListener(
+            'abort',
+            () => reject(new Error('aborted')),
+            { once: true },
+          )
+        })
+        return []
+      },
+      sendMessage: async () =>
+        ({
+          message_id: 1,
+          date: 0,
+          chat: { id: 1, type: 'private' },
+        }) as TelegramMessage,
+    }
+    const outbound = stubOutbound(transport)
+
+    const gateway = createGateway({
+      token: 't',
+      configPath,
+      pendingPath,
+      eventPath,
+      dispatch: async () => ({ reply: 'ok' }),
+      transport,
+      outbound,
+      sleep: async () => {},
+      signal: controller.signal,
+    })
+    await gateway.start()
+    await new Promise(r => setTimeout(r, 50))
+    controller.abort()
+    await gateway.stop()
+
+    expect(offsets[0]).toBe(0)
+    expect(offsets[1]).toBe(51)
+  })
+})

--- a/src 2/daemon/gateway/telegram/gateway.ts
+++ b/src 2/daemon/gateway/telegram/gateway.ts
@@ -1,0 +1,146 @@
+// Top-level Telegram gateway controller.
+//
+// Responsibilities:
+//
+//   * Long-poll getUpdates with an ever-advancing offset so Telegram never
+//     replays the same update twice.
+//   * Reconnect with exponential backoff on network / Bot API errors.
+//   * For each inbound update, hand off to handleInboundMessage to decide
+//     ignore / reply / pair.
+//   * Tail ~/.claude/kairos/events.jsonl and forward surfaces / cap-hits
+//     / reminder firings to every paired chat.
+//
+// The controller is stoppable via AbortSignal so the worker's shutdown
+// path can cancel an in-flight long-poll instantly.
+
+import { readTelegramConfig } from './config.js'
+import { createEventTail, type EventTail } from './eventTail.js'
+import { handleInboundMessage } from './inbound.js'
+import { createOutboundQueue, type OutboundQueue } from './outbound.js'
+import { createTelegramTransport, type TelegramTransport } from './transport.js'
+import type { DispatchInput, DispatchResult } from './commands.js'
+
+const LONG_POLL_TIMEOUT_S = 30
+const BACKOFF_INITIAL_MS = 1_000
+const BACKOFF_MAX_MS = 60_000
+
+export type GatewayDeps = {
+  token: string
+  configPath?: string
+  pendingPath?: string
+  eventPath: string
+  dispatch: (input: DispatchInput) => Promise<DispatchResult>
+  /** Injected so tests can stub; defaults to the real fetch-based transport. */
+  transport?: TelegramTransport
+  outbound?: OutboundQueue
+  tail?: EventTail
+  pollIntervalMs?: number
+  signal?: AbortSignal
+  log?: (msg: string) => void
+  now?: () => Date
+  sleep?: (ms: number) => Promise<void>
+}
+
+export type Gateway = {
+  start(): Promise<void>
+  stop(): Promise<void>
+}
+
+const DEFAULT_SLEEP = (ms: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(resolve, ms)
+  })
+
+export function createGateway(deps: GatewayDeps): Gateway {
+  const log = deps.log ?? (() => {})
+  const sleep = deps.sleep ?? DEFAULT_SLEEP
+  // Internal controller abort is how stop() cancels an in-flight long-poll.
+  // If the caller supplied a signal, chain it so either triggers shutdown.
+  const internalController = new AbortController()
+  if (deps.signal) {
+    if (deps.signal.aborted) internalController.abort()
+    else deps.signal.addEventListener('abort', () => internalController.abort(), { once: true })
+  }
+  const signal = internalController.signal
+  const transport =
+    deps.transport ?? createTelegramTransport(deps.token, { signal })
+  const outbound = deps.outbound ?? createOutboundQueue({ transport })
+  const rejectedChatIds = new Set<number>()
+
+  const tail =
+    deps.tail ??
+    createEventTail({
+      path: deps.eventPath,
+      outboundChatIds: async () => {
+        const config = await readTelegramConfig(deps.configPath)
+        return config?.pairedChatIds ?? []
+      },
+      outbound,
+      onError: err => log(`event tail error: ${err.message}`),
+    })
+
+  let stopped = false
+  let offset = 0
+  let loopPromise: Promise<void> | null = null
+
+  async function pollOnce(): Promise<void> {
+    const updates = await transport.getUpdates({
+      offset,
+      timeout: LONG_POLL_TIMEOUT_S,
+      allowed_updates: ['message'],
+    })
+    for (const update of updates) {
+      offset = update.update_id + 1
+      const message = update.message ?? update.edited_message
+      if (!message) continue
+      const action = await handleInboundMessage(message, {
+        dispatch: deps.dispatch,
+        rejectedChatIds,
+        configPath: deps.configPath,
+        pendingPath: deps.pendingPath,
+        now: deps.now,
+      })
+      if (action.kind === 'reply' || action.kind === 'paired') {
+        try {
+          await outbound.send({ chat_id: action.chatId, text: action.text })
+        } catch (err) {
+          log(`outbound send failed: ${(err as Error).message}`)
+        }
+      }
+    }
+  }
+
+  async function runLoop(): Promise<void> {
+    let backoff = BACKOFF_INITIAL_MS
+    while (!stopped && !signal?.aborted) {
+      try {
+        await pollOnce()
+        backoff = BACKOFF_INITIAL_MS
+      } catch (err) {
+        if (stopped || signal?.aborted) return
+        log(`getUpdates failed (${(err as Error).message}); sleeping ${backoff}ms`)
+        await sleep(backoff)
+        backoff = Math.min(backoff * 2, BACKOFF_MAX_MS)
+      }
+    }
+  }
+
+  return {
+    async start() {
+      await tail.start()
+      try {
+        const me = await transport.getMe()
+        log(`gateway online as @${me.username ?? me.first_name} (id=${me.id})`)
+      } catch (err) {
+        log(`gateway getMe failed: ${(err as Error).message}`)
+      }
+      loopPromise = runLoop()
+    },
+    async stop() {
+      stopped = true
+      internalController.abort()
+      await tail.stop()
+      if (loopPromise) await loopPromise.catch(() => {})
+    },
+  }
+}

--- a/src 2/daemon/gateway/telegram/inbound.test.ts
+++ b/src 2/daemon/gateway/telegram/inbound.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { writeTelegramConfig } from './config.js'
+import { handleInboundMessage } from './inbound.js'
+import { writePendingPair } from './pairing.js'
+import type { TelegramMessage } from './transport.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makePaths(): { configPath: string; pendingPath: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'tg-inbound-'))
+  TEMP_DIRS.push(dir)
+  return {
+    configPath: join(dir, 'telegram.json'),
+    pendingPath: join(dir, 'telegram.pending.json'),
+  }
+}
+
+function msg(partial: Partial<TelegramMessage> & { chatId?: number; text?: string; type?: 'private' | 'group' }): TelegramMessage {
+  return {
+    message_id: 1,
+    date: Math.floor(Date.now() / 1000),
+    chat: { id: partial.chatId ?? 100, type: partial.type ?? 'private' },
+    text: partial.text,
+    ...partial,
+  } as TelegramMessage
+}
+
+describe('handleInboundMessage', () => {
+  test('ignores group chats', async () => {
+    const { configPath, pendingPath } = makePaths()
+    const result = await handleInboundMessage(msg({ type: 'group', text: '/status' }), {
+      dispatch: async () => ({ reply: 'nope' }),
+      rejectedChatIds: new Set(),
+      configPath,
+      pendingPath,
+    })
+    expect(result).toEqual({ kind: 'ignore', reason: 'non_private_chat' })
+  })
+
+  test('ignores empty/non-text messages', async () => {
+    const { configPath, pendingPath } = makePaths()
+    const result = await handleInboundMessage(msg({ text: '' }), {
+      dispatch: async () => ({ reply: 'nope' }),
+      rejectedChatIds: new Set(),
+      configPath,
+      pendingPath,
+    })
+    expect(result.kind).toBe('ignore')
+  })
+
+  test('paired chat dispatches the command and replies', async () => {
+    const { configPath, pendingPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [100] }, configPath)
+
+    const result = await handleInboundMessage(msg({ text: '/status' }), {
+      dispatch: async () => ({ reply: 'daemon: idle' }),
+      rejectedChatIds: new Set(),
+      configPath,
+      pendingPath,
+    })
+
+    expect(result).toEqual({ kind: 'reply', chatId: 100, text: 'daemon: idle' })
+  })
+
+  test('unpaired chat sending the correct code is paired', async () => {
+    const { configPath, pendingPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [] }, configPath)
+    await writePendingPair(
+      { code: '424242', createdAt: new Date().toISOString() },
+      pendingPath,
+    )
+
+    const result = await handleInboundMessage(msg({ chatId: 100, text: '424242' }), {
+      dispatch: async () => ({ reply: 'should not be called' }),
+      rejectedChatIds: new Set(),
+      configPath,
+      pendingPath,
+    })
+
+    expect(result.kind).toBe('paired')
+  })
+
+  test('unpaired chat with wrong/no code gets a single rejection reply', async () => {
+    const { configPath, pendingPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [] }, configPath)
+
+    const rejected = new Set<number>()
+
+    const first = await handleInboundMessage(msg({ chatId: 100, text: 'hi' }), {
+      dispatch: async () => ({ reply: 'nope' }),
+      rejectedChatIds: rejected,
+      configPath,
+      pendingPath,
+    })
+    expect(first.kind).toBe('reply')
+    if (first.kind === 'reply') {
+      expect(first.text.toLowerCase()).toContain("not yours")
+    }
+    expect(rejected.has(100)).toBe(true)
+
+    const second = await handleInboundMessage(msg({ chatId: 100, text: 'hello' }), {
+      dispatch: async () => ({ reply: 'nope' }),
+      rejectedChatIds: rejected,
+      configPath,
+      pendingPath,
+    })
+    expect(second).toEqual({ kind: 'ignore', reason: 'already_rejected' })
+  })
+})

--- a/src 2/daemon/gateway/telegram/inbound.ts
+++ b/src 2/daemon/gateway/telegram/inbound.ts
@@ -1,0 +1,84 @@
+// Inbound message handler used by both the long-poll loop and its tests.
+//
+// Given one Telegram update, this function decides what to do:
+//
+//   * group chat → silently ignore (DM-only policy)
+//   * no text → ignore
+//   * paired chat → dispatch command, reply with result
+//   * unpaired chat → if a pending pair code matches, pair and reply
+//                     "paired"; otherwise reply "this bot isn't yours"
+//                     exactly once per chat ID, then go silent.
+
+import { isChatPaired } from './allowlist.js'
+import type { DispatchInput, DispatchResult } from './commands.js'
+import { tryPair } from './pairing.js'
+import type { TelegramMessage } from './transport.js'
+
+export type InboundContext = {
+  /** Paired-chat dispatcher (returns a reply). */
+  dispatch: (input: DispatchInput) => Promise<DispatchResult>
+  /** Chat IDs we've already sent the "bot isn't yours" reply to this run. */
+  rejectedChatIds: Set<number>
+  /** Paths are injected so tests can use tmp dirs. */
+  pendingPath?: string
+  configPath?: string
+  now?: () => Date
+}
+
+export type InboundAction =
+  | { kind: 'ignore'; reason: string }
+  | { kind: 'reply'; chatId: number; text: string }
+  | { kind: 'paired'; chatId: number; text: string }
+
+export async function handleInboundMessage(
+  message: TelegramMessage,
+  ctx: InboundContext,
+): Promise<InboundAction> {
+  if (message.chat.type !== 'private') {
+    return { kind: 'ignore', reason: 'non_private_chat' }
+  }
+  const text = message.text?.trim()
+  if (!text) {
+    return { kind: 'ignore', reason: 'no_text' }
+  }
+
+  const chatId = message.chat.id
+  const paired = await isChatPaired(chatId, ctx.configPath)
+
+  if (paired) {
+    const { reply } = await ctx.dispatch({ chatId, text })
+    return { kind: 'reply', chatId, text: reply }
+  }
+
+  // Unpaired path — try to pair first.
+  const pair = await tryPair({
+    chatId,
+    candidateCode: text,
+    now: ctx.now ? ctx.now() : undefined,
+    pendingPath: ctx.pendingPath,
+    configPath: ctx.configPath,
+  })
+
+  if (pair.outcome === 'paired') {
+    return {
+      kind: 'paired',
+      chatId,
+      text: 'Paired. You can now send /status, /pause, /resume, /remind, /skip.',
+    }
+  }
+
+  // Deliberately quiet for mismatch + expired so a stranger guessing the
+  // code doesn't get feedback on each try. The single allowed "bot isn't
+  // yours" reply lives behind the rejected set.
+  if (ctx.rejectedChatIds.has(chatId)) {
+    return { kind: 'ignore', reason: 'already_rejected' }
+  }
+  ctx.rejectedChatIds.add(chatId)
+  return {
+    kind: 'reply',
+    chatId,
+    text:
+      "This KAIROS bot is paired to another user's laptop — it's not yours to command. " +
+      'Ignoring future messages.',
+  }
+}

--- a/src 2/daemon/gateway/telegram/outbound.test.ts
+++ b/src 2/daemon/gateway/telegram/outbound.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  OUTBOUND_MAX_CHARS,
+  chunkMessage,
+  createOutboundQueue,
+} from './outbound.js'
+import type {
+  SendMessageParams,
+  TelegramMessage,
+  TelegramTransport,
+} from './transport.js'
+
+function stubTransport(
+  calls: SendMessageParams[] = [],
+  delayMs = 0,
+): { transport: TelegramTransport; calls: SendMessageParams[] } {
+  const transport: TelegramTransport = {
+    getMe: async () => ({ id: 1, is_bot: true, first_name: 'bot' }),
+    getUpdates: async () => [],
+    sendMessage: async params => {
+      calls.push(params)
+      if (delayMs > 0) {
+        await new Promise(r => setTimeout(r, delayMs))
+      }
+      return {
+        message_id: calls.length,
+        date: Math.floor(Date.now() / 1000),
+        chat: { id: params.chat_id, type: 'private' },
+        text: params.text,
+      } satisfies TelegramMessage
+    },
+  }
+  return { transport, calls }
+}
+
+describe('chunkMessage', () => {
+  test('returns a single element when the text fits', () => {
+    expect(chunkMessage('hello')).toEqual(['hello'])
+  })
+
+  test('splits on paragraph boundary when possible', () => {
+    const big = `${'a'.repeat(3000)}\n\n${'b'.repeat(3000)}`
+    const chunks = chunkMessage(big)
+
+    expect(chunks.length).toBe(2)
+    expect(chunks[0]).toBe(`${'a'.repeat(3000)}\n\n`)
+    expect(chunks[1]).toBe('b'.repeat(3000))
+    expect(chunks[0].length).toBeLessThanOrEqual(OUTBOUND_MAX_CHARS)
+  })
+
+  test('splits on line boundary when no paragraph break fits', () => {
+    const lineA = 'a'.repeat(3000)
+    const lineB = 'b'.repeat(3000)
+    const big = `${lineA}\n${lineB}`
+    const chunks = chunkMessage(big)
+
+    expect(chunks.length).toBe(2)
+    expect(chunks[0]).toBe(`${lineA}\n`)
+    expect(chunks[1]).toBe(lineB)
+  })
+
+  test('hard-cuts when no boundary is available', () => {
+    const big = 'x'.repeat(OUTBOUND_MAX_CHARS * 2 + 5)
+    const chunks = chunkMessage(big)
+
+    expect(chunks.length).toBe(3)
+    expect(chunks[0].length).toBe(OUTBOUND_MAX_CHARS)
+    expect(chunks[1].length).toBe(OUTBOUND_MAX_CHARS)
+    expect(chunks[2].length).toBe(5)
+  })
+})
+
+describe('outbound queue', () => {
+  test('sends a short message as a single API call', async () => {
+    const { transport, calls } = stubTransport()
+    const queue = createOutboundQueue({ transport })
+
+    const results = await queue.send({ chat_id: 1, text: 'hi' })
+
+    expect(calls.length).toBe(1)
+    expect(calls[0].text).toBe('hi')
+    expect(results.length).toBe(1)
+  })
+
+  test('splits a long message into chunks, each sent in order', async () => {
+    const { transport, calls } = stubTransport()
+    const queue = createOutboundQueue({ transport })
+
+    const big = `${'a'.repeat(3000)}\n\n${'b'.repeat(3000)}`
+    await queue.send({ chat_id: 1, text: big })
+
+    expect(calls.length).toBe(2)
+    expect(calls[0].text.startsWith('a')).toBe(true)
+    expect(calls[1].text.startsWith('b')).toBe(true)
+  })
+
+  test('serializes concurrent sends to the same chat', async () => {
+    const { transport, calls } = stubTransport([], 10)
+    const queue = createOutboundQueue({ transport })
+
+    await Promise.all([
+      queue.send({ chat_id: 1, text: 'first' }),
+      queue.send({ chat_id: 1, text: 'second' }),
+    ])
+
+    expect(calls.map(c => c.text)).toEqual(['first', 'second'])
+  })
+
+  test('rate-limiter forces a sleep when the token bucket empties', async () => {
+    const { transport } = stubTransport()
+    let fakeNow = 0
+    const sleeps: number[] = []
+    const queue = createOutboundQueue({
+      transport,
+      capacity: 2,
+      refillMs: 1000,
+      now: () => fakeNow,
+      sleep: async ms => {
+        sleeps.push(ms)
+        fakeNow += ms
+      },
+    })
+
+    // Burn through the bucket with 3 back-to-back sends.
+    await queue.send({ chat_id: 1, text: 'a' })
+    await queue.send({ chat_id: 1, text: 'b' })
+    await queue.send({ chat_id: 1, text: 'c' })
+
+    expect(sleeps.length).toBeGreaterThanOrEqual(1)
+    expect(sleeps.reduce((a, b) => a + b, 0)).toBeGreaterThan(0)
+  })
+
+  test('different chats use independent buckets', async () => {
+    const { transport } = stubTransport()
+    let fakeNow = 0
+    const sleeps: number[] = []
+    const queue = createOutboundQueue({
+      transport,
+      capacity: 1,
+      refillMs: 1000,
+      now: () => fakeNow,
+      sleep: async ms => {
+        sleeps.push(ms)
+        fakeNow += ms
+      },
+    })
+
+    // Each chat has 1 token — two sends across two chats should NOT sleep.
+    await queue.send({ chat_id: 1, text: 'a' })
+    await queue.send({ chat_id: 2, text: 'b' })
+
+    expect(sleeps.length).toBe(0)
+  })
+})

--- a/src 2/daemon/gateway/telegram/outbound.ts
+++ b/src 2/daemon/gateway/telegram/outbound.ts
@@ -1,0 +1,154 @@
+// Outbound message queue.
+//
+// Wraps the Telegram transport with two things the Bot API requires:
+//
+//   1. Chunking. The API rejects messages longer than 4096 chars. We
+//      split at OUTBOUND_MAX_CHARS (under that limit so we have room for
+//      a "(part N/M)" suffix if we ever add one; in v1 we just split).
+//      Split prefers paragraph, then line, then hard-cut.
+//
+//   2. Per-chat rate limiting. Telegram's documented ceiling is 30 msg/sec
+//      for the same chat. We model this with a token bucket per chat ID:
+//      `tokens` starts at capacity; each send spends one; tokens refill
+//      at `refillPerMs` based on wall-clock time. If a send would dip
+//      below zero we sleep until enough tokens refill.
+//
+// The queue is serialized per chat — two concurrent callers for the same
+// chat get ordered output — but chats run in parallel.
+
+import type {
+  SendMessageParams,
+  TelegramMessage,
+  TelegramTransport,
+} from './transport.js'
+
+export const OUTBOUND_MAX_CHARS = 4000
+const DEFAULT_CAPACITY = 30
+const DEFAULT_REFILL_MS = 1000
+const DEFAULT_SLEEP = (ms: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(resolve, ms)
+  })
+
+export type OutboundQueueDeps = {
+  transport: TelegramTransport
+  capacity?: number
+  refillMs?: number
+  now?: () => number
+  sleep?: (ms: number) => Promise<void>
+}
+
+export type OutboundQueue = {
+  send(params: SendMessageParams): Promise<TelegramMessage[]>
+  drain(): Promise<void>
+}
+
+type ChatState = {
+  tokens: number
+  lastRefillAt: number
+  chain: Promise<void>
+}
+
+export function chunkMessage(
+  text: string,
+  maxChars = OUTBOUND_MAX_CHARS,
+): string[] {
+  if (text.length <= maxChars) return [text]
+
+  const chunks: string[] = []
+  let remaining = text
+
+  while (remaining.length > maxChars) {
+    let cutAt = -1
+    // Prefer a clean paragraph break.
+    const paragraph = remaining.lastIndexOf('\n\n', maxChars)
+    if (paragraph > maxChars / 2) {
+      cutAt = paragraph + 2
+    } else {
+      const line = remaining.lastIndexOf('\n', maxChars)
+      if (line > maxChars / 2) {
+        cutAt = line + 1
+      }
+    }
+    if (cutAt <= 0) cutAt = maxChars
+    chunks.push(remaining.slice(0, cutAt))
+    remaining = remaining.slice(cutAt)
+  }
+
+  if (remaining.length > 0) chunks.push(remaining)
+  return chunks
+}
+
+export function createOutboundQueue(deps: OutboundQueueDeps): OutboundQueue {
+  const capacity = deps.capacity ?? DEFAULT_CAPACITY
+  const refillMs = deps.refillMs ?? DEFAULT_REFILL_MS
+  const now = deps.now ?? (() => Date.now())
+  const sleep = deps.sleep ?? DEFAULT_SLEEP
+  const tokensPerMs = capacity / refillMs
+  const chatStates = new Map<number, ChatState>()
+
+  function refill(state: ChatState): void {
+    const currentTime = now()
+    const elapsed = currentTime - state.lastRefillAt
+    if (elapsed <= 0) return
+    const refilled = Math.min(capacity, state.tokens + elapsed * tokensPerMs)
+    state.tokens = refilled
+    state.lastRefillAt = currentTime
+  }
+
+  async function acquire(state: ChatState): Promise<void> {
+    while (true) {
+      refill(state)
+      if (state.tokens >= 1) {
+        state.tokens -= 1
+        return
+      }
+      const needed = 1 - state.tokens
+      const waitMs = Math.max(1, Math.ceil(needed / tokensPerMs))
+      await sleep(waitMs)
+    }
+  }
+
+  function getState(chatId: number): ChatState {
+    let state = chatStates.get(chatId)
+    if (!state) {
+      state = { tokens: capacity, lastRefillAt: now(), chain: Promise.resolve() }
+      chatStates.set(chatId, state)
+    }
+    return state
+  }
+
+  async function sendChunked(
+    params: SendMessageParams,
+  ): Promise<TelegramMessage[]> {
+    const chunks = chunkMessage(params.text)
+    const state = getState(params.chat_id)
+    const results: TelegramMessage[] = []
+    for (const chunk of chunks) {
+      await acquire(state)
+      const message = await deps.transport.sendMessage({
+        ...params,
+        text: chunk,
+      })
+      results.push(message)
+    }
+    return results
+  }
+
+  return {
+    async send(params) {
+      const state = getState(params.chat_id)
+      let results: TelegramMessage[] = []
+      const next = state.chain.then(async () => {
+        results = await sendChunked(params)
+      })
+      // Swallow errors in the chain so one failure doesn't poison later sends.
+      state.chain = next.catch(() => {})
+      await next
+      return results
+    },
+    async drain() {
+      await Promise.all(Array.from(chatStates.values()).map(s => s.chain))
+    },
+  }
+}

--- a/src 2/daemon/gateway/telegram/pairing.test.ts
+++ b/src 2/daemon/gateway/telegram/pairing.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { addPairedChat, isChatPaired } from './allowlist.js'
+import { writeTelegramConfig } from './config.js'
+import {
+  clearPendingPair,
+  generatePairCode,
+  readPendingPair,
+  tryPair,
+  writePendingPair,
+} from './pairing.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makePaths(): { configPath: string; pendingPath: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'tg-pair-'))
+  TEMP_DIRS.push(dir)
+  return {
+    configPath: join(dir, 'telegram.json'),
+    pendingPath: join(dir, 'telegram.pending.json'),
+  }
+}
+
+describe('generatePairCode', () => {
+  test('returns a 6-digit zero-padded string', () => {
+    for (let i = 0; i < 20; i += 1) {
+      const code = generatePairCode()
+      expect(code).toMatch(/^\d{6}$/)
+    }
+  })
+})
+
+describe('pending pair file', () => {
+  test('readPendingPair returns null when the file does not exist', async () => {
+    const { pendingPath } = makePaths()
+    expect(await readPendingPair(pendingPath)).toBeNull()
+  })
+
+  test('write + read round-trips', async () => {
+    const { pendingPath } = makePaths()
+    const now = new Date().toISOString()
+    await writePendingPair({ code: '123456', createdAt: now }, pendingPath)
+    expect(await readPendingPair(pendingPath)).toEqual({
+      code: '123456',
+      createdAt: now,
+    })
+  })
+})
+
+describe('allowlist', () => {
+  test('addPairedChat throws if config does not exist yet', async () => {
+    const { configPath } = makePaths()
+    await expect(addPairedChat(42, configPath)).rejects.toThrow()
+  })
+
+  test('isChatPaired is false when config missing', async () => {
+    const { configPath } = makePaths()
+    expect(await isChatPaired(42, configPath)).toBe(false)
+  })
+
+  test('add then isPaired returns true; duplicate add is a no-op', async () => {
+    const { configPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [] }, configPath)
+
+    await addPairedChat(42, configPath)
+    expect(await isChatPaired(42, configPath)).toBe(true)
+
+    const second = await addPairedChat(42, configPath)
+    expect(second.pairedChatIds).toEqual([42])
+  })
+})
+
+describe('tryPair', () => {
+  test('no_pending when no code file exists', async () => {
+    const { configPath, pendingPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [] }, configPath)
+
+    const result = await tryPair({
+      chatId: 99,
+      candidateCode: '123456',
+      pendingPath,
+      configPath,
+    })
+
+    expect(result).toEqual({ outcome: 'no_pending' })
+    expect(await isChatPaired(99, configPath)).toBe(false)
+  })
+
+  test('mismatch when the DMed code does not match the pending one', async () => {
+    const { configPath, pendingPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [] }, configPath)
+    await writePendingPair(
+      { code: '654321', createdAt: new Date().toISOString() },
+      pendingPath,
+    )
+
+    const result = await tryPair({
+      chatId: 99,
+      candidateCode: '000000',
+      pendingPath,
+      configPath,
+    })
+
+    expect(result).toEqual({ outcome: 'mismatch' })
+    expect(await isChatPaired(99, configPath)).toBe(false)
+    // Pending code survives mismatches so the user can try again.
+    expect(await readPendingPair(pendingPath)).not.toBeNull()
+  })
+
+  test('paired writes chat ID to allowlist and clears pending file', async () => {
+    const { configPath, pendingPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [] }, configPath)
+    await writePendingPair(
+      { code: '424242', createdAt: new Date().toISOString() },
+      pendingPath,
+    )
+
+    const result = await tryPair({
+      chatId: 99,
+      candidateCode: '  424242  ',
+      pendingPath,
+      configPath,
+    })
+
+    expect(result).toEqual({ outcome: 'paired', chatId: 99 })
+    expect(await isChatPaired(99, configPath)).toBe(true)
+    expect(existsSync(pendingPath)).toBe(false)
+  })
+
+  test('expired when the pending code is older than the TTL', async () => {
+    const { configPath, pendingPath } = makePaths()
+    await writeTelegramConfig({ token: 't', pairedChatIds: [] }, configPath)
+    const oldTime = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    await writePendingPair({ code: '111111', createdAt: oldTime }, pendingPath)
+
+    const result = await tryPair({
+      chatId: 99,
+      candidateCode: '111111',
+      pendingPath,
+      configPath,
+    })
+
+    expect(result).toEqual({ outcome: 'expired' })
+    expect(await isChatPaired(99, configPath)).toBe(false)
+    expect(existsSync(pendingPath)).toBe(false)
+  })
+
+  test('clearPendingPair is idempotent', async () => {
+    const { pendingPath } = makePaths()
+    await clearPendingPair(pendingPath)
+    await clearPendingPair(pendingPath)
+  })
+})

--- a/src 2/daemon/gateway/telegram/pairing.ts
+++ b/src 2/daemon/gateway/telegram/pairing.ts
@@ -1,0 +1,101 @@
+// One-time pairing flow.
+//
+// Principle: a chat ID is only added to the allowlist if the user has
+// independently run the `pair` CLI (which writes a 6-digit code to
+// telegram.pending.json) AND then DMs that exact code to the bot. A
+// stranger who DMs the bot with no active code is ignored (with one
+// courtesy reply). A code expires after PENDING_TTL_MS so a forgotten
+// terminal tab doesn't leave an open pairing window forever.
+
+import { randomInt } from 'crypto'
+import { mkdir, readFile, rename, unlink, writeFile } from 'fs/promises'
+import { dirname } from 'path'
+import { addPairedChat } from './allowlist.js'
+import { getTelegramPendingPairPath } from './paths.js'
+
+const PENDING_TTL_MS = 15 * 60 * 1000
+const CODE_DIGITS = 6
+
+export type PendingPair = {
+  code: string
+  createdAt: string
+}
+
+export type PairingAttemptResult =
+  | { outcome: 'paired'; chatId: number }
+  | { outcome: 'no_pending' }
+  | { outcome: 'expired' }
+  | { outcome: 'mismatch' }
+
+export function generatePairCode(): string {
+  const n = randomInt(0, 10 ** CODE_DIGITS)
+  return String(n).padStart(CODE_DIGITS, '0')
+}
+
+export async function writePendingPair(
+  pending: PendingPair,
+  path = getTelegramPendingPairPath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tempPath = `${path}.tmp`
+  await writeFile(tempPath, `${JSON.stringify(pending, null, 2)}\n`, 'utf8')
+  await rename(tempPath, path)
+}
+
+export async function readPendingPair(
+  path = getTelegramPendingPairPath(),
+): Promise<PendingPair | null> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    const parsed = JSON.parse(raw) as Partial<PendingPair>
+    if (typeof parsed.code !== 'string' || typeof parsed.createdAt !== 'string') {
+      return null
+    }
+    return { code: parsed.code, createdAt: parsed.createdAt }
+  } catch {
+    return null
+  }
+}
+
+export async function clearPendingPair(
+  path = getTelegramPendingPairPath(),
+): Promise<void> {
+  await unlink(path).catch(() => {})
+}
+
+/**
+ * Consult a pending-pair file, decide whether a DMed code should move a
+ * chat ID into the allowlist, and on success clear the pending file so
+ * the code can't be reused. Written as a pure-ish function so tests can
+ * inject the pending-file path and now() and inspect the returned
+ * outcome enum.
+ */
+export async function tryPair(params: {
+  chatId: number
+  candidateCode: string
+  now?: Date
+  pendingPath?: string
+  configPath?: string
+}): Promise<PairingAttemptResult> {
+  const now = params.now ?? new Date()
+  const pending = await readPendingPair(params.pendingPath)
+  if (!pending) return { outcome: 'no_pending' }
+
+  const createdAt = Date.parse(pending.createdAt)
+  if (!Number.isFinite(createdAt)) {
+    await clearPendingPair(params.pendingPath)
+    return { outcome: 'expired' }
+  }
+  if (now.getTime() - createdAt > PENDING_TTL_MS) {
+    await clearPendingPair(params.pendingPath)
+    return { outcome: 'expired' }
+  }
+
+  if (params.candidateCode.trim() !== pending.code) {
+    return { outcome: 'mismatch' }
+  }
+
+  await addPairedChat(params.chatId, params.configPath)
+  await clearPendingPair(params.pendingPath)
+  return { outcome: 'paired', chatId: params.chatId }
+}

--- a/src 2/daemon/gateway/telegram/paths.ts
+++ b/src 2/daemon/gateway/telegram/paths.ts
@@ -1,0 +1,17 @@
+// File layout for the Telegram gateway.
+//
+// Everything lives under the KAIROS state dir so `rm -rf ~/.claude/kairos`
+// fully resets the feature. Token + paired chat IDs share a single file
+// (mode 0600); the pending pair code is written to a separate file so the
+// CLI can invalidate it atomically without racing the daemon's config read.
+
+import { join } from 'path'
+import { getKairosStateDir } from '../../kairos/paths.js'
+
+export function getTelegramConfigPath(): string {
+  return join(getKairosStateDir(), 'telegram.json')
+}
+
+export function getTelegramPendingPairPath(): string {
+  return join(getKairosStateDir(), 'telegram.pending.json')
+}

--- a/src 2/daemon/gateway/telegram/transport.test.ts
+++ b/src 2/daemon/gateway/telegram/transport.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  TelegramApiError,
+  TelegramTransportError,
+  createTelegramTransport,
+} from './transport.js'
+
+type FetchCall = { url: string; init: RequestInit }
+
+function makeFetcher(
+  responder: (call: FetchCall) => { status?: number; body: unknown } | Promise<{ status?: number; body: unknown }>,
+): { fetcher: typeof fetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = []
+  const fetcher: typeof fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : (input as Request).url
+    const call = { url, init: init ?? {} }
+    calls.push(call)
+    const result = await responder(call)
+    return new Response(JSON.stringify(result.body), {
+      status: result.status ?? 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  return { fetcher, calls }
+}
+
+describe('createTelegramTransport', () => {
+  test('getMe returns the parsed bot user on ok=true', async () => {
+    const { fetcher, calls } = makeFetcher(() => ({
+      body: {
+        ok: true,
+        result: { id: 42, is_bot: true, first_name: 'magnus', username: 'magnusbot' },
+      },
+    }))
+    const transport = createTelegramTransport('tok', { fetcher })
+
+    const me = await transport.getMe()
+
+    expect(me).toEqual({ id: 42, is_bot: true, first_name: 'magnus', username: 'magnusbot' })
+    expect(calls[0].url).toBe('https://api.telegram.org/bottok/getMe')
+    expect(calls[0].init.method).toBe('POST')
+  })
+
+  test('getUpdates passes offset/timeout in the request body', async () => {
+    const { fetcher, calls } = makeFetcher(() => ({
+      body: { ok: true, result: [] },
+    }))
+    const transport = createTelegramTransport('tok', { fetcher })
+
+    await transport.getUpdates({ offset: 17, timeout: 30 })
+
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({ offset: 17, timeout: 30 })
+  })
+
+  test('sendMessage throws TelegramApiError when the bot API returns ok=false', async () => {
+    const { fetcher } = makeFetcher(() => ({
+      body: { ok: false, description: 'Forbidden: bot was blocked by the user', error_code: 403 },
+    }))
+    const transport = createTelegramTransport('tok', { fetcher })
+
+    await expect(transport.sendMessage({ chat_id: 1, text: 'hi' })).rejects.toBeInstanceOf(
+      TelegramApiError,
+    )
+  })
+
+  test('network failures bubble up as TelegramTransportError', async () => {
+    const fetcher: typeof fetch = async () => {
+      throw new Error('ECONNRESET')
+    }
+    const transport = createTelegramTransport('tok', { fetcher })
+
+    await expect(transport.getMe()).rejects.toBeInstanceOf(TelegramTransportError)
+  })
+
+  test('malformed JSON surfaces as TelegramTransportError', async () => {
+    const fetcher: typeof fetch = async () =>
+      new Response('not json', { status: 200, headers: { 'Content-Type': 'text/plain' } })
+    const transport = createTelegramTransport('tok', { fetcher })
+
+    await expect(transport.getMe()).rejects.toBeInstanceOf(TelegramTransportError)
+  })
+
+  test('signal is forwarded so abort cancels the in-flight request', async () => {
+    const controller = new AbortController()
+    const { fetcher, calls } = makeFetcher(() => ({ body: { ok: true, result: [] } }))
+    const transport = createTelegramTransport('tok', { fetcher, signal: controller.signal })
+
+    await transport.getUpdates({ timeout: 30 })
+
+    expect(calls[0].init.signal).toBe(controller.signal)
+  })
+})

--- a/src 2/daemon/gateway/telegram/transport.ts
+++ b/src 2/daemon/gateway/telegram/transport.ts
@@ -1,0 +1,140 @@
+// Thin fetch-based client for the Telegram Bot API.
+//
+// We deliberately avoid `@grammyjs/grammy` and `node-telegram-bot-api` —
+// the Bot API endpoints we need are a trivial subset (getMe, getUpdates,
+// sendMessage) and a 90-line wrapper is easier to stub in tests than
+// monkey-patching a full SDK.
+//
+// Errors: the Bot API returns `{ ok: false, description, error_code }` on
+// failure with HTTP 200, so we normalize that into a thrown
+// TelegramApiError. Network / 5xx / malformed-body errors surface as
+// TelegramTransportError so the caller can distinguish "we couldn't reach
+// Telegram" from "Telegram told us no".
+
+export type TelegramUser = {
+  id: number
+  is_bot: boolean
+  first_name: string
+  username?: string
+}
+
+export type TelegramChat = {
+  id: number
+  type: 'private' | 'group' | 'supergroup' | 'channel'
+  username?: string
+  first_name?: string
+}
+
+export type TelegramMessage = {
+  message_id: number
+  date: number
+  chat: TelegramChat
+  from?: TelegramUser
+  text?: string
+}
+
+export type TelegramUpdate = {
+  update_id: number
+  message?: TelegramMessage
+  edited_message?: TelegramMessage
+}
+
+export type GetUpdatesParams = {
+  offset?: number
+  timeout?: number
+  limit?: number
+  allowed_updates?: string[]
+}
+
+export type SendMessageParams = {
+  chat_id: number
+  text: string
+  disable_notification?: boolean
+}
+
+export type FetchLike = typeof fetch
+
+export class TelegramApiError extends Error {
+  readonly errorCode: number
+  constructor(errorCode: number, description: string) {
+    super(`Telegram API error ${errorCode}: ${description}`)
+    this.name = 'TelegramApiError'
+    this.errorCode = errorCode
+  }
+}
+
+export class TelegramTransportError extends Error {
+  readonly cause?: unknown
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message)
+    this.name = 'TelegramTransportError'
+    if (options?.cause !== undefined) this.cause = options.cause
+  }
+}
+
+export type TelegramTransport = {
+  getMe(): Promise<TelegramUser>
+  getUpdates(params: GetUpdatesParams): Promise<TelegramUpdate[]>
+  sendMessage(params: SendMessageParams): Promise<TelegramMessage>
+}
+
+type TransportDeps = {
+  baseUrl?: string
+  fetcher?: FetchLike
+  /** Abort signal forwarded to every request. Long-poll callers pass it so
+   * stopping the gateway cancels an in-flight getUpdates immediately. */
+  signal?: AbortSignal
+}
+
+const DEFAULT_BASE_URL = 'https://api.telegram.org'
+
+export function createTelegramTransport(
+  token: string,
+  deps: TransportDeps = {},
+): TelegramTransport {
+  const baseUrl = deps.baseUrl ?? DEFAULT_BASE_URL
+  const fetcher = deps.fetcher ?? fetch
+  const signal = deps.signal
+
+  async function call<T>(method: string, body: unknown): Promise<T> {
+    const url = `${baseUrl}/bot${token}/${method}`
+    let response: Response
+    try {
+      response = await fetcher(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body ?? {}),
+        signal,
+      })
+    } catch (error) {
+      throw new TelegramTransportError(
+        `network error calling ${method}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      )
+    }
+
+    let parsed: { ok: boolean; result?: T; description?: string; error_code?: number }
+    try {
+      parsed = (await response.json()) as typeof parsed
+    } catch (error) {
+      throw new TelegramTransportError(
+        `malformed JSON from ${method} (status ${response.status})`,
+        { cause: error },
+      )
+    }
+
+    if (!parsed.ok) {
+      throw new TelegramApiError(
+        parsed.error_code ?? response.status,
+        parsed.description ?? 'unknown error',
+      )
+    }
+    return parsed.result as T
+  }
+
+  return {
+    getMe: () => call<TelegramUser>('getMe', {}),
+    getUpdates: params => call<TelegramUpdate[]>('getUpdates', params),
+    sendMessage: params => call<TelegramMessage>('sendMessage', params),
+  }
+}

--- a/src 2/daemon/kairos/worker.ts
+++ b/src 2/daemon/kairos/worker.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, writeFile } from 'fs/promises'
+import { appendFile, mkdir, readFile, writeFile } from 'fs/promises'
 import type { Writable } from 'stream'
 import type {
   ChildLauncher,
@@ -19,12 +19,19 @@ import { createProjectRegistry } from './projectRegistry.js'
 import { createProjectWorker } from './projectWorker.js'
 import type { CronTask } from '../../utils/cronTasks.js'
 import {
+  getKairosGlobalEventsPath,
+  getKairosPausePath,
   getKairosStateDir,
   getKairosStatusPath,
   getKairosStdoutLogPath,
 } from './paths.js'
 import { createStateWriter, type StateWriter } from './stateWriter.js'
 import { createTier3Controller, type Tier3Controller } from './tier3.js'
+import { readTelegramConfig } from '../gateway/telegram/config.js'
+import { createGateway, type Gateway } from '../gateway/telegram/gateway.js'
+import { createDispatcher } from '../gateway/telegram/commands.js'
+import { createReminderFromUserRequest } from '../../services/reminders/createReminderFromUserRequest.js'
+import { setPauseState as setGlobalPauseState } from '../dashboard/model.js'
 
 type KairosStatus = {
   kind: 'kairos'
@@ -491,6 +498,59 @@ export async function runKairosWorker(
     pid,
   })
 
+  // Start the Telegram gateway if ~/.claude/kairos/telegram.json exists.
+  // Off by default: missing config → no gateway, no API calls, no token
+  // needed. The CLI's `/kairos gateway telegram setup` writes the file,
+  // so next daemon start picks it up.
+  let telegramGateway: Gateway | null = null
+  const telegramConfig = await readTelegramConfig()
+  if (telegramConfig && telegramConfig.token) {
+    const dispatcher = createDispatcher({
+      now,
+      readStatus: async () => {
+        try {
+          return JSON.parse(await readFile(getKairosStatusPath(), 'utf8')) as unknown
+        } catch {
+          return null
+        }
+      },
+      readPause: async () => {
+        try {
+          return JSON.parse(await readFile(getKairosPausePath(), 'utf8')) as unknown
+        } catch {
+          return null
+        }
+      },
+      listProjects: async () => projectRegistry.read(),
+      setPause: async paused => {
+        await setGlobalPauseState(paused, now)
+      },
+      scheduleReminder: createReminderFromUserRequest,
+      recordSkip: async ({ chatId }) => {
+        await stateWriter.appendGlobalEvent({
+          kind: 'telegram_skip' as const,
+          t: now().toISOString(),
+          chatId,
+          source: 'daemon' as const,
+        } as never)
+      },
+    })
+    telegramGateway = createGateway({
+      token: telegramConfig.token,
+      eventPath: getKairosGlobalEventsPath(),
+      dispatch: input => dispatcher.dispatch(input),
+      signal: options.signal,
+      log: message =>
+        void logLine(`[telegram] ${message}`, {
+          stdout: options.stdout,
+          now: now(),
+          pid,
+        }),
+      now,
+    })
+    await telegramGateway.start()
+  }
+
   for (const projectDir of await projectRegistry.read()) {
     await addProject(projectDir)
   }
@@ -517,6 +577,7 @@ export async function runKairosWorker(
   await waitForAbort(options.signal)
 
   await stopWatchingProjects()
+  await telegramGateway?.stop()
   for (const projectDir of [...activeWorkers.keys()]) {
     await removeProject(projectDir)
   }


### PR DESCRIPTION
## Summary
Two-way Telegram gateway for the KAIROS daemon, off by default and enabled via an out-of-band CLI pairing flow (`/kairos gateway telegram setup|pair|status|unpair`). DM-only policy, per-chat token-bucket rate limiting, >4000-char chunking, long-poll with exponential backoff, and an `events.jsonl` tail that forwards tier3 surfaces / cap-hit notices / reminder firings to paired chats — all without touching `tier3.ts`. Trunk-safe: no edits to `commands.ts`, `tier3.ts`, `Tool.ts`, `types/`, `schemas/`, `state/`, `entrypoints/`, or `migrations/`. 89 new tests pass (241 total), lint + typecheck clean. Verified end-to-end live against @magnus114bot: setup, pair, inbound command, and tier3-surface forwarding all observed on the phone.

## Test plan
- [x] `bun test daemon/gateway/telegram` — 89 pass, 0 fail
- [x] `bun test` full suite — 241 pass, 0 fail (no regressions)
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] Live: `setup <token>` writes `telegram.json` mode 0600
- [x] Live: `pair` generates code, DM consumes it, allowlist populated, pending file removed
- [x] Live: daemon logs `[telegram] gateway online as @<bot>` at startup
- [x] Live: append to `events.jsonl` → message arrives on phone with 💡 prefix
- [ ] Reviewer: confirm no trunk-guarded files edited (`git diff origin/main...HEAD --name-only`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)