### PR TITLE
test: harden production proof checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Main branch protections and checks already present in the repo include:
 - CODEOWNERS on trunk paths in `.github/CODEOWNERS`
 - trunk guard workflow in `.github/workflows/trunk-guard.yml`
 - daily structural-fix workflow in `.github/workflows/permanent-structural-fix-daily.yml`
-- Local proof command: `cd "src 2" && bun run proof:production`
+- Local proof command: `cd "src 2" && bun run proof:production`. This runs the production pipeline, the full test suite, clean-worktree verification, GitHub main workflow checks, open-PR check rollups, Node 24-ready checkout pinning, incomplete-marker scanning, and bounded SDK/command-stub checks.
 
 If you are changing guarded architecture paths, expect extra review friction and explicit approval requirements.
 

--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -37,6 +37,34 @@ const allowedSdkUnsupported = [
   'connectRemoteControl',
 ]
 
+const workflowFiles = [
+  '.github/workflows/ci.yml',
+  '.github/workflows/permanent-structural-fix-daily.yml',
+  '.github/workflows/trunk-guard.yml',
+]
+
+const allowedDisabledCommandStubs = [
+  'src 2/commands/ant-trace/index.js',
+  'src 2/commands/autofix-pr/index.js',
+  'src 2/commands/backfill-sessions/index.js',
+  'src 2/commands/break-cache/index.js',
+  'src 2/commands/bughunter/index.js',
+  'src 2/commands/ctx_viz/index.js',
+  'src 2/commands/debug-tool-call/index.js',
+  'src 2/commands/env/index.js',
+  'src 2/commands/good-claude/index.js',
+  'src 2/commands/mock-limits/index.js',
+  'src 2/commands/oauth-refresh/index.js',
+  'src 2/commands/onboarding/index.js',
+  'src 2/commands/perf-issue/index.js',
+  'src 2/commands/reset-limits/index.js',
+  'src 2/commands/share/index.js',
+  'src 2/commands/summary/index.js',
+  'src 2/commands/teleport/index.js',
+]
+
+const allowedTodoHumanDocs = ['src 2/constants/outputStyles.ts']
+
 function run(
   command: string,
   args: string[],
@@ -84,6 +112,11 @@ function latestChecks(checks: PullRequestCheck[]): PullRequestCheck[] {
     }
   }
   return [...latest.values()]
+}
+
+function trackedFiles(repoRoot: string, prefix: string): string[] {
+  const output = run('git', ['ls-files', prefix], repoRoot, true)
+  return output ? output.split('\n').filter(Boolean) : []
 }
 
 function assertLatestWorkflowGreen(
@@ -160,6 +193,109 @@ function proveOpenPrs(repoRoot: string): void {
   console.log(`Open PRs checked: ${prs.length}`)
 }
 
+function proveWorkflowActionPins(repoRoot: string): void {
+  const badPins: string[] = []
+  for (const file of workflowFiles) {
+    const workflow = readFileSync(join(repoRoot, file), 'utf8')
+    const checkoutPins = [
+      ...workflow.matchAll(/actions\/checkout@([^\s]+)/g),
+    ].map(match => match[1]!)
+
+    if (checkoutPins.length === 0) {
+      badPins.push(`${file}: no actions/checkout pin found`)
+      continue
+    }
+
+    for (const pin of checkoutPins) {
+      if (pin !== 'v5') {
+        badPins.push(`${file}: actions/checkout@${pin}`)
+      }
+    }
+  }
+
+  if (badPins.length > 0) {
+    throw new Error(
+      `Workflow checkout actions must stay on Node 24-ready actions/checkout@v5:\n${badPins.join('\n')}`,
+    )
+  }
+
+  console.log(`Workflow checkout pins verified: ${workflowFiles.join(', ')}`)
+}
+
+function proveNoLiveIncompleteMarkers(repoRoot: string): void {
+  const sourceFiles = trackedFiles(repoRoot, 'src 2').filter(file =>
+    /\.(cjs|cts|js|jsx|mjs|mts|ts|tsx)$/.test(file),
+  )
+  const findings: string[] = []
+  const notImplementedPattern = new RegExp('not ' + 'implemented', 'i')
+  const throwMarkerPattern = new RegExp(
+    'throw new Error\\([^)]*(TODO|stub|not ' + 'implemented)',
+    'i',
+  )
+
+  for (const file of sourceFiles) {
+    const content = readFileSync(join(repoRoot, file), 'utf8')
+    const lines = content.split('\n')
+    lines.forEach((line, index) => {
+      if (/TODO\(human\)/.test(line) && !allowedTodoHumanDocs.includes(file)) {
+        findings.push(`${file}:${index + 1}: ${line.trim()}`)
+      }
+      if (notImplementedPattern.test(line)) {
+        findings.push(`${file}:${index + 1}: ${line.trim()}`)
+      }
+      if (throwMarkerPattern.test(line)) {
+        findings.push(`${file}:${index + 1}: ${line.trim()}`)
+      }
+    })
+  }
+
+  if (findings.length > 0) {
+    throw new Error(`Live incomplete markers found:\n${findings.join('\n')}`)
+  }
+
+  console.log(
+    `No live incomplete markers found across ${sourceFiles.length} tracked source files`,
+  )
+}
+
+function proveDisabledCommandStubs(repoRoot: string): void {
+  const commandFiles = trackedFiles(repoRoot, 'src 2/commands').filter(file =>
+    file.endsWith('/index.js'),
+  )
+  const found = commandFiles.filter(file => {
+    const content = readFileSync(join(repoRoot, file), 'utf8')
+    return (
+      content.includes("isEnabled: () => false") &&
+      content.includes('isHidden: true') &&
+      content.includes("name: 'stub'")
+    )
+  })
+
+  const unexpected = found.filter(
+    file => !allowedDisabledCommandStubs.includes(file),
+  )
+  const missing = allowedDisabledCommandStubs.filter(
+    file => !found.includes(file),
+  )
+
+  if (unexpected.length > 0 || missing.length > 0) {
+    throw new Error(
+      [
+        unexpected.length
+          ? `Unexpected disabled command stubs: ${unexpected.join(', ')}`
+          : '',
+        missing.length
+          ? `Expected disabled command stubs not found: ${missing.join(', ')}`
+          : '',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    )
+  }
+
+  console.log(`Disabled command stubs are bounded: ${found.length}`)
+}
+
 function proveSdkStubs(sourceRoot: string): void {
   const sdkEntry = readFileSync(
     join(sourceRoot, 'entrypoints', 'agentSdkTypes.ts'),
@@ -207,6 +343,18 @@ function main(): void {
     }
     run('git', ['diff', '--exit-code'], repoRoot, true)
     run('git', ['diff', '--cached', '--exit-code'], repoRoot, true)
+  })
+
+  step('workflow checkout actions are Node 24 ready', () => {
+    proveWorkflowActionPins(repoRoot)
+  })
+
+  step('live incomplete markers are absent', () => {
+    proveNoLiveIncompleteMarkers(repoRoot)
+  })
+
+  step('disabled command stubs are explicit and bounded', () => {
+    proveDisabledCommandStubs(repoRoot)
   })
 
   step('latest main workflows are green for origin/main', () => {


### PR DESCRIPTION
## Summary
- extend the production proof harness with Node 24-ready workflow checkout pin checks
- add deterministic scans for live incomplete markers and bounded disabled command stubs
- document the expanded proof coverage in README

## Verification
- PROOF_ALLOW_DIRTY=1 bun run proof:production
- bun run proof:production