### PR TITLE
test: prove main branch protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Main branch protections and checks already present in the repo include:
 - CODEOWNERS on trunk paths in `.github/CODEOWNERS`
 - trunk guard workflow in `.github/workflows/trunk-guard.yml`
 - daily structural-fix workflow in `.github/workflows/permanent-structural-fix-daily.yml`
-- Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow and hosted-step receipt checks, open-PR check rollups, Node 24-ready checkout pinning, GitHub workflow frozen-install/audit/static-proof gate verification, incomplete-marker scanning, and bounded SDK/command-stub checks.
+- Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow and hosted-step receipt checks, main branch protection checks, open-PR check rollups, Node 24-ready checkout pinning, GitHub workflow frozen-install/audit/static-proof gate verification, incomplete-marker scanning, and bounded SDK/command-stub checks.
 - Proof notes and current receipt in `docs/production-proof.md`
 
 If you are changing guarded architecture paths, expect extra review friction and explicit approval requirements.

--- a/docs/production-proof.md
+++ b/docs/production-proof.md
@@ -28,6 +28,8 @@ bun run proof:production
 - Hosted GitHub job receipts include successful required steps for frozen
   install, dependency audit, production pipeline/tests or daily structural fix,
   and static production proof.
+- Main branch protection requires up-to-date `block-trunk-changes` and `verify`
+  status checks, includes administrators, and blocks force pushes/deletions.
 - Current open PR check rollups have no red latest checks.
 - Workflow checkout actions stay pinned to Node 24-ready `actions/checkout@v5`.
 - GitHub `ci` and `permanent-structural-fix-daily` workflows keep
@@ -61,6 +63,7 @@ No vulnerabilities found
 No focused, skipped, pending, or expected-failing tests found across 65 test files
 ci hosted steps verified
 permanent-structural-fix-daily hosted steps verified
+Main branch protection verified
 PRODUCTION PROOF PASSED
 ```
 

--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -29,6 +29,17 @@ type RunView = {
   jobs: RunJob[]
 }
 
+type BranchProtection = {
+  required_status_checks?: {
+    strict: boolean
+    contexts?: string[]
+    checks?: Array<{ context: string }>
+  }
+  enforce_admins?: { enabled: boolean }
+  allow_force_pushes?: { enabled: boolean }
+  allow_deletions?: { enabled: boolean }
+}
+
 type PullRequestCheck = {
   name?: string
   status?: string
@@ -85,6 +96,8 @@ const requiredHostedWorkflowSteps: Record<string, string[]> = {
     'Run static production proof gates',
   ],
 }
+
+const requiredMainBranchChecks = ['block-trunk-changes', 'verify']
 
 const allowedDisabledCommandStubs = [
   'src 2/commands/ant-trace/index.js',
@@ -176,6 +189,15 @@ function trackedFiles(repoRoot: string, prefix: string): string[] {
   return output ? output.split('\n').filter(Boolean) : []
 }
 
+function repoSlug(repoRoot: string): string {
+  return run(
+    'gh',
+    ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
+    repoRoot,
+    true,
+  )
+}
+
 function assertLatestWorkflowGreen(
   runs: RunResult[],
   workflowName: string,
@@ -262,6 +284,55 @@ function proveRemoteMain(repoRoot: string): void {
   )
   proveHostedWorkflowSteps(repoRoot, ciRun)
   proveHostedWorkflowSteps(repoRoot, dailyRun)
+}
+
+function proveMainBranchProtection(repoRoot: string): void {
+  const protection = json<BranchProtection>(
+    'gh',
+    ['api', `repos/${repoSlug(repoRoot)}/branches/main/protection`],
+    repoRoot,
+  )
+  const requiredChecks = new Set([
+    ...(protection.required_status_checks?.contexts ?? []),
+    ...(protection.required_status_checks?.checks ?? []).map(
+      check => check.context,
+    ),
+  ])
+  const failures: string[] = []
+
+  if (protection.required_status_checks?.strict !== true) {
+    failures.push('main branch must require branches to be up to date')
+  }
+
+  for (const check of requiredMainBranchChecks) {
+    if (!requiredChecks.has(check)) {
+      failures.push(`main branch must require status check "${check}"`)
+    }
+  }
+
+  if (protection.enforce_admins?.enabled !== true) {
+    failures.push('main branch protection must include administrators')
+  }
+
+  if (protection.allow_force_pushes?.enabled !== false) {
+    failures.push('main branch must not allow force pushes')
+  }
+
+  if (protection.allow_deletions?.enabled !== false) {
+    failures.push('main branch must not allow deletions')
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Main branch protection is not production-ready:\n${failures.join('\n')}`,
+    )
+  }
+
+  console.log(
+    `Main branch protection verified: required checks ${requiredMainBranchChecks.join(
+      ', ',
+    )}`,
+  )
 }
 
 function proveOpenPrs(repoRoot: string): void {
@@ -617,6 +688,10 @@ function main(): void {
 
   step('latest main workflows are green for origin/main', () => {
     proveRemoteMain(repoRoot)
+  })
+
+  step('main branch protection requires green checks', () => {
+    proveMainBranchProtection(repoRoot)
   })
 
   step('open PR check rollups have no current red checks', () => {


### PR DESCRIPTION
## Summary
- assert main branch protection from the production proof
- require strict status checks for block-trunk-changes and verify
- document branch-protection receipts alongside local and hosted proof gates

## Repository setting changed
- main branch required status checks now include block-trunk-changes and verify with strict up-to-date checks enabled

## Verification
- PROOF_ALLOW_DIRTY=1 bun run proof:production
- bun run proof:production