### PR TITLE
Fix daily structural workflow auth

### DIFF
--- a/.github/workflows/permanent-structural-fix-daily.yml
+++ b/.github/workflows/permanent-structural-fix-daily.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   permanent-structural-fix:
     runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ci-test-key
     defaults:
       run:
         working-directory: "src 2"


### PR DESCRIPTION
## Summary
- Add the same CI test API key environment to the daily structural-fix workflow that the main CI workflow already uses.

## Validation
- `ANTHROPIC_API_KEY=ci-test-key bun run structural-fix:daily`