### PR TITLE
Guard cloud-sync overlay from writing into user-synced directories (#55)

### DIFF
--- a/src 2/daemon/kairos/cloudSync.test.ts
+++ b/src 2/daemon/kairos/cloudSync.test.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   statSync,
   writeFileSync,
 } from 'fs'
@@ -12,6 +13,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import {
   applyKairosCloudStateBundle,
+  assertRuntimeRootOutsideSyncRoots,
   buildKairosCloudStateBundle,
   getKairosCloudManifestPath,
   getKairosCloudOverlayDir,
@@ -25,9 +27,15 @@ import {
 import { createProjectRegistry } from './projectRegistry.js'
 
 const TEMP_DIRS: string[] = []
+const originalHome = process.env.HOME
 
 afterEach(() => {
   delete process.env.CLAUDE_CONFIG_DIR
+  if (originalHome === undefined) {
+    delete process.env.HOME
+  } else {
+    process.env.HOME = originalHome
+  }
   for (const dir of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -215,6 +223,49 @@ describe('Kairos cloud state sync', () => {
         },
       }),
     ).rejects.toThrow('has no reachable git remote')
+  })
+
+  test('allows a normal temp runtime root outside sync dirs', async () => {
+    const homeDir = makeTempDir('kairos-cloud-home-')
+    const runtimeRoot = makeTempDir('kairos-cloud-runtime-')
+    process.env.HOME = homeDir
+
+    await expect(
+      assertRuntimeRootOutsideSyncRoots(runtimeRoot),
+    ).resolves.toBeUndefined()
+  })
+
+  test('rejects a runtime root under Dropbox', async () => {
+    const homeDir = makeTempDir('kairos-cloud-home-')
+    const dropboxDir = join(homeDir, 'Dropbox')
+    const runtimeRoot = join(dropboxDir, 'kairos-runtime')
+    process.env.HOME = homeDir
+    mkdirSync(runtimeRoot, { recursive: true })
+
+    await expect(
+      assertRuntimeRootOutsideSyncRoots(runtimeRoot),
+    ).rejects.toThrow(KairosCloudSyncError)
+    await expect(
+      assertRuntimeRootOutsideSyncRoots(runtimeRoot),
+    ).rejects.toThrow('user-synced directory')
+  })
+
+  test('rejects a symlinked runtime root that resolves into Dropbox', async () => {
+    const homeDir = makeTempDir('kairos-cloud-home-')
+    const outsideDir = makeTempDir('kairos-cloud-outside-')
+    const dropboxDir = join(homeDir, 'Dropbox')
+    const realRuntimeRoot = join(dropboxDir, 'kairos-runtime')
+    const symlinkRoot = join(outsideDir, 'runtime-link')
+    process.env.HOME = homeDir
+    mkdirSync(realRuntimeRoot, { recursive: true })
+    symlinkSync(realRuntimeRoot, symlinkRoot)
+
+    await expect(
+      assertRuntimeRootOutsideSyncRoots(symlinkRoot),
+    ).rejects.toThrow(KairosCloudSyncError)
+    await expect(
+      assertRuntimeRootOutsideSyncRoots(symlinkRoot),
+    ).rejects.toThrow('Dropbox')
   })
 
   test('applies a bundle into a read-only source tree and preserves overlay state across re-syncs', async () => {

--- a/src 2/daemon/kairos/cloudSync.ts
+++ b/src 2/daemon/kairos/cloudSync.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'crypto'
-import { chmod, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'fs/promises'
-import { dirname, join, relative, sep } from 'path'
+import { chmod, mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from 'fs/promises'
+import { homedir } from 'os'
+import { dirname, join, relative, resolve, sep } from 'path'
 import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
 import { execFileNoThrowWithCwd } from '../../utils/execFileNoThrow.js'
 import { gitExe, normalizeGitRemoteUrl } from '../../utils/git.js'
@@ -98,6 +99,68 @@ async function pathExists(path: string): Promise<boolean> {
     return true
   } catch {
     return false
+  }
+}
+
+function isSubpath(candidatePath: string, rootPath: string): boolean {
+  const rel = relative(rootPath, candidatePath)
+  return rel === '' || (!rel.startsWith('..') && !rel.startsWith(`..${sep}`))
+}
+
+async function getKnownSyncRoots(): Promise<string[]> {
+  const home = process.env.HOME || homedir()
+  const roots = [
+    join(home, 'Dropbox'),
+    join(home, 'Dropbox (Personal)'),
+    join(home, 'Dropbox (Business)'),
+    join(home, 'Google Drive'),
+    join(home, 'GoogleDrive'),
+    join(home, 'OneDrive'),
+    join(home, 'Library', 'Mobile Documents'),
+  ]
+
+  const iCloudDesktopSignal = join(
+    home,
+    'Library',
+    'Mobile Documents',
+    'com~apple~CloudDocs',
+    'Desktop',
+  )
+  if (await pathExists(iCloudDesktopSignal)) {
+    roots.push(join(home, 'Documents'))
+  }
+
+  return roots
+}
+
+export async function assertRuntimeRootOutsideSyncRoots(
+  runtimeRoot: string,
+): Promise<void> {
+  const requestedRoot = resolve(runtimeRoot)
+  let resolvedRoot: string
+  try {
+    resolvedRoot = await realpath(requestedRoot)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new KairosCloudSyncError(
+      `Cloud sync runtime root must exist before applying state: ${requestedRoot} (${message})`,
+    )
+  }
+
+  const knownSyncRoots = await getKnownSyncRoots()
+  for (const syncRoot of knownSyncRoots) {
+    if (!(await pathExists(syncRoot))) {
+      continue
+    }
+    const resolvedSyncRoot = await realpath(syncRoot).catch(() => null)
+    if (!resolvedSyncRoot) {
+      continue
+    }
+    if (isSubpath(resolvedRoot, resolvedSyncRoot)) {
+      throw new KairosCloudSyncError(
+        `Refusing to apply KAIROS cloud sync inside a user-synced directory. runtimeRoot=${resolvedRoot} is under sync root ${resolvedSyncRoot}. Choose a runtime root outside Dropbox, Google Drive, OneDrive, and iCloud-managed paths.`,
+      )
+    }
   }
 }
 
@@ -526,6 +589,7 @@ export async function applyKairosCloudStateBundle(
   options: ApplyKairosCloudStateBundleOptions,
 ): Promise<ApplyKairosCloudStateBundleResult> {
   const now = options.now ?? (() => new Date())
+  await assertRuntimeRootOutsideSyncRoots(options.runtimeRoot)
   const sourceDir = getKairosCloudSourceDir(options.runtimeRoot)
   const overlayDir = getKairosCloudOverlayDir(options.runtimeRoot)
   const manifestPath = getKairosCloudManifestPath(options.runtimeRoot)


### PR DESCRIPTION
Closes #55

## Summary

- add `assertRuntimeRootOutsideSyncRoots(runtimeRoot)` to reject cloud-sync roots under known user-synced directories
- enforce that guard at the top of `applyKairosCloudStateBundle()`
- add tests for safe temp roots, direct Dropbox roots, and symlinks that resolve into Dropbox

## #55 Acceptance Criteria

- [x] "Sync updates skills, memory, and scheduled task data on the host"
  - Existing `buildKairosCloudStateBundle` and apply tests still pass unchanged; this PR does not weaken the bundle/apply path.
- [x] "Cloud runtime survives repeated syncs without corrupting state"
  - Existing re-sync preservation test still passes after the guard is added.
- [x] "Fired-task/execution metadata stays outside synced files"
  - The guard specifically blocks sync roots where the overlay could leak back into user-synced directories; overlay state still writes to the separate overlay tree after validation.
- [x] "A project without a reachable git remote is rejected with a clear error"
  - Existing error-path test still passes unchanged.
- [ ] "Visual proof shows edit on Mac -> sync -> reflected on cloud"
  - Not included in this draft PR. This remains for approval/review before flipping ready.

## Verification

### `bun test 'src 2/daemon/kairos/cloudSync.test.ts'`

```text
bun test v1.3.11 (af24e281)

src 2/daemon/kairos/cloudSync.test.ts:
(pass) Kairos cloud state sync > builds a bundle from supported KAIROS state and scheduled task data [10.73ms]
(pass) Kairos cloud state sync > rejects a project when cloud sync cannot resolve a reachable git remote [0.73ms]
(pass) Kairos cloud state sync > allows a normal temp runtime root outside sync dirs [0.99ms]
(pass) Kairos cloud state sync > rejects a runtime root under Dropbox [0.94ms]
(pass) Kairos cloud state sync > rejects a symlinked runtime root that resolves into Dropbox [0.92ms]
(pass) Kairos cloud state sync > applies a bundle into a read-only source tree and preserves overlay state across re-syncs [7.66ms]

6 pass
0 fail
29 expect() calls
Ran 6 tests across 1 file. [122.00ms]
```

### Existing adjacent KAIROS slice still passes

```text
bun test v1.3.11 (af24e281)

src 2/commands/kairos.test.ts:
(pass) /kairos command > prints help when called with no args [0.57ms]
(pass) /kairos command > prints help for unknown subcommands [0.20ms]
(pass) /kairos command > opt-in and opt-out modify projects.json [4.55ms]
(pass) /kairos command > list shows opted-in projects [1.35ms]
(pass) /kairos command > list reports empty state clearly [0.82ms]
(pass) /kairos command > demo writes a durable file-backed one-shot cron task [3.33ms]
(pass) /kairos command > pause writes pause.json and resume clears it [1.31ms]
(pass) /kairos command > resume warns the user when the prior pause was an auth_failure [0.86ms]
(pass) /kairos command > resume is silent on the auth warning when prior pause was not auth_failure [1.04ms]
(pass) /kairos command > status surfaces the daemon-authored re-auth notice verbatim [1.36ms]
(pass) /kairos command > status reports running daemon + pause state [4.70ms]
(pass) /kairos command > dashboard respects KAIROS_DASHBOARD_URL override [0.36ms]
(pass) /kairos command > logs returns the daemon stdout tail [1.67ms]
(pass) /kairos command > logs returns project log tail when a project dir is passed [1.03ms]
(pass) /kairos command > logs treats a bare number as a line count, not a project dir [0.70ms]
(pass) /kairos command > cloud-sync requires an explicit runtime root [0.37ms]
(pass) /kairos command > cloud-sync builds and applies a bundle to the requested runtime root [0.61ms]
(pass) /kairos command > cloud-sync surfaces build or apply failures as user-facing errors [0.38ms]
(pass) /kairos command > skills export emits a self-contained manifest [4.88ms]
(pass) /kairos command > skills import previews first and writes on --yes [3.93ms]
(pass) /kairos command > skills import supports confirmed pasted JSON manifests [3.88ms]
(pass) /kairos command > memory-proposals list shows pending proposals [1.73ms]
(pass) /kairos command > memory-proposals accept updates memory files [2.61ms]
(pass) /kairos command > memory wipe requires confirmation and removes artifacts [1.58ms]

src 2/daemon/kairos/cloudSync.test.ts:
(pass) Kairos cloud state sync > builds a bundle from supported KAIROS state and scheduled task data [6.79ms]
(pass) Kairos cloud state sync > rejects a project when cloud sync cannot resolve a reachable git remote [0.55ms]
(pass) Kairos cloud state sync > allows a normal temp runtime root outside sync dirs [0.61ms]
(pass) Kairos cloud state sync > rejects a runtime root under Dropbox [0.79ms]
(pass) Kairos cloud state sync > rejects a symlinked runtime root that resolves into Dropbox [0.99ms]
(pass) Kairos cloud state sync > applies a bundle into a read-only source tree and preserves overlay state across re-syncs [8.24ms]

30 pass
0 fail
85 expect() calls
Ran 30 tests across 2 files. [168.00ms]
```

### Scoped TypeScript Check

Command:

```bash
cd 'src 2' && bunx tsc --noEmit -p tsconfig.json --pretty false 2>&1 | rg 'daemon/kairos/cloudSync'
```

Output:

```text
(no output)
```

### Dist Artifact Note

- `src 2/dist/cli.js` was not touched in this change; no rebundle artifact is included.
