### PR TITLE
Add /kairos status command + root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# KAIROS
+
+KAIROS is a Claude-Code-native personal automation platform under active development in this repository.
+
+Today the repo is a Bun-based CLI/daemon codebase with KAIROS-specific work layered into it: a local background worker, a browser dashboard, reminders, Telegram gateway codepaths, skill import/export, diagnostics, and agent-oriented tooling.
+
+## Current Status
+
+- The main application currently lives under `src 2/`, not `src/`.
+- The root of the repo is intentionally thin: GitHub/workspace metadata at the top level, product code under `src 2/`.
+- KAIROS daemon/dashboard work is present and test-covered, but some command registration and packaging paths are still in progress.
+
+If you are new to the repo, start in:
+
+- `src 2/package.json`
+- `src 2/entrypoints/cli.tsx`
+- `src 2/daemon/main.ts`
+- `src 2/commands/kairos.ts`
+- `src 2/daemon/dashboard/`
+- `src 2/daemon/kairos/`
+
+## Prerequisites
+
+- Bun `1.2.23`
+- macOS or Linux-like shell environment
+
+## Quickstart
+
+```bash
+cd 'src 2'
+bun install --frozen-lockfile
+bun run smoke:cli
+```
+
+Useful validation commands:
+
+```bash
+cd 'src 2'
+bun test
+bun run pipeline
+```
+
+For faster local iteration on KAIROS-specific work:
+
+```bash
+cd 'src 2'
+bun test ./commands/kairos.test.ts
+bun test ./daemon/dashboard/server.test.ts
+```
+
+## Running KAIROS
+
+Start the daemon:
+
+```bash
+cd 'src 2'
+bun ./entrypoints/cli.tsx daemon kairos
+```
+
+The KAIROS dashboard server starts with the daemon and defaults to:
+
+- `http://127.0.0.1:7777/`
+
+Runtime state is file-backed:
+
+- global daemon state: `~/.claude/kairos/`
+- per-project KAIROS state: `<project>/.claude/kairos/`
+- scheduled tasks: `<project>/.claude/scheduled_tasks.json`
+
+Relevant implementation entry points:
+
+- daemon supervisor: `src 2/daemon/main.ts`
+- KAIROS worker: `src 2/daemon/kairos/worker.ts`
+- dashboard server: `src 2/daemon/dashboard/server.ts`
+- terminal command surface: `src 2/commands/kairos.ts`
+- Telegram gateway: `src 2/daemon/gateway/telegram/`
+
+## Repo Layout
+
+- `.github/` — workflows, CODEOWNERS, trunk guard
+- `evals/` — evaluation-related workspace files
+- `src 2/commands/` — command handlers and command UI
+- `src 2/daemon/` — KAIROS daemon, dashboard, gateway, worker state
+- `src 2/services/` — reminders, analytics, MCP, diagnostics, skill learning, API clients
+- `src 2/tools/` — tool implementations exposed to the agent runtime
+- `src 2/tasks/` — task execution surfaces
+- `src 2/entrypoints/` — CLI and SDK entrypoints
+
+## Quality Gates
+
+Main branch protections and checks already present in the repo include:
+
+- CODEOWNERS on trunk paths in `.github/CODEOWNERS`
+- trunk guard workflow in `.github/workflows/trunk-guard.yml`
+- daily structural-fix workflow in `.github/workflows/permanent-structural-fix-daily.yml`
+
+If you are changing guarded architecture paths, expect extra review friction and explicit approval requirements.
+
+## Known Quirks
+
+- The source root is currently `src 2/`; the rename to `src/` is tracked separately because it is broad path churn.
+- There is a `tmp-recover-cli.js` artifact in `src 2/`; do not treat it as a primary source file.
+- Some KAIROS surfaces are intentionally implemented before full trunk registration so the codepaths can be iterated on safely.

--- a/src 2/commands/kairos.test.ts
+++ b/src 2/commands/kairos.test.ts
@@ -7,6 +7,8 @@ import {
   getProjectRoot,
   setProjectRoot,
 } from '../bootstrap/state.js'
+import { createStateWriter } from '../daemon/kairos/stateWriter.js'
+import { writeCronTasks } from '../utils/cronTasks.js'
 import {
   __resetKairosCloudSyncDepsForTesting,
   __setKairosCloudSyncDepsForTesting,
@@ -30,6 +32,52 @@ function makeProjectDir(): string {
 
 function readJson(path: string): unknown {
   return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+async function seedKairosProjectState(projectDir: string): Promise<void> {
+  const writer = await createStateWriter()
+  await writer.ensureProjectDir(projectDir)
+  await writer.writeGlobalStatus({
+    kind: 'kairos',
+    state: 'idle',
+    pid: 4242,
+    startedAt: '2026-04-22T12:00:00Z',
+    updatedAt: '2026-04-22T12:01:00Z',
+    projects: 1,
+    lastEventAt: '2026-04-22T12:01:30Z',
+  })
+  await writer.writeProjectStatus({
+    projectDir,
+    running: true,
+    dirty: true,
+    pendingCount: 2,
+    lastEvent: 'overlap_coalesced',
+    nextFireAt: 1_746_000_000_000,
+    updatedAt: '2026-04-22T12:01:15Z',
+  })
+  await writer.writeGlobalCosts({
+    totalUSD: 0.25,
+    totalTurns: 3,
+    runs: 2,
+    updatedAt: '2026-04-22T12:01:00Z',
+  })
+  await writer.writeProjectCosts(projectDir, {
+    totalUSD: 0.15,
+    totalTurns: 2,
+    runs: 1,
+    updatedAt: '2026-04-22T12:01:00Z',
+  })
+  await writeCronTasks(
+    [
+      {
+        id: 'demo1234',
+        cron: '5 12 22 4 *',
+        prompt: 'demo task',
+        createdAt: Date.now(),
+      },
+    ],
+    projectDir,
+  )
 }
 
 beforeEach(() => {
@@ -178,24 +226,21 @@ describe('/kairos command', () => {
   })
 
   test('status reports running daemon + pause state', async () => {
-    const stateDir = join(process.env.CLAUDE_CONFIG_DIR as string, 'kairos')
-    mkdirSync(stateDir, { recursive: true })
-    writeFileSync(
-      join(stateDir, 'status.json'),
-      JSON.stringify({
-        kind: 'kairos',
-        state: 'idle',
-        pid: 4242,
-        startedAt: '2026-04-22T12:00:00Z',
-        updatedAt: '2026-04-22T12:01:00Z',
-        projects: 1,
-      }),
-    )
+    const projectDir = makeProjectDir()
+    await runKairosCommand(`opt-in ${projectDir}`)
+    await seedKairosProjectState(projectDir)
 
     await runKairosCommand('pause')
     const out = await runKairosCommand('status')
     expect(out).toContain('pid 4242')
     expect(out).toContain('paused: yes')
+    expect(out).toContain(`project: ${projectDir}`)
+    expect(out).toContain('worker running: yes')
+    expect(out).toContain('overlap pending: yes')
+    expect(out).toContain('pending count: 2')
+    expect(out).toContain('queued tasks: 1')
+    expect(out).toContain('project cost: $0.1500')
+    expect(out).toContain('global cost: $0.2500')
   })
 
   test('dashboard respects KAIROS_DASHBOARD_URL override', async () => {

--- a/src 2/commands/kairos.ts
+++ b/src 2/commands/kairos.ts
@@ -22,6 +22,7 @@ import {
   enqueueDemoTask,
   optInProject,
   optOutProject,
+  readDashboardSnapshot,
   setPauseState,
 } from '../daemon/dashboard/model.js'
 import { createProjectRegistry } from '../daemon/kairos/projectRegistry.js'
@@ -131,18 +132,31 @@ async function readJsonIfExists<T>(path: string): Promise<T | null> {
   }
 }
 
+function formatCurrency(value: number | undefined): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null
+  }
+  return `$${value.toFixed(4)}`
+}
+
+function formatOptionalValue(value: string | number | null | undefined): string {
+  if (value === null || value === undefined || value === '') {
+    return '—'
+  }
+  return String(value)
+}
+
 async function handleStatus(): Promise<string> {
-  const [status, pause, registry] = await Promise.all([
-    readJsonIfExists<GlobalStatus>(getKairosStatusPath()),
-    readJsonIfExists<PauseState>(getKairosPausePath()),
-    createProjectRegistry(),
-  ])
-  const projects = await registry.read()
+  const snapshot = await readDashboardSnapshot()
+  const { status, pause, costs, projects } = snapshot.global
   const lines: string[] = []
   if (status) {
     lines.push(`daemon: ${status.state} (pid ${status.pid})`)
     lines.push(`started: ${status.startedAt}`)
     lines.push(`updated: ${status.updatedAt}`)
+    if (status.lastEventAt) {
+      lines.push(`last event at: ${status.lastEventAt}`)
+    }
   } else {
     lines.push('daemon: not running (no status file)')
   }
@@ -157,6 +171,36 @@ async function handleStatus(): Promise<string> {
     lines.push('paused: no')
   }
   lines.push(`projects: ${projects.length}`)
+  const globalCost = formatCurrency(costs?.totalUSD)
+  if (globalCost) {
+    lines.push(
+      `global cost: ${globalCost} across ${costs?.runs ?? 0} run(s) / ${costs?.totalTurns ?? 0} turn(s)`,
+    )
+  }
+  for (const project of snapshot.projects) {
+    lines.push(`project: ${project.projectDir}`)
+    lines.push(
+      `  worker running: ${project.status?.running === true ? 'yes' : 'no'}`,
+    )
+    lines.push(
+      `  overlap pending: ${project.status?.dirty === true ? 'yes' : 'no'}`,
+    )
+    lines.push(
+      `  pending count: ${formatOptionalValue(project.status?.pendingCount)}`,
+    )
+    lines.push(`  queued tasks: ${project.tasks.length}`)
+    lines.push(`  last event: ${formatOptionalValue(project.status?.lastEvent)}`)
+    lines.push(
+      `  next fire at: ${formatOptionalValue(project.status?.nextFireAt ?? null)}`,
+    )
+    lines.push(`  updated: ${formatOptionalValue(project.status?.updatedAt)}`)
+    const projectCost = formatCurrency(project.costs?.totalUSD)
+    if (projectCost) {
+      lines.push(
+        `  project cost: ${projectCost} across ${project.costs?.runs ?? 0} run(s) / ${project.costs?.totalTurns ?? 0} turn(s)`,
+      )
+    }
+  }
   return lines.join('\n')
 }
 


### PR DESCRIPTION
Closes #71
Refs #75

## Summary

- add a root `README.md` for KAIROS and the current repo layout
- route `/kairos status` through `readDashboardSnapshot()` so the terminal and browser surfaces read the same file-backed model
- extend seeded-state coverage for richer `/kairos status` output in `src 2/commands/kairos.test.ts`

## #71 Acceptance Criteria

- [x] "GitHub shows a useful landing page for the repo"
  - `README.md` now exists at the repo root and explains what KAIROS is, where the code lives, and where to start reading.
- [x] "a new contributor can get from clone to running the main commands without source-diving first"
  - `README.md` includes prerequisites, install/setup commands, validation commands, and the daemon startup command.
- [x] "the README reflects the repo as it exists today, not an idealized future state"
  - `README.md` explicitly documents the current `src 2/` layout, current KAIROS daemon/dashboard entry points, and known quirks.

## Verification Receipts

### `bun test 'src 2/commands/kairos.test.ts'`

```text
(pass) /kairos command > prints help when called with no args [17.10ms]
(pass) /kairos command > prints help for unknown subcommands [2.58ms]
(pass) /kairos command > opt-in and opt-out modify projects.json [51.17ms]
(pass) /kairos command > list shows opted-in projects [72.14ms]
(pass) /kairos command > list reports empty state clearly [19.08ms]
(pass) /kairos command > demo writes a durable file-backed one-shot cron task [71.71ms]
(pass) /kairos command > pause writes pause.json and resume clears it [75.24ms]
(pass) /kairos command > resume warns the user when the prior pause was an auth_failure [359.48ms]
(pass) /kairos command > resume is silent on the auth warning when prior pause was not auth_failure [42.42ms]
(pass) /kairos command > status surfaces the daemon-authored re-auth notice verbatim [145.64ms]
(pass) /kairos command > status reports running daemon + pause state [279.12ms]
(pass) /kairos command > dashboard respects KAIROS_DASHBOARD_URL override [0.38ms]
(pass) /kairos command > logs returns the daemon stdout tail [176.40ms]
(pass) /kairos command > logs returns project log tail when a project dir is passed [79.24ms]
(pass) /kairos command > logs treats a bare number as a line count, not a project dir [59.88ms]
(pass) /kairos command > cloud-sync requires an explicit runtime root [8.92ms]
(pass) /kairos command > cloud-sync builds and applies a bundle to the requested runtime root [5.44ms]
(pass) /kairos command > cloud-sync surfaces build or apply failures as user-facing errors [1.07ms]
(pass) /kairos command > skills export emits a self-contained manifest [137.88ms]
(pass) /kairos command > skills import previews first and writes on --yes [91.19ms]
(pass) /kairos command > skills import supports confirmed pasted JSON manifests [286.84ms]
(pass) /kairos command > memory-proposals list shows pending proposals [3.53ms]
(pass) /kairos command > memory-proposals accept updates memory files [5.26ms]
(pass) /kairos command > memory wipe requires confirmation and removes artifacts [4.98ms]

24 pass
0 fail
56 expect() calls
Ran 24 tests across 1 file. [3.49s]
```

### `README.md` first 20 lines

```md
# KAIROS

KAIROS is a Claude-Code-native personal automation platform under active development in this repository.

Today the repo is a Bun-based CLI/daemon codebase with KAIROS-specific work layered into it: a local background worker, a browser dashboard, reminders, Telegram gateway codepaths, skill import/export, diagnostics, and agent-oriented tooling.

## Current Status

- The main application currently lives under `src 2/`, not `src/`.
- The root of the repo is intentionally thin: GitHub/workspace metadata at the top level, product code under `src 2/`.
- KAIROS daemon/dashboard work is present and test-covered, but some command registration and packaging paths are still in progress.

If you are new to the repo, start in:

- `src 2/package.json`
- `src 2/entrypoints/cli.tsx`
- `src 2/daemon/main.ts`
- `src 2/commands/kairos.ts`
- `src 2/daemon/dashboard/`
- `src 2/daemon/kairos/`
```

### `/kairos status` sample output against seeded state

```text
daemon: idle (pid 4242)
started: 2026-04-22T12:00:00Z
updated: 2026-04-22T12:01:00Z
last event at: 2026-04-22T12:01:30Z
paused: yes scope=global
projects: 1
global cost: $0.2500 across 2 run(s) / 3 turn(s)
project: /var/folders/79/x0hsq2wj3qz0d3k35271zm5w0000gn/T/kairos-pr-project-B4Gdbp
  worker running: yes
  overlap pending: yes
  pending count: 2
  queued tasks: 1
  last event: overlap_coalesced
  next fire at: 1746000000000
  updated: 2026-04-22T12:01:15Z
  project cost: $0.1500 across 1 run(s) / 2 turn(s)
```

## Dist Artifact Note

- `src 2/dist/cli.js` was not touched in this change; no rebundle artifact is included.
