### PR TITLE
Add eval trace format and comparator

### DIFF
--- a/src 2/evals/compare.ts
+++ b/src 2/evals/compare.ts
@@ -1,0 +1,156 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { deserializeTrace } from './serialize.js'
+import type { DiffEntry, IgnoredFieldPath, Trace } from './types.js'
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url))
+const DEFAULT_IGNORED_FIELDS_PATH = resolve(MODULE_DIR, 'ignored-fields.json')
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function shouldIgnorePath(
+  path: string[],
+  ignoredPaths: IgnoredFieldPath[],
+): boolean {
+  return ignoredPaths.some(ignoredPath => {
+    if (ignoredPath.length > path.length) {
+      return false
+    }
+
+    return ignoredPath.every((segment, index) => segment === path[index])
+  })
+}
+
+export function loadIgnoredFieldPaths(
+  ignoredFieldsPath = DEFAULT_IGNORED_FIELDS_PATH,
+): IgnoredFieldPath[] {
+  if (!existsSync(ignoredFieldsPath)) {
+    return []
+  }
+
+  const parsed = JSON.parse(readFileSync(ignoredFieldsPath, 'utf8')) as unknown
+  if (!Array.isArray(parsed)) {
+    throw new Error('ignored-fields.json must be an array of path arrays')
+  }
+
+  return parsed.map((entry, index) => {
+    if (!Array.isArray(entry) || !entry.every(segment => typeof segment === 'string')) {
+      throw new Error(
+        `ignored-fields.json entry ${index} must be an array of strings`,
+      )
+    }
+    return entry
+  })
+}
+
+function compareValues(
+  expected: unknown,
+  actual: unknown,
+  path: string[],
+  ignoredPaths: IgnoredFieldPath[],
+  diffs: DiffEntry[],
+): void {
+  if (shouldIgnorePath(path, ignoredPaths)) {
+    return
+  }
+
+  if (Array.isArray(expected) && Array.isArray(actual)) {
+    const maxLength = Math.max(expected.length, actual.length)
+    for (let index = 0; index < maxLength; index += 1) {
+      const nextPath = [...path, String(index)]
+      if (index >= expected.length) {
+        if (!shouldIgnorePath(nextPath, ignoredPaths)) {
+          diffs.push({
+            path: nextPath,
+            kind: 'extra',
+            actual: actual[index],
+          })
+        }
+        continue
+      }
+      if (index >= actual.length) {
+        if (!shouldIgnorePath(nextPath, ignoredPaths)) {
+          diffs.push({
+            path: nextPath,
+            kind: 'missing',
+            expected: expected[index],
+          })
+        }
+        continue
+      }
+      compareValues(expected[index], actual[index], nextPath, ignoredPaths, diffs)
+    }
+    return
+  }
+
+  if (isPlainObject(expected) && isPlainObject(actual)) {
+    const keys = new Set([...Object.keys(expected), ...Object.keys(actual)])
+    for (const key of Array.from(keys).sort()) {
+      const nextPath = [...path, key]
+      if (!(key in actual)) {
+        if (!shouldIgnorePath(nextPath, ignoredPaths)) {
+          diffs.push({
+            path: nextPath,
+            kind: 'missing',
+            expected: expected[key],
+          })
+        }
+        continue
+      }
+      if (!(key in expected)) {
+        if (!shouldIgnorePath(nextPath, ignoredPaths)) {
+          diffs.push({
+            path: nextPath,
+            kind: 'extra',
+            actual: actual[key],
+          })
+        }
+        continue
+      }
+      compareValues(expected[key], actual[key], nextPath, ignoredPaths, diffs)
+    }
+    return
+  }
+
+  if (expected !== actual) {
+    diffs.push({
+      path,
+      kind: 'changed',
+      expected,
+      actual,
+    })
+  }
+}
+
+export function compareTraces(
+  expected: Trace,
+  actual: Trace,
+  options?: {
+    ignoredPaths?: IgnoredFieldPath[]
+    ignoredFieldsPath?: string
+  },
+): DiffEntry[] {
+  const ignoredPaths =
+    options?.ignoredPaths ?? loadIgnoredFieldPaths(options?.ignoredFieldsPath)
+  const diffs: DiffEntry[] = []
+  compareValues(expected, actual, [], ignoredPaths, diffs)
+  return diffs
+}
+
+export function compareSerializedTraces(
+  expected: string,
+  actual: string,
+  options?: {
+    ignoredPaths?: IgnoredFieldPath[]
+    ignoredFieldsPath?: string
+  },
+): DiffEntry[] {
+  return compareTraces(
+    deserializeTrace(expected),
+    deserializeTrace(actual),
+    options,
+  )
+}

--- a/src 2/evals/ignored-fields.json
+++ b/src 2/evals/ignored-fields.json
@@ -1,0 +1,3 @@
+[
+  ["meta", "commitSha"]
+]

--- a/src 2/evals/serialize.ts
+++ b/src 2/evals/serialize.ts
@@ -1,0 +1,46 @@
+import type { Trace } from './types.js'
+
+type StableJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | StableJsonValue[]
+  | { [key: string]: StableJsonValue }
+
+function toStableJsonValue(value: unknown): StableJsonValue {
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'number' ||
+    typeof value === 'string'
+  ) {
+    return value as StableJsonValue
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => toStableJsonValue(item))
+  }
+
+  if (typeof value === 'object') {
+    const result: { [key: string]: StableJsonValue } = {}
+    for (const key of Object.keys(value).sort()) {
+      result[key] = toStableJsonValue((value as Record<string, unknown>)[key])
+    }
+    return result
+  }
+
+  throw new Error(`Unsupported value in trace serialization: ${typeof value}`)
+}
+
+export function normalizeTrace(trace: Trace): Trace {
+  return toStableJsonValue(trace) as Trace
+}
+
+export function serializeTrace(trace: Trace): string {
+  return `${JSON.stringify(normalizeTrace(trace), null, 2)}\n`
+}
+
+export function deserializeTrace(raw: string): Trace {
+  return normalizeTrace(JSON.parse(raw) as Trace)
+}

--- a/src 2/evals/traceComparator.test.ts
+++ b/src 2/evals/traceComparator.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test'
+import { compareTraces } from './compare.js'
+import { deserializeTrace, serializeTrace } from './serialize.js'
+import type { Trace } from './types.js'
+
+function makeTrace(overrides: Partial<Trace> = {}): Trace {
+  return {
+    meta: {
+      caseId: 'case-1',
+      commitSha: 'abc123',
+      harnessVersion: 1,
+    },
+    toolCalls: [
+      {
+        tool: 'Read',
+        inputSha: 'in-1',
+        outputSha: 'out-1',
+        durationMs: '<100ms',
+      },
+    ],
+    wideEvents: [
+      {
+        name: 'tool_started',
+        phase: 'run',
+        keysPresent: ['tool', 'inputSha'],
+      },
+    ],
+    finalResponseSha: 'final-1',
+    exitCode: 0,
+    ...overrides,
+  }
+}
+
+describe('trace comparator', () => {
+  test('Identical traces -> empty diff', () => {
+    const trace = makeTrace()
+    const expected = deserializeTrace(serializeTrace(trace))
+    const actual = deserializeTrace(serializeTrace(trace))
+
+    expect(compareTraces(expected, actual)).toEqual([])
+  })
+
+  test('Traces that differ only in ignored fields -> empty diff', () => {
+    const expected = makeTrace()
+    const actual = makeTrace({
+      meta: {
+        ...expected.meta,
+        commitSha: 'def456',
+      },
+    })
+
+    expect(compareTraces(expected, actual)).toEqual([])
+  })
+
+  test('Extra tool call -> diff reports it', () => {
+    const expected = makeTrace()
+    const actual = makeTrace({
+      toolCalls: [
+        ...expected.toolCalls,
+        {
+          tool: 'Write',
+          inputSha: 'in-2',
+          outputSha: 'out-2',
+          durationMs: '100-1000ms',
+        },
+      ],
+    })
+
+    expect(compareTraces(expected, actual)).toEqual([
+      {
+        path: ['toolCalls', '1'],
+        kind: 'extra',
+        actual: actual.toolCalls[1],
+      },
+    ])
+  })
+
+  test('Missing wide event -> diff reports it', () => {
+    const expected = makeTrace({
+      wideEvents: [
+        {
+          name: 'tool_started',
+          phase: 'run',
+          keysPresent: ['tool', 'inputSha'],
+        },
+        {
+          name: 'tool_finished',
+          phase: 'run',
+          keysPresent: ['tool', 'outputSha'],
+        },
+      ],
+    })
+    const actual = makeTrace({
+      wideEvents: [expected.wideEvents[0]!],
+    })
+
+    expect(compareTraces(expected, actual)).toEqual([
+      {
+        path: ['wideEvents', '1'],
+        kind: 'missing',
+        expected: expected.wideEvents[1],
+      },
+    ])
+  })
+
+  test('Changed finalResponseSha -> diff reports it', () => {
+    const expected = makeTrace()
+    const actual = makeTrace({
+      finalResponseSha: 'final-2',
+    })
+
+    expect(compareTraces(expected, actual)).toEqual([
+      {
+        path: ['finalResponseSha'],
+        kind: 'changed',
+        expected: 'final-1',
+        actual: 'final-2',
+      },
+    ])
+  })
+})

--- a/src 2/evals/types.ts
+++ b/src 2/evals/types.ts
@@ -1,0 +1,39 @@
+export type TraceDurationBucket = '<100ms' | '100-1000ms' | '>1s'
+
+export type TraceMeta = {
+  caseId: string
+  commitSha: string
+  harnessVersion: number
+}
+
+export type TraceToolCall = {
+  tool: string
+  inputSha: string
+  outputSha: string
+  durationMs: TraceDurationBucket
+}
+
+export type TraceWideEvent = {
+  name: string
+  phase: string
+  keysPresent: string[]
+}
+
+export type Trace = {
+  meta: TraceMeta
+  toolCalls: TraceToolCall[]
+  wideEvents: TraceWideEvent[]
+  finalResponseSha: string
+  exitCode: number
+}
+
+export type DiffKind = 'missing' | 'extra' | 'changed'
+
+export type DiffEntry = {
+  path: string[]
+  kind: DiffKind
+  expected?: unknown
+  actual?: unknown
+}
+
+export type IgnoredFieldPath = string[]


### PR DESCRIPTION
Closes #59 (PR A of 3)

## Summary
Adds the pure eval trace data layer for deterministic comparisons: typed trace shapes, stable JSON serialization, an ignore-aware comparator, and focused unit coverage. This PR does not add daemon integration, CLI wiring, or live KAIROS trace capture.

## What Changed
- added `evals/types.ts` with `Trace`, `DiffEntry`, and related helper types
- added `evals/serialize.ts` for deterministic JSON normalization, serialization, and deserialization
- added `evals/compare.ts` with a structured comparator that returns `missing`, `extra`, and `changed` diffs and respects `evals/ignored-fields.json`
- added `evals/ignored-fields.json` with `["meta", "commitSha"]` pre-populated as the initial ignored field example
- added `evals/traceComparator.test.ts` covering the requested comparator cases

## Test Cases
- `Identical traces -> empty diff`: proves the comparator stays silent when two normalized traces are equivalent
- `Traces that differ only in ignored fields -> empty diff`: proves ignored path configuration suppresses expected non-deterministic metadata like `meta.commitSha`
- `Extra tool call -> diff reports it`: proves the comparator surfaces appended tool activity as a structured `extra` diff
- `Missing wide event -> diff reports it`: proves the comparator surfaces dropped event records as a structured `missing` diff
- `Changed finalResponseSha -> diff reports it`: proves terminal-output changes surface as a leaf `changed` diff

## Verification
`bun test ./evals/traceComparator.test.ts`

```text
bun test v1.3.11 (af24e281)

src 2/evals/traceComparator.test.ts:
(pass) trace comparator > Identical traces -> empty diff [5.39ms]
(pass) trace comparator > Traces that differ only in ignored fields -> empty diff [0.34ms]
(pass) trace comparator > Extra tool call -> diff reports it [0.19ms]
(pass) trace comparator > Missing wide event -> diff reports it [0.83ms]
(pass) trace comparator > Changed finalResponseSha -> diff reports it [0.10ms]

 5 pass
 0 fail
 5 expect() calls
Ran 5 tests across 1 file. [603.00ms]
```

Scoped typecheck:

```text
cd 'src 2'
bunx tsc-files --noEmit --ignoreDeprecations 6.0 --pretty false 'evals/types.ts' 'evals/serialize.ts' 'evals/compare.ts' 'evals/traceComparator.test.ts'
<no output>
```

## Trunk Guard / Dist
- `trunk-change-approved` is not required; this PR only adds files under `src 2/evals/`, which are not matched by `.github/workflows/trunk-guard.yml`
- `src 2/dist/cli.js` was not touched
