### PR TITLE
test: verify hosted workflow step receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Main branch protections and checks already present in the repo include:
 - CODEOWNERS on trunk paths in `.github/CODEOWNERS`
 - trunk guard workflow in `.github/workflows/trunk-guard.yml`
 - daily structural-fix workflow in `.github/workflows/permanent-structural-fix-daily.yml`
-- Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow checks, open-PR check rollups, Node 24-ready checkout pinning, GitHub workflow frozen-install/audit/static-proof gate verification, incomplete-marker scanning, and bounded SDK/command-stub checks.
+- Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow and hosted-step receipt checks, open-PR check rollups, Node 24-ready checkout pinning, GitHub workflow frozen-install/audit/static-proof gate verification, incomplete-marker scanning, and bounded SDK/command-stub checks.
 - Proof notes and current receipt in `docs/production-proof.md`
 
 If you are changing guarded architecture paths, expect extra review friction and explicit approval requirements.

--- a/docs/production-proof.md
+++ b/docs/production-proof.md
@@ -25,6 +25,9 @@ bun run proof:production
   main commit.
 - Latest `origin/main` `permanent-structural-fix-daily` workflow is completed
   and successful for the exact main commit.
+- Hosted GitHub job receipts include successful required steps for frozen
+  install, dependency audit, production pipeline/tests or daily structural fix,
+  and static production proof.
 - Current open PR check rollups have no red latest checks.
 - Workflow checkout actions stay pinned to Node 24-ready `actions/checkout@v5`.
 - GitHub `ci` and `permanent-structural-fix-daily` workflows keep
@@ -49,13 +52,15 @@ cd "src 2"
 bun run proof:production
 ```
 
-The local proof result must end with:
+The local proof result must include the hosted-step receipt lines and end with:
 
 ```text
 411 pass
 0 fail
 No vulnerabilities found
 No focused, skipped, pending, or expected-failing tests found across 65 test files
+ci hosted steps verified
+permanent-structural-fix-daily hosted steps verified
 PRODUCTION PROOF PASSED
 ```
 

--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -12,6 +12,23 @@ type RunResult = {
   url: string
 }
 
+type RunStep = {
+  name: string
+  status: string
+  conclusion: string | null
+}
+
+type RunJob = {
+  name: string
+  status: string
+  conclusion: string | null
+  steps: RunStep[]
+}
+
+type RunView = {
+  jobs: RunJob[]
+}
+
 type PullRequestCheck = {
   name?: string
   status?: string
@@ -52,6 +69,22 @@ const workflowStaticProofFiles = [
   '.github/workflows/ci.yml',
   '.github/workflows/permanent-structural-fix-daily.yml',
 ]
+
+const requiredHostedWorkflowSteps: Record<string, string[]> = {
+  ci: [
+    'Install dependencies',
+    'Audit dependencies',
+    'Run production pipeline',
+    'Run full test suite',
+    'Run static production proof gates',
+  ],
+  'permanent-structural-fix-daily': [
+    'Install dependencies',
+    'Audit dependencies',
+    'Run permanent structural fix loop',
+    'Run static production proof gates',
+  ],
+}
 
 const allowedDisabledCommandStubs = [
   'src 2/commands/ant-trace/index.js',
@@ -147,7 +180,7 @@ function assertLatestWorkflowGreen(
   runs: RunResult[],
   workflowName: string,
   headSha: string,
-): void {
+): RunResult {
   const runForHead = latestWorkflowRun(runs, workflowName, headSha)
   if (!runForHead) {
     throw new Error(`No ${workflowName} run found for origin/main ${headSha}`)
@@ -158,6 +191,49 @@ function assertLatestWorkflowGreen(
     )
   }
   console.log(`${workflowName}: ${runForHead.url}`)
+  return runForHead
+}
+
+function proveHostedWorkflowSteps(repoRoot: string, runResult: RunResult): void {
+  const requiredSteps = requiredHostedWorkflowSteps[runResult.workflowName]
+  if (!requiredSteps) {
+    throw new Error(
+      `No required hosted steps configured for ${runResult.workflowName}`,
+    )
+  }
+
+  const runView = json<RunView>(
+    'gh',
+    ['run', 'view', String(runResult.databaseId), '--json', 'jobs'],
+    repoRoot,
+  )
+  const steps = runView.jobs.flatMap(job =>
+    (job.steps ?? []).map(step => ({ ...step, jobName: job.name })),
+  )
+  const failures: string[] = []
+
+  for (const stepName of requiredSteps) {
+    const step = steps.find(candidate => candidate.name === stepName)
+    if (!step) {
+      failures.push(`${runResult.workflowName}: missing hosted step "${stepName}"`)
+      continue
+    }
+    if (step.status !== 'completed' || step.conclusion !== 'success') {
+      failures.push(
+        `${runResult.workflowName}: step "${stepName}" in job "${step.jobName}" is ${step.status}/${step.conclusion}`,
+      )
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Hosted workflow step receipts are not green:\n${failures.join('\n')}`,
+    )
+  }
+
+  console.log(
+    `${runResult.workflowName} hosted steps verified: ${requiredSteps.join(', ')}`,
+  )
 }
 
 function proveRemoteMain(repoRoot: string): void {
@@ -178,8 +254,14 @@ function proveRemoteMain(repoRoot: string): void {
     repoRoot,
   )
 
-  assertLatestWorkflowGreen(runs, 'ci', mainSha)
-  assertLatestWorkflowGreen(runs, 'permanent-structural-fix-daily', mainSha)
+  const ciRun = assertLatestWorkflowGreen(runs, 'ci', mainSha)
+  const dailyRun = assertLatestWorkflowGreen(
+    runs,
+    'permanent-structural-fix-daily',
+    mainSha,
+  )
+  proveHostedWorkflowSteps(repoRoot, ciRun)
+  proveHostedWorkflowSteps(repoRoot, dailyRun)
 }
 
 function proveOpenPrs(repoRoot: string): void {


### PR DESCRIPTION
## Summary
- make production proof inspect hosted GitHub run job steps for current main
- require CI and daily structural runs to show install, audit, pipeline/structural, tests where applicable, and static-proof steps completed successfully
- document the hosted-step receipt contract

## Verification
- PROOF_ALLOW_DIRTY=1 bun run proof:production
- bun run proof:production