### PR TITLE
Implement SDK session transcript helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ If you are changing guarded architecture paths, expect extra review friction and
 
 - The source root is currently `src 2/`; the rename to `src/` is tracked separately because it is broad path churn.
 - Some KAIROS surfaces are intentionally implemented before full trunk registration so the codepaths can be iterated on safely.
-- The Agent SDK compatibility facade is partial. Tool/server helpers, query/session creation, session listing/info, rename/tag, and missed-task formatting are wired; `getSessionMessages`, `forkSession`, `watchScheduledTasks`, and `connectRemoteControl` fail explicitly with a rebuild-specific unsupported message.
+- The Agent SDK compatibility facade is partial. Tool/server helpers, `getSessionMessages`, `forkSession`, session listing/info, rename/tag, and missed-task formatting are wired; query/session creation/prompting, `watchScheduledTasks`, and `connectRemoteControl` fail explicitly with a rebuild-specific unsupported message.

--- a/src 2/entrypoints/agentSdkTypes.test.ts
+++ b/src 2/entrypoints/agentSdkTypes.test.ts
@@ -1,9 +1,56 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   buildMissedTaskNotification,
   forkSession,
+  getSessionInfo,
+  getSessionMessages,
   tool,
+  watchScheduledTasks,
 } from './agentSdkTypes.js'
+import { getProjectDir } from '../utils/sessionStoragePortable.js'
+
+const ORIGINAL_CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  if (ORIGINAL_CLAUDE_CONFIG_DIR === undefined) {
+    delete process.env.CLAUDE_CONFIG_DIR
+  } else {
+    process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CLAUDE_CONFIG_DIR
+  }
+})
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+function writeSessionFixture(
+  sessionId: string,
+  projectDir: string,
+  entries: unknown[],
+): void {
+  const transcriptDir = getProjectDir(projectDir)
+  mkdirSync(transcriptDir, { recursive: true })
+  writeFileSync(
+    join(transcriptDir, `${sessionId}.jsonl`),
+    entries.map(entry => JSON.stringify(entry)).join('\n') + '\n',
+  )
+}
 
 describe('Agent SDK compatibility facade', () => {
   test('creates SDK tool definitions instead of throwing placeholder errors', () => {
@@ -38,9 +85,155 @@ describe('Agent SDK compatibility facade', () => {
     expect(message).toContain('check deploy status')
   })
 
-  test('unsupported SDK surfaces fail with explicit rebuild context', async () => {
-    await expect(forkSession('missing-session')).rejects.toThrow(
-      'rebuilt CLI distribution',
+  test('reads session messages from transcript storage', async () => {
+    const configDir = tempDir('agent-sdk-config-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    const projectDir = realpathSync(tempDir('agent-sdk-project-'))
+    const sessionId = '11111111-1111-4111-8111-111111111111'
+    writeSessionFixture(sessionId, projectDir, [
+      {
+        type: 'system',
+        subtype: 'init',
+        uuid: '22222222-2222-4222-8222-222222222222',
+        parentUuid: null,
+        timestamp: '2026-04-24T10:00:00.000Z',
+        sessionId,
+        isSidechain: false,
+      },
+      {
+        type: 'user',
+        uuid: '33333333-3333-4333-8333-333333333333',
+        parentUuid: '22222222-2222-4222-8222-222222222222',
+        timestamp: '2026-04-24T10:01:00.000Z',
+        sessionId,
+        isSidechain: false,
+        message: { role: 'user', content: 'hello' },
+      },
+      {
+        type: 'assistant',
+        uuid: '44444444-4444-4444-8444-444444444444',
+        parentUuid: '33333333-3333-4333-8333-333333333333',
+        timestamp: '2026-04-24T10:02:00.000Z',
+        sessionId,
+        isSidechain: false,
+        message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+      },
+    ])
+
+    const messages = await getSessionMessages(sessionId, { dir: projectDir })
+    expect(messages.map(message => message.type)).toEqual(['user', 'assistant'])
+
+    const withSystem = await getSessionMessages(sessionId, {
+      dir: projectDir,
+      includeSystemMessages: true,
+    })
+    expect(withSystem.map(message => message.type)).toEqual([
+      'system',
+      'user',
+      'assistant',
+    ])
+
+    const second = await getSessionMessages(sessionId, {
+      dir: projectDir,
+      offset: 1,
+      limit: 1,
+    })
+    expect(second.map(message => message.type)).toEqual(['assistant'])
+  })
+
+  test('forks sessions with fresh message UUIDs', async () => {
+    const configDir = tempDir('agent-sdk-config-')
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    const projectDir = realpathSync(tempDir('agent-sdk-project-'))
+    const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const userUuid = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    const assistantUuid = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+    writeSessionFixture(sessionId, projectDir, [
+      {
+        type: 'user',
+        uuid: userUuid,
+        parentUuid: null,
+        timestamp: '2026-04-24T11:01:00.000Z',
+        sessionId,
+        isSidechain: false,
+        message: { role: 'user', content: 'branch me' },
+      },
+      {
+        type: 'assistant',
+        uuid: assistantUuid,
+        parentUuid: userUuid,
+        timestamp: '2026-04-24T11:02:00.000Z',
+        sessionId,
+        isSidechain: false,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'branched' }],
+        },
+      },
+      {
+        type: 'content-replacement',
+        sessionId,
+        replacements: [
+          {
+            kind: 'tool-result',
+            toolUseId: 'toolu_123',
+            replacement: '[tool result omitted]',
+          },
+        ],
+      },
+    ])
+
+    const result = await forkSession(sessionId, {
+      dir: projectDir,
+      title: 'Branch title',
+    })
+
+    expect(result.sessionId).not.toBe(sessionId)
+    const messages = await getSessionMessages(result.sessionId, {
+      dir: projectDir,
+    })
+    expect(messages.map(message => message.type)).toEqual(['user', 'assistant'])
+    expect(messages.map(message => message.sessionId)).toEqual([
+      result.sessionId,
+      result.sessionId,
+    ])
+    expect(messages.map(message => message.uuid)).not.toEqual([
+      userUuid,
+      assistantUuid,
+    ])
+    expect(messages[1]!.parentUuid).toBe(messages[0]!.uuid)
+
+    const info = await getSessionInfo(result.sessionId, { dir: projectDir })
+    expect(info?.customTitle).toBe('Branch title')
+
+    const forkContent = readFileSync(
+      join(getProjectDir(projectDir), `${result.sessionId}.jsonl`),
+      'utf8',
     )
+    const forkEntries = forkContent
+      .trim()
+      .split('\n')
+      .map(
+        line => JSON.parse(line) as { type: string; replacements?: unknown[] },
+      )
+    const replacementEntry = forkEntries.find(
+      entry => entry.type === 'content-replacement',
+    )
+    expect(replacementEntry?.replacements).toEqual([
+      {
+        kind: 'tool-result',
+        toolUseId: 'toolu_123',
+        replacement: '[tool result omitted]',
+      },
+    ])
+  })
+
+  test('unsupported SDK surfaces fail with explicit rebuild context', () => {
+    expect(() =>
+      watchScheduledTasks({
+        dir: process.cwd(),
+        signal: new AbortController().signal,
+      }),
+    ).toThrow('rebuilt CLI distribution')
   })
 })

--- a/src 2/entrypoints/agentSdkTypes.ts
+++ b/src 2/entrypoints/agentSdkTypes.ts
@@ -14,16 +14,21 @@ import type {
   ToolAnnotations,
 } from '@modelcontextprotocol/sdk/types.js'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { appendFile } from 'fs/promises'
+import { randomUUID } from 'crypto'
+import { appendFile, writeFile } from 'fs/promises'
+import { dirname, join } from 'path'
 import {
   listSessionsImpl,
   parseSessionInfoFromLite,
+  type SessionInfo,
 } from '../utils/listSessionsImpl.js'
 import {
   readSessionLite,
+  readTranscriptForLoad,
   resolveSessionFilePath,
 } from '../utils/sessionStoragePortable.js'
 import { cronToHuman } from '../utils/cron.js'
+import { parseJSONL } from '../utils/json.js'
 
 // Control protocol types for SDK builders (bridge subpath consumers)
 /** @alpha */
@@ -48,37 +53,73 @@ export * from './sdk/toolTypes.js'
 import type {
   SDKMessage,
   SDKResultMessage,
-  SDKSessionInfo,
   SDKUserMessage,
 } from './sdk/coreTypes.js'
 // Import types needed for function signatures
 import type {
   AnyZodRawShape,
-  ForkSessionOptions,
-  ForkSessionResult,
-  GetSessionInfoOptions,
-  GetSessionMessagesOptions,
   InferShape,
-  InternalOptions,
-  InternalQuery,
-  ListSessionsOptions,
   McpSdkServerConfigWithInstance,
   Options,
   Query,
   SDKSession,
   SDKSessionOptions,
   SdkMcpToolDefinition,
-  SessionMessage,
-  SessionMutationOptions,
 } from './sdk/runtimeTypes.js'
 
-export type {
-  ListSessionsOptions,
-  GetSessionInfoOptions,
-  SessionMutationOptions,
-  ForkSessionOptions,
-  ForkSessionResult,
-  SDKSessionInfo,
+type InternalOptions = Options
+type InternalQuery = Query
+
+export type SDKSessionInfo = SessionInfo
+
+export type ListSessionsOptions = {
+  dir?: string
+  limit?: number
+  offset?: number
+  includeWorktrees?: boolean
+}
+
+export type GetSessionInfoOptions = {
+  dir?: string
+}
+
+export type GetSessionMessagesOptions = {
+  dir?: string
+  limit?: number
+  offset?: number
+  includeSystemMessages?: boolean
+}
+
+export type SessionMutationOptions = {
+  dir?: string
+}
+
+export type ForkSessionOptions = {
+  dir?: string
+  upToMessageId?: string
+  title?: string
+}
+
+export type ForkSessionResult = {
+  sessionId: string
+}
+
+export type SessionMessage = {
+  type: string
+  uuid: string
+  parentUuid: string | null
+  logicalParentUuid?: string | null
+  sessionId?: string
+  timestamp?: string
+  isSidechain?: boolean
+  message?: unknown
+  [key: string]: unknown
+}
+
+type ContentReplacementEntry = {
+  type: 'content-replacement'
+  sessionId: string
+  replacements: unknown[]
 }
 
 function unsupportedSdkApi(name: string): never {
@@ -89,6 +130,173 @@ function unsupportedSdkApi(name: string): never {
 
 function sessionDir(options: unknown): string | undefined {
   return (options as { dir?: string } | undefined)?.dir
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isSessionMessage(entry: unknown): entry is SessionMessage {
+  if (!isRecord(entry)) return false
+  if (typeof entry.type !== 'string') return false
+  if (typeof entry.uuid !== 'string') return false
+  return entry.parentUuid === null || typeof entry.parentUuid === 'string'
+}
+
+function isConversationMessage(
+  entry: SessionMessage,
+  includeSystemMessages: boolean,
+): boolean {
+  return (
+    entry.type === 'user' ||
+    entry.type === 'assistant' ||
+    entry.type === 'attachment' ||
+    (includeSystemMessages && entry.type === 'system')
+  )
+}
+
+function parseTranscriptMessages(buf: Buffer): Map<string, SessionMessage> {
+  const messages = new Map<string, SessionMessage>()
+  const progressBridge = new Map<string, string | null>()
+
+  for (const entry of parseJSONL<unknown>(buf)) {
+    if (
+      isRecord(entry) &&
+      entry.type === 'progress' &&
+      typeof entry.uuid === 'string'
+    ) {
+      const parentUuid =
+        entry.parentUuid === null || typeof entry.parentUuid === 'string'
+          ? (entry.parentUuid as string | null)
+          : null
+      const uuid = entry.uuid
+      progressBridge.set(
+        uuid,
+        parentUuid && progressBridge.has(parentUuid)
+          ? (progressBridge.get(parentUuid) ?? null)
+          : parentUuid,
+      )
+      continue
+    }
+
+    if (!isSessionMessage(entry)) continue
+    if (
+      !['user', 'assistant', 'attachment', 'system'].includes(entry.type) ||
+      entry.isSidechain === true
+    ) {
+      continue
+    }
+
+    if (entry.parentUuid && progressBridge.has(entry.parentUuid)) {
+      entry.parentUuid = progressBridge.get(entry.parentUuid) ?? null
+    }
+    messages.set(entry.uuid, entry)
+  }
+
+  return messages
+}
+
+function findLatestLeaf(
+  messages: Iterable<SessionMessage>,
+): SessionMessage | undefined {
+  const all = [...messages]
+  const parentUuids = new Set(
+    all
+      .map(message => message.parentUuid)
+      .filter((uuid): uuid is string => typeof uuid === 'string'),
+  )
+
+  let latest: SessionMessage | undefined
+  let maxTime = -Infinity
+  for (let index = 0; index < all.length; index++) {
+    const message = all[index]!
+    if (parentUuids.has(message.uuid)) continue
+    const timestamp =
+      typeof message.timestamp === 'string'
+        ? Date.parse(message.timestamp)
+        : NaN
+    const time = Number.isFinite(timestamp) ? timestamp : index
+    if (time > maxTime) {
+      maxTime = time
+      latest = message
+    }
+  }
+  return latest
+}
+
+function buildSessionChain(
+  messages: Map<string, SessionMessage>,
+  leaf: SessionMessage,
+): SessionMessage[] {
+  const chain: SessionMessage[] = []
+  const seen = new Set<string>()
+  let current: SessionMessage | undefined = leaf
+
+  while (current && !seen.has(current.uuid)) {
+    seen.add(current.uuid)
+    chain.push(current)
+    current = current.parentUuid ? messages.get(current.parentUuid) : undefined
+  }
+
+  chain.reverse()
+  return chain
+}
+
+function contentReplacementRecordsFor(
+  buf: Buffer,
+  sessionId: string,
+): unknown[] {
+  return parseJSONL<unknown>(buf).flatMap(entry => {
+    if (!isRecord(entry)) return []
+    if (entry.type !== 'content-replacement') return []
+    if (entry.sessionId !== sessionId) return []
+    if (!Array.isArray(entry.replacements)) return []
+    return (entry as ContentReplacementEntry).replacements
+  })
+}
+
+function cloneForkMessage(
+  entry: SessionMessage,
+  sourceSessionId: string,
+  forkSessionId: string,
+  uuidMap: Map<string, string>,
+): SessionMessage {
+  const originalUuid = entry.uuid
+  const forkedUuid = uuidMap.get(originalUuid)
+  if (!forkedUuid) {
+    throw new Error(
+      `Unable to fork message without UUID mapping: ${originalUuid}`,
+    )
+  }
+
+  return {
+    ...entry,
+    uuid: forkedUuid,
+    parentUuid: entry.parentUuid
+      ? (uuidMap.get(entry.parentUuid) ?? null)
+      : null,
+    logicalParentUuid: entry.logicalParentUuid
+      ? (uuidMap.get(entry.logicalParentUuid) ?? null)
+      : entry.logicalParentUuid,
+    sessionId: forkSessionId,
+    isSidechain: false,
+    forkedFrom: {
+      sessionId: sourceSessionId,
+      messageUuid: originalUuid,
+    },
+  }
+}
+
+function findForkBoundary(
+  chain: SessionMessage[],
+  upToMessageId: string | undefined,
+): number {
+  if (!upToMessageId) return chain.length
+  const index = chain.findIndex(message => message.uuid === upToMessageId)
+  if (index === -1) {
+    throw new Error(`Message not found in session chain: ${upToMessageId}`)
+  }
+  return index + 1
 }
 
 async function resolveMutableSessionFile(
@@ -242,10 +450,28 @@ export async function unstable_v2_prompt(
  * @returns Array of messages, or empty array if session not found
  */
 export async function getSessionMessages(
-  _sessionId: string,
-  _options?: GetSessionMessagesOptions,
+  sessionId: string,
+  options?: GetSessionMessagesOptions,
 ): Promise<SessionMessage[]> {
-  unsupportedSdkApi('getSessionMessages')
+  const resolved = await resolveSessionFilePath(sessionId, sessionDir(options))
+  if (!resolved) return []
+
+  const { postBoundaryBuf } = await readTranscriptForLoad(
+    resolved.filePath,
+    resolved.fileSize,
+  )
+  const messages = parseTranscriptMessages(postBoundaryBuf)
+  const leaf = findLatestLeaf(messages.values())
+  if (!leaf) return []
+
+  const includeSystemMessages = options?.includeSystemMessages === true
+  const offset = Math.max(0, options?.offset ?? 0)
+  const limit = options?.limit ?? 0
+  const chain = buildSessionChain(messages, leaf).filter(message =>
+    isConversationMessage(message, includeSystemMessages),
+  )
+  const page = chain.slice(offset)
+  return limit > 0 ? page.slice(0, limit) : page
 }
 
 /**
@@ -352,10 +578,72 @@ export async function tagSession(
  * @returns `{ sessionId }` — UUID of the new forked session
  */
 export async function forkSession(
-  _sessionId: string,
-  _options?: ForkSessionOptions,
+  sessionId: string,
+  options?: ForkSessionOptions,
 ): Promise<ForkSessionResult> {
-  unsupportedSdkApi('forkSession')
+  if (options?.title !== undefined && options.title.trim().length === 0) {
+    throw new Error('Session title cannot be empty')
+  }
+
+  const resolved = await resolveSessionFilePath(sessionId, sessionDir(options))
+  if (!resolved) {
+    throw new Error(`Session not found: ${sessionId}`)
+  }
+
+  const { postBoundaryBuf } = await readTranscriptForLoad(
+    resolved.filePath,
+    resolved.fileSize,
+  )
+  const messages = parseTranscriptMessages(postBoundaryBuf)
+  const leaf = findLatestLeaf(messages.values())
+  if (!leaf) {
+    throw new Error(`No messages to fork: ${sessionId}`)
+  }
+
+  const sourceChain = buildSessionChain(messages, leaf)
+  const forkBoundary = findForkBoundary(sourceChain, options?.upToMessageId)
+  const forkSource = sourceChain.slice(0, forkBoundary)
+  if (forkSource.length === 0) {
+    throw new Error(`No messages to fork: ${sessionId}`)
+  }
+
+  const forkSessionId = randomUUID()
+  const uuidMap = new Map(
+    forkSource.map(message => [message.uuid, randomUUID()] as const),
+  )
+  const forkedMessages = forkSource.map(message =>
+    cloneForkMessage(message, sessionId, forkSessionId, uuidMap),
+  )
+  const lines = forkedMessages.map(message => JSON.stringify(message))
+
+  if (options?.title) {
+    lines.push(
+      JSON.stringify({
+        type: 'custom-title',
+        customTitle: options.title.trim(),
+        sessionId: forkSessionId,
+      }),
+    )
+  }
+
+  const replacements = contentReplacementRecordsFor(postBoundaryBuf, sessionId)
+  if (replacements.length > 0) {
+    lines.push(
+      JSON.stringify({
+        type: 'content-replacement',
+        sessionId: forkSessionId,
+        replacements,
+      }),
+    )
+  }
+
+  const forkPath = join(dirname(resolved.filePath), `${forkSessionId}.jsonl`)
+  await writeFile(forkPath, lines.join('\n') + '\n', {
+    encoding: 'utf8',
+    mode: 0o600,
+  })
+
+  return { sessionId: forkSessionId }
 }
 
 // ============================================================================
@@ -457,10 +745,11 @@ export function buildMissedTaskNotification(_missed: CronTask[]): string {
 
   const blocks = _missed.map(t => {
     const meta = `[${cronToHuman(t.cron)}, created ${new Date(t.createdAt).toLocaleString()}]`
-    const longestRun = (t.prompt.match(/`+/g) ?? []).reduce(
-      (max, run) => Math.max(max, run.length),
-      0,
-    )
+    const backtickRuns = t.prompt.match(/`+/g) ?? []
+    let longestRun = 0
+    for (const run of backtickRuns) {
+      longestRun = Math.max(longestRun, run.length)
+    }
     const fence = '`'.repeat(Math.max(3, longestRun + 1))
     return `${meta}\n${fence}\n${t.prompt}\n${fence}`
   })


### PR DESCRIPTION
## Summary
- implement Agent SDK getSessionMessages over local JSONL transcript storage
- implement Agent SDK forkSession with fresh message UUIDs, title support, and content-replacement preservation
- localize rebuild-owned SDK helper types and update the README compatibility caveat

## Verification
- bun test ./entrypoints/agentSdkTypes.test.ts
- bun run pipeline
- bun test