### PR TITLE
chore: update checkout action to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: "src 2"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/permanent-structural-fix-daily.yml
+++ b/.github/workflows/permanent-structural-fix-daily.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: "src 2"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/trunk-guard.yml
+++ b/.github/workflows/trunk-guard.yml
@@ -9,7 +9,7 @@ jobs:
   block-trunk-changes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- move GitHub workflows from actions/checkout@v4 to @v5
- remove the Node 20 deprecation annotation from CI and structural workflows

## Verification
- verified actions/checkout v5.0.0 is a non-prerelease release
- checked all workflow checkout references now point at @v5