### PR TITLE
ci: restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/permanent-structural-fix-daily.yml
+++ b/.github/workflows/permanent-structural-fix-daily.yml
@@ -5,6 +5,9 @@ on:
     - cron: '17 9 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   permanent-structural-fix:
     runs-on: ubuntu-latest

--- a/.github/workflows/trunk-guard.yml
+++ b/.github/workflows/trunk-guard.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   block-trunk-changes:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Main branch protections and checks already present in the repo include:
 - CODEOWNERS on trunk paths in `.github/CODEOWNERS`
 - trunk guard workflow in `.github/workflows/trunk-guard.yml`
 - daily structural-fix workflow in `.github/workflows/permanent-structural-fix-daily.yml`
-- Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow and hosted-step receipt checks, main branch protection checks, open-PR check rollups, Node 24-ready checkout pinning, GitHub workflow frozen-install/audit/static-proof gate verification, incomplete-marker scanning, and bounded SDK/command-stub checks.
+- Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow and hosted-step receipt checks, main branch protection checks, open-PR check rollups, Node 24-ready checkout pinning, GitHub workflow frozen-install/audit/static-proof gate verification, least-privilege workflow token permission checks, incomplete-marker scanning, and bounded SDK/command-stub checks.
 - Proof notes and current receipt in `docs/production-proof.md`
 
 If you are changing guarded architecture paths, expect extra review friction and explicit approval requirements.

--- a/docs/production-proof.md
+++ b/docs/production-proof.md
@@ -34,6 +34,8 @@ bun run proof:production
 - Workflow checkout actions stay pinned to Node 24-ready `actions/checkout@v5`.
 - GitHub `ci` and `permanent-structural-fix-daily` workflows keep
   frozen-lockfile install, supply-chain audit, and static proof gates enabled.
+- GitHub workflows declare least-privilege `GITHUB_TOKEN` permissions and do
+  not request write-scoped or broad read/write-all permissions.
 - Live incomplete markers are absent across tracked source files.
 - Disabled command stubs are explicit and bounded.
 - SDK unsupported surfaces are explicit and bounded.
@@ -64,6 +66,7 @@ No focused, skipped, pending, or expected-failing tests found across 65 test fil
 ci hosted steps verified
 permanent-structural-fix-daily hosted steps verified
 Main branch protection verified
+Workflow token permissions verified
 PRODUCTION PROOF PASSED
 ```
 
@@ -73,9 +76,10 @@ GitHub workflows also run:
 bun run proof:static
 ```
 
-That CI-friendly proof mode verifies test hygiene, workflow pins and
-supply-chain gates, incomplete-marker scanning, disabled command stub bounds,
-and SDK unsupported-surface bounds without requiring GitHub API access.
+That CI-friendly proof mode verifies test hygiene, workflow pins, workflow
+supply-chain/static-proof gates, least-privilege token permissions,
+incomplete-marker scanning, disabled command stub bounds, and SDK
+unsupported-surface bounds without requiring GitHub API access.
 
 ## 8090 Comparison Boundary
 

--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -81,6 +81,15 @@ const workflowStaticProofFiles = [
   '.github/workflows/permanent-structural-fix-daily.yml',
 ]
 
+const requiredWorkflowPermissions: Record<string, string[]> = {
+  '.github/workflows/ci.yml': ['contents: read'],
+  '.github/workflows/permanent-structural-fix-daily.yml': ['contents: read'],
+  '.github/workflows/trunk-guard.yml': [
+    'contents: read',
+    'pull-requests: read',
+  ],
+}
+
 const requiredHostedWorkflowSteps: Record<string, string[]> = {
   ci: [
     'Install dependencies',
@@ -442,6 +451,40 @@ function proveWorkflowStaticProofGates(repoRoot: string): void {
   )
 }
 
+function proveWorkflowTokenPermissions(repoRoot: string): void {
+  const failures: string[] = []
+  const writePermissionPattern = /^\s*[a-z-]+:\s*write\s*$/m
+
+  for (const [file, permissions] of Object.entries(requiredWorkflowPermissions)) {
+    const workflow = readFileSync(join(repoRoot, file), 'utf8')
+    const expectedBlock = `permissions:\n${permissions
+      .map(permission => `  ${permission}`)
+      .join('\n')}`
+
+    if (!workflow.includes(expectedBlock)) {
+      failures.push(`${file}: missing exact least-privilege permissions block`)
+    }
+    if (/^\s*permissions:\s*(?:read-all|write-all)\s*$/m.test(workflow)) {
+      failures.push(`${file}: must not use broad read-all/write-all permissions`)
+    }
+    if (writePermissionPattern.test(workflow)) {
+      failures.push(`${file}: must not request write token permissions`)
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Workflow token permissions are not least-privilege:\n${failures.join('\n')}`,
+    )
+  }
+
+  console.log(
+    `Workflow token permissions verified: ${Object.keys(
+      requiredWorkflowPermissions,
+    ).join(', ')}`,
+  )
+}
+
 function proveNoLiveIncompleteMarkers(repoRoot: string): void {
   const sourceFiles = trackedFiles(repoRoot, 'src 2').filter(file =>
     /\.(cjs|cts|js|jsx|mjs|mts|ts|tsx)$/.test(file),
@@ -611,6 +654,10 @@ function proveStaticGates(repoRoot: string, sourceRoot: string): void {
     proveWorkflowStaticProofGates(repoRoot)
   })
 
+  step('workflow token permissions are least-privilege', () => {
+    proveWorkflowTokenPermissions(repoRoot)
+  })
+
   step('live incomplete markers are absent', () => {
     proveNoLiveIncompleteMarkers(repoRoot)
   })
@@ -676,6 +723,10 @@ function main(): void {
 
   step('workflow static production proof gates are enabled', () => {
     proveWorkflowStaticProofGates(repoRoot)
+  })
+
+  step('workflow token permissions are least-privilege', () => {
+    proveWorkflowTokenPermissions(repoRoot)
   })
 
   step('live incomplete markers are absent', () => {


### PR DESCRIPTION
## Summary
- declare least-privilege GITHUB_TOKEN permissions in CI, daily structural proof, and trunk guard workflows
- make production/static proof fail if workflow token permissions drift to write-all/read-all or write-scoped grants
- document the new workflow permission proof gate

## Verification
- PROOF_ALLOW_DIRTY=1 bun run proof:static
- bun run proof:production