### PR TITLE
docs: document test hygiene proof gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Main branch protections and checks already present in the repo include:
 - CODEOWNERS on trunk paths in `.github/CODEOWNERS`
 - trunk guard workflow in `.github/workflows/trunk-guard.yml`
 - daily structural-fix workflow in `.github/workflows/permanent-structural-fix-daily.yml`
-- Local proof command: `cd "src 2" && bun run proof:production`. This runs the production pipeline, the full test suite, clean-worktree verification, GitHub main workflow checks, open-PR check rollups, Node 24-ready checkout pinning, incomplete-marker scanning, and bounded SDK/command-stub checks.
+- Local proof command: `cd "src 2" && bun run proof:production`. This runs the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow checks, open-PR check rollups, Node 24-ready checkout pinning, incomplete-marker scanning, and bounded SDK/command-stub checks.
 - Proof notes and current receipt in `docs/production-proof.md`
 
 If you are changing guarded architecture paths, expect extra review friction and explicit approval requirements.

--- a/docs/production-proof.md
+++ b/docs/production-proof.md
@@ -15,7 +15,9 @@ bun run proof:production
 - Local production pipeline: typecheck, lint, builds, CLI smoke, bundle smoke,
   KAIROS smoke, and employee smoke.
 - Full local test suite: 411 tests across 65 files.
-- Tracked worktree cleanliness after the proof run.
+- Test hygiene: no focused, skipped, pending, or expected-failing test
+  modifiers across tracked test files.
+- Tracked worktree cleanliness before and after the proof run.
 - Latest `origin/main` `ci` workflow is completed and successful for the exact
   main commit.
 - Latest `origin/main` `permanent-structural-fix-daily` workflow is completed
@@ -47,6 +49,7 @@ The local proof result must end with:
 ```text
 411 pass
 0 fail
+No focused, skipped, pending, or expected-failing tests found across 65 test files
 PRODUCTION PROOF PASSED
 ```
 
@@ -85,5 +88,6 @@ The SDK facade currently permits exactly these unsupported surfaces:
 - `watchScheduledTasks`
 - `connectRemoteControl`
 
-Any new live incomplete marker, unbounded disabled command stub, or unexpected
-SDK unsupported surface should fail `bun run proof:production`.
+Any new live incomplete marker, focused/skipped/pending/expected-failing test,
+unbounded disabled command stub, or unexpected SDK unsupported surface should
+fail `bun run proof:production`.


### PR DESCRIPTION
## What changed

Updates the README and production-proof receipt so the written quality gate matches the executable proof command after the latest hardening work.

The docs now mention:

- preflight and post-run tracked worktree cleanliness
- no focused, skipped, pending, or expected-failing test modifiers
- the expected proof receipt line for the test-hygiene scan

## Why

The production proof is only useful if the repo documentation describes the actual guardrails. This keeps the anti-slop receipt precise and non-stale.

## Validation

- `git diff --check`
- `cd "src 2" && bun run proof:production`
- Result: production proof passed with 411 tests passing and the test-hygiene gate clean across 65 test files.