### PR TITLE
test: preflight proof worktree cleanliness

### DIFF
--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -336,9 +336,22 @@ function proveSdkStubs(sourceRoot: string): void {
   console.log(`Documented SDK unsupported surfaces: ${found.join(', ')}`)
 }
 
+function proveTrackedWorktreeClean(repoRoot: string): void {
+  if (process.env.PROOF_ALLOW_DIRTY === '1') {
+    console.log('Skipped because PROOF_ALLOW_DIRTY=1')
+    return
+  }
+  run('git', ['diff', '--exit-code'], repoRoot, true)
+  run('git', ['diff', '--cached', '--exit-code'], repoRoot, true)
+}
+
 function main(): void {
   const repoRoot = run('git', ['rev-parse', '--show-toplevel'], process.cwd(), true)
   const sourceRoot = join(repoRoot, 'src 2')
+
+  step('tracked worktree clean before proof run', () => {
+    proveTrackedWorktreeClean(repoRoot)
+  })
 
   step('local production pipeline', () => {
     run('bun', ['run', 'pipeline'], sourceRoot)
@@ -349,12 +362,7 @@ function main(): void {
   })
 
   step('tracked worktree unchanged by proof run', () => {
-    if (process.env.PROOF_ALLOW_DIRTY === '1') {
-      console.log('Skipped because PROOF_ALLOW_DIRTY=1')
-      return
-    }
-    run('git', ['diff', '--exit-code'], repoRoot, true)
-    run('git', ['diff', '--cached', '--exit-code'], repoRoot, true)
+    proveTrackedWorktreeClean(repoRoot)
   })
 
   step('workflow checkout actions are Node 24 ready', () => {


### PR DESCRIPTION
## What changed

Adds a preflight tracked-worktree cleanliness check to `bun run proof:production` before the expensive pipeline and full test suite run. The existing post-run cleanliness assertion remains in place.

## Why

This makes the production proof harder to fool: if tracked files are dirty before verification begins, the proof fails immediately instead of spending time on build/test output and only checking cleanliness afterward.

## Validation

- `cd "src 2" && bun run proof:production`
- Result: production proof passed with 411 tests passing, live incomplete marker scan clean, disabled command stubs bounded, latest main CI/daily workflows green, open PR rollups clean, and SDK unsupported surfaces bounded.