### PR TITLE
[codex] enforce CI supply-chain audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Audit dependencies
+        run: bun audit
+
       - name: Run production pipeline
         run: bun run pipeline
 

--- a/.github/workflows/permanent-structural-fix-daily.yml
+++ b/.github/workflows/permanent-structural-fix-daily.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Audit dependencies
+        run: bun audit
+
       - name: Run permanent structural fix loop
         run: bun run structural-fix:daily

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Main branch protections and checks already present in the repo include:
 - CODEOWNERS on trunk paths in `.github/CODEOWNERS`
 - trunk guard workflow in `.github/workflows/trunk-guard.yml`
 - daily structural-fix workflow in `.github/workflows/permanent-structural-fix-daily.yml`
-- Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow checks, open-PR check rollups, Node 24-ready checkout pinning, incomplete-marker scanning, and bounded SDK/command-stub checks.
+- Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow checks, open-PR check rollups, Node 24-ready checkout pinning, GitHub workflow frozen-install/audit gate verification, incomplete-marker scanning, and bounded SDK/command-stub checks.
 - Proof notes and current receipt in `docs/production-proof.md`
 
 If you are changing guarded architecture paths, expect extra review friction and explicit approval requirements.

--- a/docs/production-proof.md
+++ b/docs/production-proof.md
@@ -27,6 +27,8 @@ bun run proof:production
   and successful for the exact main commit.
 - Current open PR check rollups have no red latest checks.
 - Workflow checkout actions stay pinned to Node 24-ready `actions/checkout@v5`.
+- GitHub `ci` and `permanent-structural-fix-daily` workflows keep
+  frozen-lockfile install and supply-chain audit gates enabled.
 - Live incomplete markers are absent across tracked source files.
 - Disabled command stubs are explicit and bounded.
 - SDK unsupported surfaces are explicit and bounded.

--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -43,6 +43,11 @@ const workflowFiles = [
   '.github/workflows/trunk-guard.yml',
 ]
 
+const workflowSupplyChainFiles = [
+  '.github/workflows/ci.yml',
+  '.github/workflows/permanent-structural-fix-daily.yml',
+]
+
 const allowedDisabledCommandStubs = [
   'src 2/commands/ant-trace/index.js',
   'src 2/commands/autofix-pr/index.js',
@@ -234,6 +239,30 @@ function proveWorkflowActionPins(repoRoot: string): void {
   console.log(`Workflow checkout pins verified: ${workflowFiles.join(', ')}`)
 }
 
+function proveWorkflowSupplyChainGates(repoRoot: string): void {
+  const missing: string[] = []
+
+  for (const file of workflowSupplyChainFiles) {
+    const workflow = readFileSync(join(repoRoot, file), 'utf8')
+    if (!workflow.includes('bun install --frozen-lockfile')) {
+      missing.push(`${file}: missing bun install --frozen-lockfile`)
+    }
+    if (!workflow.includes('bun audit')) {
+      missing.push(`${file}: missing bun audit`)
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Workflow supply-chain gates must stay enabled:\n${missing.join('\n')}`,
+    )
+  }
+
+  console.log(
+    `Workflow supply-chain gates verified: ${workflowSupplyChainFiles.join(', ')}`,
+  )
+}
+
 function proveNoLiveIncompleteMarkers(repoRoot: string): void {
   const sourceFiles = trackedFiles(repoRoot, 'src 2').filter(file =>
     /\.(cjs|cts|js|jsx|mjs|mts|ts|tsx)$/.test(file),
@@ -412,6 +441,10 @@ function main(): void {
 
   step('workflow checkout actions are Node 24 ready', () => {
     proveWorkflowActionPins(repoRoot)
+  })
+
+  step('workflow supply-chain gates are enabled', () => {
+    proveWorkflowSupplyChainGates(repoRoot)
   })
 
   step('live incomplete markers are absent', () => {


### PR DESCRIPTION
## Summary

- add `bun audit` to the GitHub `ci` workflow after frozen install
- add `bun audit` to the daily structural workflow after frozen install
- make `bun run proof:production` verify CI workflows keep frozen-install and audit gates enabled
- document the workflow supply-chain gate in the production proof notes

## Why

PR #97 made local production proof include dependency reproducibility and zero known vulnerabilities. This PR makes the same supply-chain signal part of GitHub green status, and makes proof fail if someone removes those workflow gates later.

## Validation

- `bun audit`
- `PROOF_ALLOW_DIRTY=1 bun run proof:production`
- strict `bun run proof:production` after commit, ending in `PRODUCTION PROOF PASSED`
