### PR TITLE
Add subsystem traceability index

### DIFF
--- a/src 2/bridge/bridgeUtilities.test.ts
+++ b/src 2/bridge/bridgeUtilities.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test'
+import { validateBridgeId } from './bridgeApi.js'
+import {
+  abbreviateActivity,
+  computeShimmerSegments,
+  getBridgeStatus,
+} from './bridgeStatusUtil.js'
+import { safeFilenameId } from './sessionRunner.js'
+
+describe('bridge utilities', () => {
+  test('rejects unsafe bridge ids and sanitizes file-safe ids', () => {
+    expect(validateBridgeId('env_123-abc', 'environmentId')).toBe('env_123-abc')
+    expect(() => validateBridgeId('../oops', 'environmentId')).toThrow(
+      /unsafe characters/,
+    )
+    expect(() => validateBridgeId('bad/slash', 'environmentId')).toThrow(
+      /unsafe characters/,
+    )
+
+    expect(safeFilenameId('../session/one')).toBe('___session_one')
+    expect(safeFilenameId('session:prod?42')).toBe('session_prod_42')
+  })
+
+  test('derives bridge status with the expected priority order', () => {
+    expect(
+      getBridgeStatus({
+        error: 'boom',
+        connected: true,
+        sessionActive: true,
+        reconnecting: true,
+      }),
+    ).toEqual({ label: 'Remote Control failed', color: 'error' })
+
+    expect(
+      getBridgeStatus({
+        error: undefined,
+        connected: true,
+        sessionActive: false,
+        reconnecting: true,
+      }),
+    ).toEqual({ label: 'Remote Control reconnecting', color: 'warning' })
+
+    expect(
+      getBridgeStatus({
+        error: undefined,
+        connected: false,
+        sessionActive: true,
+        reconnecting: false,
+      }),
+    ).toEqual({ label: 'Remote Control active', color: 'success' })
+  })
+
+  test('splits shimmer segments without losing the original text', () => {
+    const text = 'Read file 😀 done'
+    const segments = computeShimmerSegments(text, 5)
+
+    expect(segments.before + segments.shimmer + segments.after).toBe(text)
+    expect(segments.shimmer.length).toBeGreaterThan(0)
+  })
+
+  test('abbreviates long activity summaries for the bridge trail', () => {
+    const abbreviated = abbreviateActivity(
+      'Running a very long command that should be shortened for the footer',
+    )
+
+    expect(abbreviated.length).toBeLessThanOrEqual(30)
+    expect(abbreviated).toContain('Running')
+  })
+})

--- a/src 2/dist/employee-smoke.js
+++ b/src 2/dist/employee-smoke.js
@@ -48466,7 +48466,7 @@ var require_package = __commonJS((exports, module) => {
 
 // node_modules/@aws-sdk/util-user-agent-node/dist-cjs/index.js
 var require_dist_cjs72 = __commonJS((exports) => {
-  var __dirname = "/Users/gaganarora/conductor/workspaces/again/cayenne/src 2/node_modules/@aws-sdk/util-user-agent-node/dist-cjs";
+  var __dirname = "/Users/gaganarora/conductor/workspaces/again/stuttgart-v1/src 2/node_modules/@aws-sdk/util-user-agent-node/dist-cjs";
   var node_os = __require("os");
   var node_process = __require("process");
   var utilConfigProvider = require_dist_cjs57();
@@ -104004,7 +104004,8 @@ async function readCronTasks(dir) {
       createdAt: t2.createdAt,
       ...typeof t2.lastFiredAt === "number" ? { lastFiredAt: t2.lastFiredAt } : {},
       ...t2.recurring ? { recurring: true } : {},
-      ...t2.permanent ? { permanent: true } : {}
+      ...t2.permanent ? { permanent: true } : {},
+      ...typeof t2.kind === "string" && t2.kind.length > 0 ? { kind: t2.kind } : {}
     });
   }
   return out;
@@ -104018,14 +104019,15 @@ async function writeCronTasks(tasks, dir) {
   await writeFile3(getCronFilePath(root2), jsonStringify(body, null, 2) + `
 `, "utf-8");
 }
-async function addCronTask(cron, prompt, recurring, durable, agentId) {
+async function addCronTask(cron, prompt, recurring, durable, agentId, kind) {
   const id = randomUUID4().slice(0, 8);
   const task = {
     id,
     cron,
     prompt,
     createdAt: Date.now(),
-    ...recurring ? { recurring: true } : {}
+    ...recurring ? { recurring: true } : {},
+    ...kind ? { kind } : {}
   };
   if (!durable) {
     addSessionCronTask({ ...task, ...agentId ? { agentId } : {} });

--- a/src 2/docs/navigation.md
+++ b/src 2/docs/navigation.md
@@ -1,0 +1,25 @@
+# MAGIC DOC: Repo navigation
+_Keep this doc terse. Send readers to `./subsystems.yaml` first, then to the listed entry files and verification commands._
+
+This repo's checked-in subsystem map lives in [subsystems.yaml](./subsystems.yaml).
+
+Use it in this order:
+
+1. Match the file you want to touch against the most specific `owned_paths` entry.
+2. Read the subsystem's `entry_files` before scanning neighboring modules.
+3. Check `high_risk_paths` and `change_expectation` to decide whether the change is likely `trunk-safe` or `trunk-touch`.
+4. Run the subsystem's listed verification commands or tests before widening the diff.
+
+Governance anchors:
+
+- [CODEOWNERS](../../.github/CODEOWNERS)
+- [trunk-guard workflow](../../.github/workflows/trunk-guard.yml)
+
+The subsystem manifest is intentionally partial. It covers the core runtime slices that are easiest to break with broad edits:
+
+- CLI / session loop
+- AgentTool / subagents
+- MCP / IDE bridge
+- daemon / KAIROS surfaces
+- state persistence
+- telemetry / diagnostics

--- a/src 2/docs/subsystems.yaml
+++ b/src 2/docs/subsystems.yaml
@@ -1,0 +1,279 @@
+schema_version: 1
+manifest_owner: "@gagan114662"
+matching_rule: "Treat owned_paths as repo-relative prefixes. When several entries match a file, use the most specific prefix."
+governance_files:
+  - ".github/CODEOWNERS"
+  - ".github/workflows/trunk-guard.yml"
+magic_docs:
+  - "src 2/docs/navigation.md"
+subsystems:
+  - id: "cli-session-loop"
+    name: "CLI / session loop"
+    owner: "@gagan114662"
+    reviewer_expectation: "Escalate before changing startup routing, prompt assembly, or query contracts. This slice usually crosses trunk-guarded files."
+    change_expectation: "trunk-touch"
+    owned_paths:
+      - "src 2/entrypoints/"
+      - "src 2/main.tsx"
+      - "src 2/replLauncher.tsx"
+      - "src 2/interactiveHelpers.tsx"
+      - "src 2/query.ts"
+      - "src 2/query/"
+      - "src 2/commands.ts"
+      - "src 2/context.ts"
+    high_risk_paths:
+      - "src 2/QueryEngine.ts"
+      - "src 2/Task.ts"
+      - "src 2/Tool.ts"
+      - "src 2/query/"
+      - "src 2/context.ts"
+    entry_files:
+      - "src 2/entrypoints/cli.tsx"
+      - "src 2/main.tsx"
+      - "src 2/query.ts"
+    neighboring_modules:
+      - "src 2/replLauncher.tsx"
+      - "src 2/interactiveHelpers.tsx"
+      - "src 2/commands.ts"
+      - "src 2/context.ts"
+      - "src 2/QueryEngine.ts"
+    tests:
+      files: []
+      commands:
+        - "bun run smoke:cli"
+        - "bun run smoke:bundle"
+    exercise:
+      commands:
+        - "bun ./entrypoints/cli.tsx --version"
+        - "bun ./dist/cli.js --version"
+      tools: []
+    common_failure_modes:
+      - "Fast-path argument handling drifts from the main initialization path."
+      - "Prompt assembly changes break query budgeting or session restore assumptions."
+      - "Command registration and REPL rendering fall out of sync after startup edits."
+
+  - id: "agenttool-subagents"
+    name: "AgentTool / subagents"
+    owner: "@gagan114662"
+    reviewer_expectation: "Normal edits are usually leaf-safe inside tools and tasks. Escalate when worktree isolation, async task lifecycle, or agent prompt contracts change."
+    change_expectation: "trunk-safe"
+    owned_paths:
+      - "src 2/tools/AgentTool/"
+      - "src 2/tasks/LocalAgentTask/"
+      - "src 2/tasks/RemoteAgentTask/"
+      - "src 2/tasks/InProcessTeammateTask/"
+      - "src 2/tools/shared/spawnMultiAgent.ts"
+      - "src 2/tools/SendMessageTool/"
+      - "src 2/tools/TeamCreateTool/"
+    high_risk_paths:
+      - "src 2/tools/AgentTool/runAgent.ts"
+      - "src 2/tools/AgentTool/forkSubagent.ts"
+      - "src 2/tasks/LocalAgentTask/LocalAgentTask.tsx"
+      - "src 2/tasks/RemoteAgentTask/RemoteAgentTask.tsx"
+      - "src 2/tools/shared/spawnMultiAgent.ts"
+    entry_files:
+      - "src 2/tools/AgentTool/AgentTool.tsx"
+      - "src 2/tools/AgentTool/runAgent.ts"
+      - "src 2/tools/AgentTool/loadAgentsDir.ts"
+    neighboring_modules:
+      - "src 2/tools/AgentTool/forkSubagent.ts"
+      - "src 2/tasks/LocalAgentTask/LocalAgentTask.tsx"
+      - "src 2/tasks/RemoteAgentTask/RemoteAgentTask.tsx"
+      - "src 2/tasks/InProcessTeammateTask/InProcessTeammateTask.tsx"
+      - "src 2/tools/shared/spawnMultiAgent.ts"
+    tests:
+      files: []
+      commands:
+        - "bun run smoke:employee"
+    exercise:
+      commands:
+        - "bun ./scripts/employeeSmoke.ts"
+      tools:
+        - "AgentTool"
+        - "SendMessageTool"
+        - "TaskCreateTool"
+        - "TaskGetTool"
+        - "TaskOutputTool"
+    common_failure_modes:
+      - "Background and foreground task states diverge, leaving orphaned or invisible agent runs."
+      - "Worktree or remote isolation changes leak cwd, permissions, or messages across agents."
+      - "Agent schema changes break built-in agent selection or teammate routing."
+
+  - id: "mcp-ide-bridge"
+    name: "MCP / IDE bridge"
+    owner: "@gagan114662"
+    reviewer_expectation: "Treat connection lifecycle, auth, and remote-control surfaces as high risk. Use the dedicated MCP and bridge utility tests for regression checks, then follow with command-level smoke for connection and CLI surfaces."
+    change_expectation: "trunk-safe"
+    owned_paths:
+      - "src 2/services/mcp/"
+      - "src 2/bridge/"
+      - "src 2/commands/mcp/"
+      - "src 2/commands/ide/"
+    high_risk_paths:
+      - "src 2/services/mcp/client.ts"
+      - "src 2/bridge/bridgeMain.ts"
+      - "src 2/bridge/replBridge.ts"
+      - "src 2/bridge/createSession.ts"
+      - "src 2/services/mcp/MCPConnectionManager.tsx"
+    entry_files:
+      - "src 2/services/mcp/client.ts"
+      - "src 2/bridge/bridgeMain.ts"
+      - "src 2/bridge/createSession.ts"
+    neighboring_modules:
+      - "src 2/services/mcp/MCPConnectionManager.tsx"
+      - "src 2/services/mcp/config.ts"
+      - "src 2/bridge/replBridge.ts"
+      - "src 2/bridge/sessionRunner.ts"
+      - "src 2/commands/ide/ide.tsx"
+    tests:
+      files:
+        - "src 2/services/mcp/client.test.ts"
+        - "src 2/bridge/bridgeUtilities.test.ts"
+      commands:
+        - "bun test ./services/mcp/client.test.ts ./bridge/bridgeUtilities.test.ts"
+        - "bun run smoke:cli"
+        - "bun ./entrypoints/cli.tsx mcp --help"
+        - "bun ./entrypoints/cli.tsx ide --help"
+        - "bun ./entrypoints/cli.tsx remote-control --help"
+    exercise:
+      commands:
+        - "claude mcp"
+        - "claude ide"
+        - "claude remote-control"
+      tools:
+        - "MCPTool"
+        - "ListMcpResourcesTool"
+        - "ReadMcpResourceTool"
+        - "WebFetchTool"
+    common_failure_modes:
+      - "Auth refresh or session expiry handling leaves clients permanently disconnected."
+      - "Bridge session state drifts between local state, claude.ai, and IDE callbacks."
+      - "Tool or resource discovery changes silently hide MCP capabilities from the model."
+
+  - id: "daemon-kairos"
+    name: "daemon / KAIROS surfaces"
+    owner: "@gagan114662"
+    reviewer_expectation: "Daemon work is leaf-safe until it changes child-run policy, persisted state layout, or dashboard/control contracts."
+    change_expectation: "trunk-safe"
+    owned_paths:
+      - "src 2/daemon/"
+      - "src 2/commands/kairos.ts"
+      - "src 2/commands/kairos-skill-improvements.ts"
+      - "src 2/commands/kairos-memory-proposals.ts"
+    high_risk_paths:
+      - "src 2/daemon/main.ts"
+      - "src 2/daemon/kairos/worker.ts"
+      - "src 2/daemon/kairos/childRunner.ts"
+      - "src 2/daemon/kairos/cloudSync.ts"
+      - "src 2/daemon/dashboard/server.ts"
+    entry_files:
+      - "src 2/daemon/main.ts"
+      - "src 2/daemon/kairos/worker.ts"
+      - "src 2/commands/kairos.ts"
+    neighboring_modules:
+      - "src 2/daemon/kairos/projectWorker.ts"
+      - "src 2/daemon/kairos/stateWriter.ts"
+      - "src 2/daemon/kairos/tier3.ts"
+      - "src 2/daemon/dashboard/server.ts"
+      - "src 2/daemon/gateway/telegram/gateway.ts"
+    tests:
+      files:
+        - "src 2/commands/kairos.test.ts"
+        - "src 2/daemon/kairos/worker.test.ts"
+        - "src 2/daemon/kairos/projectWorker.test.ts"
+        - "src 2/daemon/kairos/childRunner.test.ts"
+        - "src 2/daemon/dashboard/server.test.ts"
+      commands:
+        - "bun test ./commands/kairos.test.ts ./daemon/kairos/worker.test.ts ./daemon/dashboard/server.test.ts"
+    exercise:
+      commands:
+        - "claude /kairos status"
+        - "claude daemon kairos"
+      tools: []
+    common_failure_modes:
+      - "Pause, auth-failure, or cap-hit state is written inconsistently across status files and event logs."
+      - "Project workers double-run or skip scheduled tasks after backpressure and abort races."
+      - "Dashboard and terminal controls disagree because they stop sharing the same on-disk model."
+
+  - id: "state-persistence"
+    name: "State persistence"
+    owner: "@gagan114662"
+    reviewer_expectation: "Assume changes are trunk-touch when they alter session identity, app state shape, transcript layout, or durable memory paths."
+    change_expectation: "trunk-touch"
+    owned_paths:
+      - "src 2/state/"
+      - "src 2/bootstrap/state.ts"
+      - "src 2/utils/sessionStorage.ts"
+      - "src 2/services/memory/"
+    high_risk_paths:
+      - "src 2/bootstrap/state.ts"
+      - "src 2/state/AppStateStore.ts"
+      - "src 2/utils/sessionStorage.ts"
+      - "src 2/services/memory/sessionIndex.ts"
+      - "src 2/services/memory/sessionSummaryTask.ts"
+    entry_files:
+      - "src 2/state/AppStateStore.ts"
+      - "src 2/utils/sessionStorage.ts"
+      - "src 2/services/memory/sessionIndex.ts"
+    neighboring_modules:
+      - "src 2/state/onChangeAppState.ts"
+      - "src 2/bootstrap/state.ts"
+      - "src 2/services/memory/sessionSummaryTask.ts"
+      - "src 2/services/memory/summarizeSession.ts"
+      - "src 2/services/memory/paths.ts"
+    tests:
+      files:
+        - "src 2/services/memory/sessionIndex.test.ts"
+        - "src 2/services/memory/sessionSummaryTask.test.ts"
+        - "src 2/services/memory/summarizeSession.test.ts"
+      commands:
+        - "bun test ./services/memory/sessionIndex.test.ts ./services/memory/sessionSummaryTask.test.ts ./services/memory/summarizeSession.test.ts"
+    exercise:
+      commands:
+        - "claude /resume"
+        - "claude /memory"
+      tools:
+        - "RecallPastSessionsTool"
+    common_failure_modes:
+      - "Transcript parent chains or tombstoning rules regress and break resume."
+      - "AppState shape changes stop hydrating cleanly across interactive sessions."
+      - "SQLite or on-disk memory files drift from the summaries the UI expects."
+
+  - id: "telemetry-diagnostics"
+    name: "Telemetry / diagnostics"
+    owner: "@gagan114662"
+    reviewer_expectation: "Keep telemetry metadata redacted, and treat diagnostics fetching as user-visible latency. Escalate before changing sinks or privacy boundaries."
+    change_expectation: "trunk-safe"
+    owned_paths:
+      - "src 2/services/analytics/"
+      - "src 2/services/diagnosticTracking.ts"
+      - "src 2/services/internalLogging.ts"
+      - "src 2/utils/telemetry/"
+    high_risk_paths:
+      - "src 2/services/analytics/index.ts"
+      - "src 2/services/analytics/sink.ts"
+      - "src 2/services/analytics/firstPartyEventLoggingExporter.ts"
+      - "src 2/services/analytics/datadog.ts"
+      - "src 2/services/diagnosticTracking.ts"
+    entry_files:
+      - "src 2/services/analytics/index.ts"
+      - "src 2/services/analytics/sink.ts"
+      - "src 2/services/diagnosticTracking.ts"
+    neighboring_modules:
+      - "src 2/services/analytics/datadog.ts"
+      - "src 2/services/analytics/firstPartyEventLoggingExporter.ts"
+      - "src 2/services/analytics/growthbook.ts"
+      - "src 2/hooks/useIdeLogging.ts"
+      - "src 2/utils/log.ts"
+    tests:
+      files: []
+      commands:
+        - "bun run smoke:cli"
+    exercise:
+      commands:
+        - "claude --verbose"
+      tools: []
+    common_failure_modes:
+      - "New metadata leaks code, paths, or PII into general-access analytics backends."
+      - "Queued events never flush because sinks attach too late or reset unexpectedly."
+      - "Diagnostics baselines go stale and report old IDE problems as new regressions."

--- a/src 2/package.json
+++ b/src 2/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "bun ./entrypoints/cli.tsx",
     "test": "bun test",
+    "subsystems:validate": "bun ./scripts/validateSubsystems.ts",
     "structural-fix:resolver-eval": "bun ./scripts/structuralFixResolverEval.ts",
     "structural-fix:smoke": "bun ./scripts/structuralFixSmoke.ts",
     "structural-fix:daily": "bun test ./services/structuralFix/structuralFix.test.ts ./utils/skills/repoSkillResolver.test.ts ./utils/skills/repoSkillAutoload.test.ts ./utils/processUserInput/processUserInput.test.ts && bun run structural-fix:resolver-eval && bun run structural-fix:smoke",

--- a/src 2/scripts/validateSubsystems.test.ts
+++ b/src 2/scripts/validateSubsystems.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { validateSubsystemManifest } from './validateSubsystems.js'
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(MODULE_DIR, '../..')
+
+function writeFileEnsuringDir(path: string, contents = ''): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, contents)
+}
+
+describe('validateSubsystemManifest', () => {
+  test('accepts the checked-in subsystem manifest', () => {
+    const result = validateSubsystemManifest({
+      repoRoot: REPO_ROOT,
+      manifestPath: join(REPO_ROOT, 'src 2/docs/subsystems.yaml'),
+    })
+    expect(result.manifest.subsystems.length).toBeGreaterThanOrEqual(6)
+    expect(result.checkedPathCount).toBeGreaterThan(0)
+  })
+
+  test('rejects a manifest with a missing referenced path', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'subsystems-fixture-'))
+    try {
+      writeFileEnsuringDir(join(repoRoot, '.github/CODEOWNERS'))
+      writeFileEnsuringDir(join(repoRoot, 'docs/navigation.md'), '# MAGIC DOC: Nav\n')
+      writeFileEnsuringDir(join(repoRoot, 'src/entry.ts'))
+
+      const manifestPath = join(repoRoot, 'docs/subsystems.yaml')
+      writeFileSync(
+        manifestPath,
+        `schema_version: 1
+manifest_owner: "@owner"
+matching_rule: "most specific prefix wins"
+governance_files:
+  - ".github/CODEOWNERS"
+magic_docs:
+  - "docs/navigation.md"
+subsystems:
+  - id: "fixture"
+    name: "Fixture"
+    owner: "@owner"
+    reviewer_expectation: "Test fixture."
+    change_expectation: "trunk-safe"
+    owned_paths:
+      - "src/"
+    high_risk_paths:
+      - "src/missing.ts"
+    entry_files:
+      - "src/entry.ts"
+    neighboring_modules:
+      - "src/entry.ts"
+    tests:
+      files: []
+      commands:
+        - "bun test"
+    exercise:
+      commands:
+        - "bun run fixture"
+      tools: []
+    common_failure_modes:
+      - "Fixture failure."
+`,
+      )
+
+      expect(() =>
+        validateSubsystemManifest({
+          repoRoot,
+          manifestPath,
+        }),
+      ).toThrow(/src\/missing\.ts/)
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/src 2/scripts/validateSubsystems.ts
+++ b/src 2/scripts/validateSubsystems.ts
@@ -1,0 +1,203 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, isAbsolute, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse as parseYaml } from 'yaml'
+import { z } from 'zod/v4'
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url))
+const DEFAULT_REPO_ROOT = resolve(MODULE_DIR, '../..')
+const DEFAULT_MANIFEST_PATH = resolve(
+  DEFAULT_REPO_ROOT,
+  'src 2/docs/subsystems.yaml',
+)
+
+const testsSchema = z.object({
+  files: z.array(z.string().min(1)),
+  commands: z.array(z.string().min(1)),
+})
+
+const exerciseSchema = z.object({
+  commands: z.array(z.string().min(1)),
+  tools: z.array(z.string().min(1)),
+})
+
+const subsystemSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  owner: z.string().min(1),
+  reviewer_expectation: z.string().min(1),
+  change_expectation: z.enum(['trunk-safe', 'trunk-touch']),
+  owned_paths: z.array(z.string().min(1)).min(1),
+  high_risk_paths: z.array(z.string().min(1)).min(1),
+  entry_files: z.array(z.string().min(1)).min(1),
+  neighboring_modules: z.array(z.string().min(1)).min(1),
+  tests: testsSchema,
+  exercise: exerciseSchema,
+  common_failure_modes: z.array(z.string().min(1)).min(1),
+})
+
+const manifestSchema = z.object({
+  schema_version: z.literal(1),
+  manifest_owner: z.string().min(1),
+  matching_rule: z.string().min(1),
+  governance_files: z.array(z.string().min(1)).min(1),
+  magic_docs: z.array(z.string().min(1)).min(1),
+  subsystems: z.array(subsystemSchema).min(1),
+})
+
+type SubsystemManifest = z.infer<typeof manifestSchema>
+
+function resolveFromRepoRoot(repoRoot: string, value: string): string {
+  return isAbsolute(value) ? value : resolve(repoRoot, value)
+}
+
+function validateExistingPath(
+  repoRoot: string,
+  value: string,
+  label: string,
+  errors: string[],
+): void {
+  const resolvedPath = resolveFromRepoRoot(repoRoot, value)
+  if (!existsSync(resolvedPath)) {
+    errors.push(`${label} does not exist: ${value}`)
+  }
+}
+
+function validateUniqueStrings(
+  values: string[],
+  label: string,
+  errors: string[],
+): void {
+  const seen = new Set<string>()
+  for (const value of values) {
+    if (seen.has(value)) {
+      errors.push(`Duplicate ${label}: ${value}`)
+      continue
+    }
+    seen.add(value)
+  }
+}
+
+export function parseSubsystemManifest(rawManifest: string): SubsystemManifest {
+  return manifestSchema.parse(parseYaml(rawManifest))
+}
+
+export function validateSubsystemManifest(params?: {
+  manifestPath?: string
+  repoRoot?: string
+}): {
+  manifest: SubsystemManifest
+  manifestPath: string
+  repoRoot: string
+  checkedPathCount: number
+} {
+  const repoRoot = params?.repoRoot
+    ? resolve(params.repoRoot)
+    : DEFAULT_REPO_ROOT
+  const manifestPath = params?.manifestPath
+    ? resolve(params.manifestPath)
+    : DEFAULT_MANIFEST_PATH
+  const manifest = parseSubsystemManifest(readFileSync(manifestPath, 'utf8'))
+  const errors: string[] = []
+
+  const topLevelPaths = [...manifest.governance_files, ...manifest.magic_docs]
+  validateUniqueStrings(
+    manifest.subsystems.map(subsystem => subsystem.id),
+    'subsystem id',
+    errors,
+  )
+  validateUniqueStrings(topLevelPaths, 'top-level path reference', errors)
+
+  for (const topLevelPath of topLevelPaths) {
+    validateExistingPath(repoRoot, topLevelPath, 'Referenced path', errors)
+  }
+
+  const ownedPathRegistry = new Map<string, string>()
+  let checkedPathCount = topLevelPaths.length
+
+  for (const subsystem of manifest.subsystems) {
+    const subsystemPathGroups = [
+      ...subsystem.owned_paths,
+      ...subsystem.high_risk_paths,
+      ...subsystem.entry_files,
+      ...subsystem.neighboring_modules,
+      ...subsystem.tests.files,
+    ]
+
+    validateUniqueStrings(
+      subsystem.owned_paths,
+      `${subsystem.id} owned_path`,
+      errors,
+    )
+    validateUniqueStrings(
+      subsystem.high_risk_paths,
+      `${subsystem.id} high_risk_path`,
+      errors,
+    )
+    validateUniqueStrings(
+      subsystem.entry_files,
+      `${subsystem.id} entry_file`,
+      errors,
+    )
+    validateUniqueStrings(
+      subsystem.neighboring_modules,
+      `${subsystem.id} neighboring_module`,
+      errors,
+    )
+    validateUniqueStrings(
+      subsystem.tests.files,
+      `${subsystem.id} test file`,
+      errors,
+    )
+
+    for (const ownedPath of subsystem.owned_paths) {
+      const existingOwner = ownedPathRegistry.get(ownedPath)
+      if (existingOwner) {
+        errors.push(
+          `owned_path ${ownedPath} is claimed by both ${existingOwner} and ${subsystem.id}`,
+        )
+      } else {
+        ownedPathRegistry.set(ownedPath, subsystem.id)
+      }
+    }
+
+    for (const pathValue of subsystemPathGroups) {
+      checkedPathCount += 1
+      validateExistingPath(
+        repoRoot,
+        pathValue,
+        `${subsystem.id} path reference`,
+        errors,
+      )
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(errors.join('\n'))
+  }
+
+  return {
+    manifest,
+    manifestPath,
+    repoRoot,
+    checkedPathCount,
+  }
+}
+
+function main(): void {
+  const manifestArg = process.argv[2]
+  const result = validateSubsystemManifest({
+    manifestPath: manifestArg,
+  })
+  console.log(
+    `Validated ${result.manifest.subsystems.length} subsystems and ${result.checkedPathCount} referenced paths in ${result.manifestPath}`,
+  )
+  console.log('Covered subsystems:')
+  for (const subsystem of result.manifest.subsystems) {
+    console.log(`- ${subsystem.id}: ${subsystem.name}`)
+  }
+}
+
+if (import.meta.main) {
+  main()
+}

--- a/src 2/services/mcp/client.test.ts
+++ b/src 2/services/mcp/client.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import type { ScopedMcpServerConfig } from './types.js'
+import {
+  areMcpConfigsEqual,
+  getMcpServerConnectionBatchSize,
+  getServerCacheKey,
+  inferCompactSchema,
+  isMcpSessionExpiredError,
+  mcpToolInputToAutoClassifierInput,
+} from './client.js'
+
+const ORIGINAL_BATCH_SIZE = process.env.MCP_SERVER_CONNECTION_BATCH_SIZE
+
+afterEach(() => {
+  if (ORIGINAL_BATCH_SIZE === undefined) {
+    delete process.env.MCP_SERVER_CONNECTION_BATCH_SIZE
+  } else {
+    process.env.MCP_SERVER_CONNECTION_BATCH_SIZE = ORIGINAL_BATCH_SIZE
+  }
+})
+
+function makeHttpConfig(
+  overrides: Partial<ScopedMcpServerConfig> = {},
+): ScopedMcpServerConfig {
+  return {
+    scope: 'project',
+    type: 'http',
+    url: 'https://example.com/mcp',
+    headers: { Authorization: 'Bearer token' },
+    ...overrides,
+  } as ScopedMcpServerConfig
+}
+
+describe('MCP client helpers', () => {
+  test('recognizes session-expired 404 errors from MCP servers', () => {
+    const expired = Object.assign(
+      new Error('{"error":{"code":-32001,"message":"Session not found"}}'),
+      { code: 404 },
+    )
+    const generic404 = Object.assign(new Error('Not found'), { code: 404 })
+
+    expect(isMcpSessionExpiredError(expired)).toBe(true)
+    expect(isMcpSessionExpiredError(generic404)).toBe(false)
+    expect(isMcpSessionExpiredError(new Error('{"error":{"code":-32001}}'))).toBe(
+      false,
+    )
+  })
+
+  test('uses the default MCP connection batch size unless overridden', () => {
+    delete process.env.MCP_SERVER_CONNECTION_BATCH_SIZE
+    expect(getMcpServerConnectionBatchSize()).toBe(3)
+
+    process.env.MCP_SERVER_CONNECTION_BATCH_SIZE = '7'
+    expect(getMcpServerConnectionBatchSize()).toBe(7)
+  })
+
+  test('compares MCP configs while ignoring scope metadata', () => {
+    const projectConfig = makeHttpConfig({ scope: 'project' })
+    const localConfig = makeHttpConfig({ scope: 'local' })
+    const changedConfig = makeHttpConfig({
+      headers: { Authorization: 'Bearer different-token' },
+    })
+
+    expect(areMcpConfigsEqual(projectConfig, localConfig)).toBe(true)
+    expect(areMcpConfigsEqual(projectConfig, changedConfig)).toBe(false)
+  })
+
+  test('builds stable cache keys and classifier inputs', () => {
+    const config = makeHttpConfig()
+
+    expect(getServerCacheKey('github', config)).toContain('github-')
+    expect(
+      mcpToolInputToAutoClassifierInput(
+        { path: '/tmp/demo', recursive: true },
+        'mcp__fs__read',
+      ),
+    ).toBe('path=/tmp/demo recursive=true')
+    expect(mcpToolInputToAutoClassifierInput({}, 'mcp__fs__read')).toBe(
+      'mcp__fs__read',
+    )
+  })
+
+  test('infers compact schemas for nested MCP result payloads', () => {
+    expect(
+      inferCompactSchema({
+        title: 'Build',
+        count: 2,
+        items: [{ id: 1, ok: true }],
+      }, 3),
+    ).toBe('{title: string, count: number, items: [{id: number, ok: boolean}]}')
+    expect(inferCompactSchema([], 2)).toBe('[]')
+    expect(inferCompactSchema({ deep: { nested: { value: 1 } } }, 1)).toBe(
+      '{deep: {...}}',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Closes #61.

- add a checked-in subsystem traceability manifest at `src 2/docs/subsystems.yaml`
- add a seeded Magic Doc entrypoint at `src 2/docs/navigation.md`
- add a validator script and test coverage for manifest path integrity
- add concrete MCP and bridge tests so the `mcp-ide-bridge` slice has real test files, not only smoke commands

## Verification

### Scoped typecheck

Command:

```bash
bunx tsc-files --noEmit --ignoreDeprecations 6.0 --pretty false scripts/validateSubsystems.ts scripts/validateSubsystems.test.ts services/mcp/client.test.ts bridge/bridgeUtilities.test.ts
```

Output:

```text
<no output>
```

### Raw `subsystems:validate` output

Command:

```bash
bun run subsystems:validate
```

Output:

```text
$ bun ./scripts/validateSubsystems.ts
Validated 6 subsystems and 122 referenced paths in /Users/gaganarora/conductor/workspaces/again/stuttgart-v1/src 2/docs/subsystems.yaml
Covered subsystems:
- cli-session-loop: CLI / session loop
- agenttool-subagents: AgentTool / subagents
- mcp-ide-bridge: MCP / IDE bridge
- daemon-kairos: daemon / KAIROS surfaces
- state-persistence: State persistence
- telemetry-diagnostics: Telemetry / diagnostics
```

### Additional verification

```bash
bun test ./scripts/validateSubsystems.test.ts ./services/mcp/client.test.ts ./bridge/bridgeUtilities.test.ts
bun run pipeline
```

## Trunk Guard Reality Check

- `trunk-change-approved` is **not required** for this PR under the current rules.
- I checked `.github/workflows/trunk-guard.yml` and `.github/CODEOWNERS`; the touched paths in this PR do not match the trunk-protected patterns.
- `src 2/dist/cli.js` is touched, but it is **not** currently trunk-guarded by those rules.

## Dist Artifact Note

- `src 2/dist/cli.js` changes in this PR are a rebuild artifact, not manually authored source edits.
- `src 2/dist/employee-smoke.js` was also regenerated by the normal build/smoke flow.
- The repo should evaluate either:
  - gitignoring `dist/cli.js` and rebuilding it in CI, or
  - landing rebundles in one dedicated PR after feature merges rather than in every feature PR

I am not opening a separate issue for that here.
