### PR TITLE
test: prove no focused or skipped tests

### DIFF
--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -336,6 +336,34 @@ function proveSdkStubs(sourceRoot: string): void {
   console.log(`Documented SDK unsupported surfaces: ${found.join(', ')}`)
 }
 
+function proveNoFocusedOrSkippedTests(repoRoot: string): void {
+  const testFiles = trackedFiles(repoRoot, 'src 2').filter(file =>
+    /\.(test|spec)\.(cjs|cts|js|jsx|mjs|mts|ts|tsx)$/.test(file),
+  )
+  const modifierPattern =
+    /\b(?:describe|test|it)\s*\.\s*(?:only|skip)\b(?:\s*\.\s*each\b)?\s*\(/g
+  const findings: string[] = []
+
+  for (const file of testFiles) {
+    const content = readFileSync(join(repoRoot, file), 'utf8')
+    const lines = content.split('\n')
+    lines.forEach((line, index) => {
+      if (modifierPattern.test(line)) {
+        findings.push(`${file}:${index + 1}: ${line.trim()}`)
+      }
+      modifierPattern.lastIndex = 0
+    })
+  }
+
+  if (findings.length > 0) {
+    throw new Error(`Focused or skipped tests found:\n${findings.join('\n')}`)
+  }
+
+  console.log(
+    `No focused or skipped tests found across ${testFiles.length} test files`,
+  )
+}
+
 function proveTrackedWorktreeClean(repoRoot: string): void {
   if (process.env.PROOF_ALLOW_DIRTY === '1') {
     console.log('Skipped because PROOF_ALLOW_DIRTY=1')
@@ -359,6 +387,10 @@ function main(): void {
 
   step('full local test suite', () => {
     run('bun', ['test'], sourceRoot)
+  })
+
+  step('test suite has no focused or skipped tests', () => {
+    proveNoFocusedOrSkippedTests(repoRoot)
   })
 
   step('tracked worktree unchanged by proof run', () => {


### PR DESCRIPTION
## What changed

Adds a production-proof gate that scans tracked test files for focused or skipped test modifiers such as `test.only(...)`, `describe.skip(...)`, and `it.skip.each(...)`.

## Why

A green test run is much stronger when the proof also verifies that no tests were silently focused or skipped. This gives the production-readiness receipt another deterministic anti-slop check.

## Validation

- `cd "src 2" && PROOF_ALLOW_DIRTY=1 bun run proof:production`
- `cd "src 2" && bun run proof:production`
- Result: production proof passed with 411 tests passing and `No focused or skipped tests found across 65 test files`.