### PR TITLE
Add KAIROS push-only cloud sync

### DIFF
--- a/src 2/commands/kairos.test.ts
+++ b/src 2/commands/kairos.test.ts
@@ -7,7 +7,11 @@ import {
   getProjectRoot,
   setProjectRoot,
 } from '../bootstrap/state.js'
-import { runKairosCommand } from './kairos.js'
+import {
+  __resetKairosCloudSyncDepsForTesting,
+  __setKairosCloudSyncDepsForTesting,
+  runKairosCommand,
+} from './kairos.js'
 
 const TEMP_DIRS: string[] = []
 let originalProjectRoot: string
@@ -35,6 +39,7 @@ beforeEach(() => {
 
 afterEach(() => {
   setProjectRoot(originalProjectRoot)
+  __resetKairosCloudSyncDepsForTesting()
   delete process.env.CLAUDE_CONFIG_DIR
   delete process.env.KAIROS_DASHBOARD_URL
   for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
@@ -48,6 +53,7 @@ describe('/kairos command', () => {
     expect(out).toContain('/kairos status')
     expect(out).toContain('/kairos opt-in')
     expect(out).toContain('/kairos demo')
+    expect(out).toContain('/kairos cloud-sync')
   })
 
   test('prints help for unknown subcommands', async () => {
@@ -236,6 +242,83 @@ describe('/kairos command', () => {
 
     const out = await runKairosCommand('logs 3')
     expect(out).toBe(['b', 'c', 'd'].join('\n'))
+  })
+
+  test('cloud-sync requires an explicit runtime root', async () => {
+    const out = await runKairosCommand('cloud-sync')
+    expect(out).toBe('Usage: /kairos cloud-sync <runtimeRoot>')
+  })
+
+  test('cloud-sync builds and applies a bundle to the requested runtime root', async () => {
+    const runtimeRoot = makeProjectDir()
+    let receivedRuntimeRoot: string | null = null
+    __setKairosCloudSyncDepsForTesting({
+      async buildBundle() {
+        return {
+          version: 1,
+          createdAt: '2026-04-22T12:00:00.000Z',
+          files: [
+            {
+              relativePath: 'config/.claude/skills/demo/SKILL.md',
+              sizeBytes: 4,
+              sha256: 'abcd',
+              contentBase64: Buffer.from('demo', 'utf8').toString('base64'),
+            },
+          ],
+          projects: [
+            {
+              id: 'proj1234abcd',
+              remoteUrl: 'https://github.com/example/repo.git',
+              normalizedRemoteUrl: 'github.com/example/repo',
+              headRef: 'main',
+              headCommit: 'deadbeef',
+            },
+          ],
+        }
+      },
+      async applyBundle(_bundle, options) {
+        receivedRuntimeRoot = options.runtimeRoot
+        return {
+          sourceDir: join(options.runtimeRoot, 'source'),
+          overlayDir: join(options.runtimeRoot, 'overlay'),
+          manifestPath: join(options.runtimeRoot, 'source', 'manifest.json'),
+          registryPath: join(
+            options.runtimeRoot,
+            'source',
+            'registry',
+            'projects.json',
+          ),
+          managedPaths: [
+            'config/.claude/skills/demo/SKILL.md',
+            'manifest.json',
+            'registry/projects.json',
+          ],
+        }
+      },
+    })
+
+    const out = await runKairosCommand(`cloud-sync ${runtimeRoot}`)
+    expect(receivedRuntimeRoot).toBe(runtimeRoot)
+    expect(out).toContain('Cloud sync applied: 1 file(s), 1 project(s)')
+    expect(out).toContain(`runtime root: ${runtimeRoot}`)
+    expect(out).toContain(join(runtimeRoot, 'source'))
+    expect(out).toContain(join(runtimeRoot, 'overlay'))
+  })
+
+  test('cloud-sync surfaces build or apply failures as user-facing errors', async () => {
+    __setKairosCloudSyncDepsForTesting({
+      async buildBundle() {
+        throw new Error('Project /tmp/missing has no reachable git remote')
+      },
+      async applyBundle() {
+        throw new Error('unreachable')
+      },
+    })
+
+    const out = await runKairosCommand('cloud-sync ./runtime-root')
+    expect(out).toBe(
+      'Cloud sync failed: Project /tmp/missing has no reachable git remote',
+    )
   })
 
   test('skills export emits a self-contained manifest', async () => {

--- a/src 2/commands/kairos.ts
+++ b/src 2/commands/kairos.ts
@@ -9,6 +9,7 @@
 // Trunk registration is Phase 5B (see epic #11).
 
 import { readFile } from 'fs/promises'
+import { resolve } from 'path'
 import { getProjectRoot } from '../bootstrap/state.js'
 import type { Command } from '../types/command.js'
 import {
@@ -36,6 +37,12 @@ import {
   startPairing,
   unpairTelegram,
 } from '../daemon/gateway/telegram/cli.js'
+import {
+  applyKairosCloudStateBundle,
+  buildKairosCloudStateBundle,
+  type ApplyKairosCloudStateBundleResult,
+  type KairosCloudStateBundle,
+} from '../daemon/kairos/cloudSync.js'
 import { safeParseJSON } from '../utils/json.js'
 import type { GlobalStatus, PauseState } from '../daemon/kairos/stateWriter.js'
 
@@ -52,6 +59,7 @@ const HELP_TEXT = `Usage:
 /kairos resume
 /kairos dashboard
 /kairos logs [projectDir] [lines]
+/kairos cloud-sync <runtimeRoot>
 /kairos gateway telegram setup <bot-token>
 /kairos gateway telegram pair
 /kairos gateway telegram status
@@ -73,6 +81,7 @@ type Subcommand =
   | 'resume'
   | 'dashboard'
   | 'logs'
+  | 'cloud-sync'
   | 'gateway'
   | 'skills'
   | 'skill-improvements'
@@ -89,6 +98,7 @@ const SUBCOMMANDS = new Set<Subcommand>([
   'resume',
   'dashboard',
   'logs',
+  'cloud-sync',
   'gateway',
   'skills',
   'skill-improvements',
@@ -284,6 +294,57 @@ async function handleGateway(rest: string[]): Promise<string> {
   return 'Usage: /kairos gateway telegram <setup|pair|status|unpair> [...]'
 }
 
+type KairosCloudSyncDeps = {
+  buildBundle: () => Promise<KairosCloudStateBundle>
+  applyBundle: (
+    bundle: KairosCloudStateBundle,
+    options: { runtimeRoot: string },
+  ) => Promise<ApplyKairosCloudStateBundleResult>
+}
+
+let kairosCloudSyncDeps: KairosCloudSyncDeps = {
+  buildBundle: () => buildKairosCloudStateBundle(),
+  applyBundle: (bundle, options) =>
+    applyKairosCloudStateBundle(bundle, options),
+}
+
+export function __setKairosCloudSyncDepsForTesting(
+  deps: KairosCloudSyncDeps,
+): void {
+  kairosCloudSyncDeps = deps
+}
+
+export function __resetKairosCloudSyncDepsForTesting(): void {
+  kairosCloudSyncDeps = {
+    buildBundle: () => buildKairosCloudStateBundle(),
+    applyBundle: (bundle, options) =>
+      applyKairosCloudStateBundle(bundle, options),
+  }
+}
+
+async function handleCloudSync(runtimeRootArg: string | undefined): Promise<string> {
+  if (!runtimeRootArg || runtimeRootArg.trim().length === 0) {
+    return 'Usage: /kairos cloud-sync <runtimeRoot>'
+  }
+
+  const runtimeRoot = resolve(runtimeRootArg)
+  try {
+    const bundle = await kairosCloudSyncDeps.buildBundle()
+    const result = await kairosCloudSyncDeps.applyBundle(bundle, { runtimeRoot })
+    return [
+      `Cloud sync applied: ${bundle.files.length} file(s), ${bundle.projects.length} project(s)`,
+      `runtime root: ${runtimeRoot}`,
+      `source: ${result.sourceDir}`,
+      `overlay: ${result.overlayDir}`,
+      `manifest: ${result.manifestPath}`,
+      `registry: ${result.registryPath}`,
+    ].join('\n')
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return `Cloud sync failed: ${message}`
+  }
+}
+
 export async function runKairosCommand(args: string): Promise<string> {
   const { sub, rest } = parseArgs(args)
   if (sub === null) {
@@ -306,6 +367,8 @@ export async function runKairosCommand(args: string): Promise<string> {
       return handleResume()
     case 'dashboard':
       return handleDashboard()
+    case 'cloud-sync':
+      return handleCloudSync(rest.join(' ').trim() || undefined)
     case 'gateway':
       return handleGateway(rest)
     case 'logs': {
@@ -337,7 +400,7 @@ const kairos = {
   name: 'kairos',
   description: 'Inspect and control the KAIROS background daemon',
   argumentHint:
-    'status|list|opt-in|opt-out|demo|pause|resume|dashboard|logs|gateway|skills|skill-improvements|memory-proposals|memory',
+    'status|list|opt-in|opt-out|demo|pause|resume|dashboard|logs|cloud-sync|gateway|skills|skill-improvements|memory-proposals|memory',
   load: () => import('./kairos-ui.js'),
 } satisfies Command
 

--- a/src 2/daemon/kairos/cloudSync.test.ts
+++ b/src 2/daemon/kairos/cloudSync.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  applyKairosCloudStateBundle,
+  buildKairosCloudStateBundle,
+  getKairosCloudManifestPath,
+  getKairosCloudOverlayDir,
+  getKairosCloudOverlayStateDir,
+  getKairosCloudProjectOverlayDir,
+  getKairosCloudRegistryPath,
+  getKairosCloudSourceDir,
+  KairosCloudSyncError,
+  type KairosCloudBundleProject,
+} from './cloudSync.js'
+import { createProjectRegistry } from './projectRegistry.js'
+
+const TEMP_DIRS: string[] = []
+
+afterEach(() => {
+  delete process.env.CLAUDE_CONFIG_DIR
+  for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  TEMP_DIRS.push(dir)
+  return dir
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function modeOf(path: string): number {
+  return statSync(path).mode & 0o777
+}
+
+describe('Kairos cloud state sync', () => {
+  test('builds a bundle from supported KAIROS state and scheduled task data', async () => {
+    const configDir = makeTempDir('kairos-cloud-config-')
+    const projectDir = makeTempDir('kairos-cloud-project-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    mkdirSync(join(configDir, 'skills', 'daily-review'), { recursive: true })
+    writeFileSync(
+      join(configDir, 'skills', 'daily-review', 'SKILL.md'),
+      '---\nname: daily-review\ndescription: review things\n---\n# Skill\n',
+    )
+    mkdirSync(join(configDir, 'skills', 'daily-review', 'assets'), {
+      recursive: true,
+    })
+    writeFileSync(
+      join(configDir, 'skills', 'daily-review', 'assets', 'notes.txt'),
+      'keep sibling assets under a real skill dir',
+    )
+    mkdirSync(join(configDir, 'skills', 'daily-review', 'node_modules'), {
+      recursive: true,
+    })
+    writeFileSync(
+      join(configDir, 'skills', 'daily-review', 'node_modules', 'junk.js'),
+      'do not sync node_modules',
+    )
+    mkdirSync(join(configDir, 'skills', '.backup-skill', 'demo'), {
+      recursive: true,
+    })
+    writeFileSync(
+      join(configDir, 'skills', '.backup-skill', 'demo', 'SKILL.md'),
+      '---\nname: backup\ndescription: should be ignored\n---\n',
+    )
+    mkdirSync(join(configDir, 'memory'), { recursive: true })
+    writeFileSync(
+      join(configDir, 'memory', 'sessions.db'),
+      Buffer.from([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]),
+    )
+    mkdirSync(join(configDir, 'memory', '.pending-proposals'), {
+      recursive: true,
+    })
+    writeFileSync(
+      join(configDir, 'memory', '.pending-proposals', 'prop-1.json'),
+      JSON.stringify({ id: 'prop-1', content: 'keep this' }),
+    )
+    mkdirSync(join(configDir, 'memory', '.archived-proposals'), {
+      recursive: true,
+    })
+    writeFileSync(
+      join(configDir, 'memory', '.archived-proposals', 'prop-old.json'),
+      JSON.stringify({ id: 'prop-old', status: 'accepted' }),
+    )
+    mkdirSync(join(configDir, 'memory', 'backups'), { recursive: true })
+    writeFileSync(
+      join(configDir, 'memory', 'backups', 'old.md.bak'),
+      'do not sync backups',
+    )
+    mkdirSync(join(configDir, 'sessions', '.summaries'), { recursive: true })
+    writeFileSync(
+      join(configDir, 'sessions', '.summaries', 'sess-1.json'),
+      JSON.stringify({ id: 'sess-1', summary: 'done' }),
+    )
+
+    mkdirSync(join(projectDir, '.claude'), { recursive: true })
+    writeFileSync(
+      join(projectDir, '.claude', 'scheduled_tasks.json'),
+      JSON.stringify(
+        {
+          tasks: [{ id: 'abcd1234', cron: '* * * * *', prompt: 'check in', createdAt: 1 }],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const registry = await createProjectRegistry()
+    await registry.write([projectDir])
+
+    const bundle = await buildKairosCloudStateBundle({
+      now: () => new Date('2026-04-22T12:00:00.000Z'),
+      resolveProjectMetadata: async (): Promise<KairosCloudBundleProject> => ({
+        id: 'proj1234abcd',
+        remoteUrl: 'https://github.com/example/project.git',
+        normalizedRemoteUrl: 'github.com/example/project',
+        headRef: 'main',
+        headCommit: '0123456789abcdef',
+        defaultBranch: 'main',
+        repoHost: 'github.com',
+        repoOwner: 'example',
+        repoName: 'project',
+      }),
+    })
+
+    expect(bundle).toMatchObject({
+      version: 1,
+      createdAt: '2026-04-22T12:00:00.000Z',
+      projects: [
+        {
+          id: 'proj1234abcd',
+          remoteUrl: 'https://github.com/example/project.git',
+          scheduledTasksSyncPath:
+            'project-sync/proj1234abcd/.claude/scheduled_tasks.json',
+        },
+      ],
+    })
+
+    expect(bundle.files.map(file => file.relativePath)).toEqual([
+      'config/.claude/memory/.archived-proposals/prop-old.json',
+      'config/.claude/memory/.pending-proposals/prop-1.json',
+      'config/.claude/memory/sessions.db',
+      'config/.claude/skills/daily-review/assets/notes.txt',
+      'config/.claude/skills/daily-review/SKILL.md',
+      'project-sync/proj1234abcd/.claude/scheduled_tasks.json',
+    ])
+
+    const skillFile = bundle.files.find(
+      file => file.relativePath === 'config/.claude/skills/daily-review/SKILL.md',
+    )
+    expect(
+      Buffer.from(skillFile!.contentBase64, 'base64').toString('utf8'),
+    ).toContain('daily-review')
+
+    const memoryFile = bundle.files.find(
+      file => file.relativePath === 'config/.claude/memory/sessions.db',
+    )
+    expect(Buffer.from(memoryFile!.contentBase64, 'base64')).toEqual(
+      Buffer.from([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]),
+    )
+    expect(
+      bundle.files.some(
+        file =>
+          file.relativePath === 'config/.claude/sessions/.summaries/sess-1.json',
+      ),
+    ).toBe(false)
+    expect(
+      bundle.files.some(
+        file =>
+          file.relativePath === 'config/.claude/memory/backups/old.md.bak',
+      ),
+    ).toBe(false)
+    expect(
+      bundle.files.some(
+        file =>
+          file.relativePath ===
+          'config/.claude/skills/daily-review/node_modules/junk.js',
+      ),
+    ).toBe(false)
+    expect(
+      bundle.files.some(
+        file =>
+          file.relativePath === 'config/.claude/skills/.backup-skill/demo/SKILL.md',
+      ),
+    ).toBe(false)
+  })
+
+  test('rejects a project when cloud sync cannot resolve a reachable git remote', async () => {
+    const configDir = makeTempDir('kairos-cloud-config-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    await expect(
+      buildKairosCloudStateBundle({
+        readProjects: async () => ['/tmp/no-remote'],
+        resolveProjectMetadata: async projectDir => {
+          throw new KairosCloudSyncError(
+            `Project ${projectDir} has no reachable git remote: origin`,
+          )
+        },
+      }),
+    ).rejects.toThrow('has no reachable git remote')
+  })
+
+  test('applies a bundle into a read-only source tree and preserves overlay state across re-syncs', async () => {
+    const runtimeRoot = makeTempDir('kairos-cloud-runtime-')
+
+    const firstBundle = {
+      version: 1 as const,
+      createdAt: '2026-04-22T12:00:00.000Z',
+      projects: [
+        {
+          id: 'proj1234abcd',
+          remoteUrl: 'https://github.com/example/project.git',
+          normalizedRemoteUrl: 'github.com/example/project',
+          headRef: 'main',
+          headCommit: '0123456789abcdef',
+          defaultBranch: 'main',
+          scheduledTasksSyncPath:
+            'project-sync/proj1234abcd/.claude/scheduled_tasks.json',
+        },
+      ],
+      files: [
+        {
+          relativePath: 'config/.claude/skills/daily-review/SKILL.md',
+          sizeBytes: 5,
+          sha256: 'skill-v1',
+          contentBase64: Buffer.from('v1\n', 'utf8').toString('base64'),
+        },
+        {
+          relativePath: 'config/.claude/memory/sessions.db',
+          sizeBytes: 6,
+          sha256: 'memory-v1',
+          contentBase64: Buffer.from('mem-v1', 'utf8').toString('base64'),
+        },
+        {
+          relativePath: 'project-sync/proj1234abcd/.claude/scheduled_tasks.json',
+          sizeBytes: 11,
+          sha256: 'tasks-v1',
+          contentBase64: Buffer.from('{"tasks":[]}', 'utf8').toString('base64'),
+        },
+      ],
+    }
+
+    await applyKairosCloudStateBundle(firstBundle, {
+      runtimeRoot,
+      now: () => new Date('2026-04-22T12:05:00.000Z'),
+    })
+
+    const sourceDir = getKairosCloudSourceDir(runtimeRoot)
+    const overlayDir = getKairosCloudOverlayDir(runtimeRoot)
+    const skillPath = join(
+      sourceDir,
+      'config',
+      '.claude',
+      'skills',
+      'daily-review',
+      'SKILL.md',
+    )
+    const scheduledTasksPath = join(
+      sourceDir,
+      'project-sync',
+      'proj1234abcd',
+      '.claude',
+      'scheduled_tasks.json',
+    )
+    const overlayMarker = join(
+      getKairosCloudProjectOverlayDir(runtimeRoot, 'proj1234abcd'),
+      'events.jsonl',
+    )
+
+    expect(readFileSync(skillPath, 'utf8')).toBe('v1\n')
+    expect(modeOf(skillPath)).toBe(0o444)
+    expect(modeOf(scheduledTasksPath)).toBe(0o444)
+    expect(modeOf(getKairosCloudRegistryPath(runtimeRoot))).toBe(0o444)
+    expect(modeOf(getKairosCloudManifestPath(runtimeRoot))).toBe(0o444)
+    expect(existsSync(getKairosCloudOverlayStateDir(runtimeRoot))).toBe(true)
+    expect(existsSync(overlayDir)).toBe(true)
+
+    writeFileSync(overlayMarker, '{"kind":"runtime_event"}\n')
+
+    const secondBundle = {
+      version: 1 as const,
+      createdAt: '2026-04-22T12:10:00.000Z',
+      projects: firstBundle.projects,
+      files: [
+        {
+          relativePath: 'config/.claude/memory/sessions.db',
+          sizeBytes: 6,
+          sha256: 'memory-v2',
+          contentBase64: Buffer.from('mem-v2', 'utf8').toString('base64'),
+        },
+        {
+          relativePath: 'project-sync/proj1234abcd/.claude/scheduled_tasks.json',
+          sizeBytes: 24,
+          sha256: 'tasks-v2',
+          contentBase64: Buffer.from(
+            '{"tasks":[{"id":"next"}]}',
+            'utf8',
+          ).toString('base64'),
+        },
+      ],
+    }
+
+    await applyKairosCloudStateBundle(secondBundle, {
+      runtimeRoot,
+      now: () => new Date('2026-04-22T12:15:00.000Z'),
+    })
+
+    expect(existsSync(skillPath)).toBe(false)
+    expect(readFileSync(join(sourceDir, 'config', '.claude', 'memory', 'sessions.db'), 'utf8')).toBe(
+      'mem-v2',
+    )
+    expect(readFileSync(scheduledTasksPath, 'utf8')).toContain('"next"')
+    expect(readFileSync(overlayMarker, 'utf8')).toContain('runtime_event')
+
+    const registry = readJson(getKairosCloudRegistryPath(runtimeRoot)) as {
+      syncedAt: string
+      projects: Array<{ id: string }>
+    }
+    expect(registry.syncedAt).toBe('2026-04-22T12:10:00.000Z')
+    expect(registry.projects).toHaveLength(1)
+
+    const manifest = readJson(getKairosCloudManifestPath(runtimeRoot)) as {
+      managedPaths: string[]
+      bundleCreatedAt: string
+    }
+    expect(manifest.bundleCreatedAt).toBe('2026-04-22T12:10:00.000Z')
+    expect(manifest.managedPaths).not.toContain(
+      'config/.claude/skills/daily-review/SKILL.md',
+    )
+  })
+})

--- a/src 2/daemon/kairos/cloudSync.ts
+++ b/src 2/daemon/kairos/cloudSync.ts
@@ -1,0 +1,581 @@
+import { createHash, randomUUID } from 'crypto'
+import { chmod, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'fs/promises'
+import { dirname, join, relative, sep } from 'path'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
+import { execFileNoThrowWithCwd } from '../../utils/execFileNoThrow.js'
+import { gitExe, normalizeGitRemoteUrl } from '../../utils/git.js'
+import { parseGitRemote } from '../../utils/detectRepository.js'
+import { jsonStringify } from '../../utils/slowOperations.js'
+import { createProjectRegistry } from './projectRegistry.js'
+
+const CLOUD_SYNC_VERSION = 1
+const SOURCE_DIRNAME = 'source'
+const OVERLAY_DIRNAME = 'overlay'
+const MANIFEST_RELATIVE_PATH = 'manifest.json'
+const REGISTRY_RELATIVE_PATH = join('registry', 'projects.json')
+const CONFIG_ROOT_RELATIVE_PATH = join('config', '.claude')
+const PROJECT_SYNC_ROOT_RELATIVE_PATH = 'project-sync'
+const READONLY_MODE = 0o444
+const OVERLAY_DIR_MODE = 0o700
+const GIT_PROBE_TIMEOUT_MS = 30_000
+const SKILL_JUNK_DIRS = new Set(['.git', 'node_modules'])
+
+export class KairosCloudSyncError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'KairosCloudSyncError'
+  }
+}
+
+export type KairosCloudBundleFile = {
+  relativePath: string
+  sizeBytes: number
+  sha256: string
+  contentBase64: string
+}
+
+export type KairosCloudBundleProject = {
+  id: string
+  remoteUrl: string
+  normalizedRemoteUrl: string
+  headRef: string
+  headCommit: string
+  defaultBranch?: string
+  repoHost?: string
+  repoOwner?: string
+  repoName?: string
+  scheduledTasksSyncPath?: string
+}
+
+export type KairosCloudStateBundle = {
+  version: 1
+  createdAt: string
+  files: KairosCloudBundleFile[]
+  projects: KairosCloudBundleProject[]
+}
+
+type AppliedManifest = {
+  version: 1
+  appliedAt: string
+  bundleCreatedAt: string
+  managedPaths: string[]
+  fileChecksums: Record<string, string>
+  projects: KairosCloudBundleProject[]
+}
+
+export type ApplyKairosCloudStateBundleResult = {
+  sourceDir: string
+  overlayDir: string
+  manifestPath: string
+  registryPath: string
+  managedPaths: string[]
+}
+
+export type BuildKairosCloudStateBundleOptions = {
+  now?: () => Date
+  readProjects?: () => Promise<string[]>
+  resolveProjectMetadata?: (
+    projectDir: string,
+  ) => Promise<KairosCloudBundleProject>
+}
+
+export type ApplyKairosCloudStateBundleOptions = {
+  runtimeRoot: string
+  now?: () => Date
+}
+
+function toPortableRelativePath(value: string): string {
+  return value.split(sep).join('/')
+}
+
+function createSha256(content: Uint8Array): string {
+  return createHash('sha256').update(content).digest('hex')
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function collectDirectoryFiles(
+  sourceDir: string,
+  targetRoot: string,
+  options: { ignoredDirNames?: Set<string> } = {},
+): Promise<KairosCloudBundleFile[]> {
+  if (!(await pathExists(sourceDir))) {
+    return []
+  }
+
+  const out: KairosCloudBundleFile[] = []
+  const stack = [sourceDir]
+
+  while (stack.length > 0) {
+    const current = stack.pop()!
+    const entries = await readdir(current, { withFileTypes: true })
+    entries.sort((a, b) => a.name.localeCompare(b.name))
+
+    for (const entry of entries) {
+      const fullPath = join(current, entry.name)
+      if (entry.isDirectory()) {
+        if (options.ignoredDirNames?.has(entry.name)) {
+          continue
+        }
+        stack.push(fullPath)
+        continue
+      }
+      if (!entry.isFile()) {
+        continue
+      }
+
+      const raw = await readFile(fullPath)
+      const rel = relative(sourceDir, fullPath)
+      out.push({
+        relativePath: toPortableRelativePath(join(targetRoot, rel)),
+        sizeBytes: raw.byteLength,
+        sha256: createSha256(raw),
+        contentBase64: raw.toString('base64'),
+      })
+    }
+  }
+
+  out.sort((a, b) => a.relativePath.localeCompare(b.relativePath))
+  return out
+}
+
+async function collectSkillFiles(configDir: string): Promise<KairosCloudBundleFile[]> {
+  const skillsRoot = join(configDir, 'skills')
+  if (!(await pathExists(skillsRoot))) {
+    return []
+  }
+
+  const out: KairosCloudBundleFile[] = []
+  const stack = [skillsRoot]
+
+  while (stack.length > 0) {
+    const current = stack.pop()!
+    const entries = await readdir(current, { withFileTypes: true })
+    entries.sort((a, b) => a.name.localeCompare(b.name))
+
+    for (const entry of entries) {
+      const fullPath = join(current, entry.name)
+      if (entry.isDirectory()) {
+        if (SKILL_JUNK_DIRS.has(entry.name)) {
+          continue
+        }
+        if (current === skillsRoot && entry.name.startsWith('.')) {
+          continue
+        }
+        stack.push(fullPath)
+        continue
+      }
+      if (!entry.isFile() || entry.name !== 'SKILL.md') {
+        continue
+      }
+
+      const skillDir = current
+      out.push(
+        ...(await collectDirectoryFiles(
+          skillDir,
+          join(CONFIG_ROOT_RELATIVE_PATH, 'skills', relative(skillsRoot, skillDir)),
+          { ignoredDirNames: SKILL_JUNK_DIRS },
+        )),
+      )
+    }
+  }
+
+  const deduped = new Map<string, KairosCloudBundleFile>()
+  for (const file of out) {
+    deduped.set(file.relativePath, file)
+  }
+  return [...deduped.values()].sort((a, b) =>
+    a.relativePath.localeCompare(b.relativePath),
+  )
+}
+
+async function collectKairosMemoryFiles(
+  configDir: string,
+): Promise<KairosCloudBundleFile[]> {
+  const files: KairosCloudBundleFile[] = []
+
+  files.push(
+    ...(await maybeCollectSingleFile(
+      join(configDir, 'memory', 'sessions.db'),
+      join(CONFIG_ROOT_RELATIVE_PATH, 'memory', 'sessions.db'),
+    )),
+  )
+  files.push(
+    ...(await collectDirectoryFiles(
+      join(configDir, 'memory', '.pending-proposals'),
+      join(CONFIG_ROOT_RELATIVE_PATH, 'memory', '.pending-proposals'),
+    )),
+  )
+  files.push(
+    ...(await collectDirectoryFiles(
+      join(configDir, 'memory', '.archived-proposals'),
+      join(CONFIG_ROOT_RELATIVE_PATH, 'memory', '.archived-proposals'),
+    )),
+  )
+
+  return files
+}
+
+async function maybeCollectSingleFile(
+  sourcePath: string,
+  relativePath: string,
+): Promise<KairosCloudBundleFile[]> {
+  if (!(await pathExists(sourcePath))) {
+    return []
+  }
+  const raw = await readFile(sourcePath)
+  return [
+    {
+      relativePath: toPortableRelativePath(relativePath),
+      sizeBytes: raw.byteLength,
+      sha256: createSha256(raw),
+      contentBase64: raw.toString('base64'),
+    },
+  ]
+}
+
+async function readProjectsFromRegistry(): Promise<string[]> {
+  const registry = await createProjectRegistry()
+  return registry.read()
+}
+
+async function gitString(
+  projectDir: string,
+  args: string[],
+  errorContext: string,
+): Promise<string> {
+  const result = await execFileNoThrowWithCwd(gitExe(), args, {
+    cwd: projectDir,
+    timeout: GIT_PROBE_TIMEOUT_MS,
+    preserveOutputOnError: true,
+  })
+  if (result.code !== 0) {
+    throw new KairosCloudSyncError(
+      `Project ${projectDir} ${errorContext}: ${result.stderr.trim() || result.error || 'git command failed'}`,
+    )
+  }
+  const value = result.stdout.trim()
+  if (!value) {
+    throw new KairosCloudSyncError(
+      `Project ${projectDir} ${errorContext}: empty git output`,
+    )
+  }
+  return value
+}
+
+export async function resolveKairosCloudProjectMetadata(
+  projectDir: string,
+): Promise<KairosCloudBundleProject> {
+  const remoteUrl = await gitString(
+    projectDir,
+    ['remote', 'get-url', 'origin'],
+    'has no git remote configured',
+  )
+
+  const probe = await execFileNoThrowWithCwd(
+    gitExe(),
+    ['ls-remote', '--exit-code', remoteUrl, 'HEAD'],
+    {
+      cwd: projectDir,
+      timeout: GIT_PROBE_TIMEOUT_MS,
+      preserveOutputOnError: true,
+    },
+  )
+  if (probe.code !== 0) {
+    throw new KairosCloudSyncError(
+      `Project ${projectDir} has no reachable git remote: ${remoteUrl}`,
+    )
+  }
+
+  const headRef = await gitString(
+    projectDir,
+    ['rev-parse', '--abbrev-ref', 'HEAD'],
+    'could not resolve the current branch',
+  )
+  const headCommit = await gitString(
+    projectDir,
+    ['rev-parse', 'HEAD'],
+    'could not resolve HEAD',
+  )
+
+  const defaultBranchResult = await execFileNoThrowWithCwd(
+    gitExe(),
+    ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+    {
+      cwd: projectDir,
+      timeout: GIT_PROBE_TIMEOUT_MS,
+      preserveOutputOnError: true,
+    },
+  )
+  const defaultBranch =
+    defaultBranchResult.code === 0
+      ? defaultBranchResult.stdout.trim().split('/').pop()
+      : undefined
+
+  const normalizedRemoteUrl = normalizeGitRemoteUrl(remoteUrl) ?? remoteUrl
+  const parsedRemote = parseGitRemote(remoteUrl)
+  const id = createHash('sha256')
+    .update(`${normalizedRemoteUrl}\n${headRef === 'HEAD' ? headCommit : headRef}`)
+    .digest('hex')
+    .slice(0, 16)
+
+  return {
+    id,
+    remoteUrl,
+    normalizedRemoteUrl,
+    headRef,
+    headCommit,
+    ...(defaultBranch ? { defaultBranch } : {}),
+    ...(parsedRemote
+      ? {
+          repoHost: parsedRemote.host,
+          repoOwner: parsedRemote.owner,
+          repoName: parsedRemote.name,
+        }
+      : {}),
+  }
+}
+
+export async function buildKairosCloudStateBundle(
+  options: BuildKairosCloudStateBundleOptions = {},
+): Promise<KairosCloudStateBundle> {
+  const now = options.now ?? (() => new Date())
+  const configDir = getClaudeConfigHomeDir()
+  const readProjects = options.readProjects ?? readProjectsFromRegistry
+  const resolveProjectMetadata =
+    options.resolveProjectMetadata ?? resolveKairosCloudProjectMetadata
+
+  const files: KairosCloudBundleFile[] = []
+  files.push(...(await collectSkillFiles(configDir)))
+  files.push(...(await collectKairosMemoryFiles(configDir)))
+
+  const projects = await readProjects()
+  const resolvedProjects: KairosCloudBundleProject[] = []
+  for (const projectDir of [...projects].sort()) {
+    const project = await resolveProjectMetadata(projectDir)
+    const scheduledTasksSyncPath = toPortableRelativePath(
+      join(PROJECT_SYNC_ROOT_RELATIVE_PATH, project.id, '.claude', 'scheduled_tasks.json'),
+    )
+    files.push(
+      ...(await maybeCollectSingleFile(
+        join(projectDir, '.claude', 'scheduled_tasks.json'),
+        scheduledTasksSyncPath,
+      )),
+    )
+    resolvedProjects.push({
+      ...project,
+      ...(await pathExists(join(projectDir, '.claude', 'scheduled_tasks.json'))
+        ? { scheduledTasksSyncPath }
+        : {}),
+    })
+  }
+
+  files.sort((a, b) => a.relativePath.localeCompare(b.relativePath))
+  resolvedProjects.sort((a, b) => a.id.localeCompare(b.id))
+
+  return {
+    version: CLOUD_SYNC_VERSION,
+    createdAt: now().toISOString(),
+    files,
+    projects: resolvedProjects,
+  }
+}
+
+export function getKairosCloudSourceDir(runtimeRoot: string): string {
+  return join(runtimeRoot, SOURCE_DIRNAME)
+}
+
+export function getKairosCloudOverlayDir(runtimeRoot: string): string {
+  return join(runtimeRoot, OVERLAY_DIRNAME)
+}
+
+export function getKairosCloudRegistryPath(runtimeRoot: string): string {
+  return join(getKairosCloudSourceDir(runtimeRoot), REGISTRY_RELATIVE_PATH)
+}
+
+export function getKairosCloudManifestPath(runtimeRoot: string): string {
+  return join(getKairosCloudSourceDir(runtimeRoot), MANIFEST_RELATIVE_PATH)
+}
+
+export function getKairosCloudOverlayStateDir(runtimeRoot: string): string {
+  return join(getKairosCloudOverlayDir(runtimeRoot), 'config', '.claude', 'kairos')
+}
+
+export function getKairosCloudProjectOverlayDir(
+  runtimeRoot: string,
+  projectId: string,
+): string {
+  return join(
+    getKairosCloudOverlayDir(runtimeRoot),
+    'projects',
+    projectId,
+    '.claude',
+    'kairos',
+  )
+}
+
+function createRegistryContent(bundle: KairosCloudStateBundle): Buffer {
+  return Buffer.from(
+    `${jsonStringify(
+      {
+        version: CLOUD_SYNC_VERSION,
+        syncedAt: bundle.createdAt,
+        projects: bundle.projects,
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  )
+}
+
+function createManifestContent(
+  appliedAt: string,
+  bundle: KairosCloudStateBundle,
+  managedPaths: string[],
+): Buffer {
+  const fileChecksums: Record<string, string> = {}
+  for (const file of bundle.files) {
+    fileChecksums[file.relativePath] = file.sha256
+  }
+  fileChecksums[REGISTRY_RELATIVE_PATH] = createSha256(createRegistryContent(bundle))
+
+  const manifest: AppliedManifest = {
+    version: CLOUD_SYNC_VERSION,
+    appliedAt,
+    bundleCreatedAt: bundle.createdAt,
+    managedPaths,
+    fileChecksums,
+    projects: bundle.projects,
+  }
+
+  return Buffer.from(`${jsonStringify(manifest, null, 2)}\n`, 'utf8')
+}
+
+async function readAppliedManifest(
+  manifestPath: string,
+): Promise<AppliedManifest | null> {
+  try {
+    const raw = await readFile(manifestPath, 'utf8')
+    const parsed = JSON.parse(raw) as Partial<AppliedManifest>
+    if (
+      parsed.version !== CLOUD_SYNC_VERSION ||
+      !Array.isArray(parsed.managedPaths) ||
+      typeof parsed.bundleCreatedAt !== 'string' ||
+      typeof parsed.appliedAt !== 'string'
+    ) {
+      return null
+    }
+    return {
+      version: CLOUD_SYNC_VERSION,
+      appliedAt: parsed.appliedAt,
+      bundleCreatedAt: parsed.bundleCreatedAt,
+      managedPaths: parsed.managedPaths.filter(
+        value => typeof value === 'string',
+      ),
+      fileChecksums:
+        parsed.fileChecksums && typeof parsed.fileChecksums === 'object'
+          ? Object.fromEntries(
+              Object.entries(parsed.fileChecksums).filter(
+                ([key, value]) =>
+                  typeof key === 'string' && typeof value === 'string',
+              ),
+            )
+          : {},
+      projects: Array.isArray(parsed.projects)
+        ? (parsed.projects as KairosCloudBundleProject[])
+        : [],
+    }
+  } catch {
+    return null
+  }
+}
+
+async function pruneEmptyParents(
+  startDir: string,
+  stopDir: string,
+): Promise<void> {
+  let current = startDir
+  while (current.startsWith(stopDir) && current !== stopDir) {
+    const entries = await readdir(current).catch(() => null)
+    if (!entries || entries.length > 0) {
+      return
+    }
+    await rm(current, { recursive: false, force: true }).catch(() => {})
+    current = dirname(current)
+  }
+}
+
+async function writeManagedFile(path: string, content: Buffer): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tempPath = `${path}.${randomUUID()}.tmp`
+  await writeFile(tempPath, content)
+  await rename(tempPath, path)
+  await chmod(path, READONLY_MODE)
+}
+
+export async function applyKairosCloudStateBundle(
+  bundle: KairosCloudStateBundle,
+  options: ApplyKairosCloudStateBundleOptions,
+): Promise<ApplyKairosCloudStateBundleResult> {
+  const now = options.now ?? (() => new Date())
+  const sourceDir = getKairosCloudSourceDir(options.runtimeRoot)
+  const overlayDir = getKairosCloudOverlayDir(options.runtimeRoot)
+  const manifestPath = getKairosCloudManifestPath(options.runtimeRoot)
+  const registryPath = getKairosCloudRegistryPath(options.runtimeRoot)
+
+  await mkdir(sourceDir, { recursive: true })
+  await mkdir(getKairosCloudOverlayStateDir(options.runtimeRoot), {
+    recursive: true,
+    mode: OVERLAY_DIR_MODE,
+  })
+  for (const project of bundle.projects) {
+    await mkdir(getKairosCloudProjectOverlayDir(options.runtimeRoot, project.id), {
+      recursive: true,
+      mode: OVERLAY_DIR_MODE,
+    })
+  }
+
+  const managedFiles = new Map<string, Buffer>()
+  for (const file of bundle.files) {
+    managedFiles.set(file.relativePath, Buffer.from(file.contentBase64, 'base64'))
+  }
+  managedFiles.set(REGISTRY_RELATIVE_PATH, createRegistryContent(bundle))
+
+  const managedPaths = [...managedFiles.keys(), MANIFEST_RELATIVE_PATH].sort()
+  const appliedAt = now().toISOString()
+  managedFiles.set(
+    MANIFEST_RELATIVE_PATH,
+    createManifestContent(appliedAt, bundle, managedPaths),
+  )
+
+  const previousManifest = await readAppliedManifest(manifestPath)
+  const nextPaths = new Set(managedFiles.keys())
+  for (const previousPath of previousManifest?.managedPaths ?? []) {
+    if (nextPaths.has(previousPath)) {
+      continue
+    }
+    const fullPath = join(sourceDir, previousPath)
+    await rm(fullPath, { force: true })
+    await pruneEmptyParents(dirname(fullPath), sourceDir)
+  }
+
+  for (const relativePath of [...managedFiles.keys()].sort()) {
+    await writeManagedFile(join(sourceDir, relativePath), managedFiles.get(relativePath)!)
+  }
+
+  return {
+    sourceDir,
+    overlayDir,
+    manifestPath,
+    registryPath,
+    managedPaths,
+  }
+}


### PR DESCRIPTION
Implements the core Mac-to-cloud KAIROS sync workflow for #55.

This adds a push-only cloud sync service that builds a read-only source bundle from supported KAIROS state, validates opted-in projects have reachable git remotes, and applies the bundle into a separate cloud source/overlay layout. It also adds a `/kairos cloud-sync <runtimeRoot>` command for local verification and command-level test seams. The sync subset was tightened to real skill directories rooted by `SKILL.md` plus the explicit KAIROS memory database/proposal queues and project scheduled tasks, excluding backup and junk trees. Tests: `bun test 'src 2/daemon/kairos/cloudSync.test.ts' 'src 2/commands/kairos.test.ts'`.