### PR TITLE
test: prove Actions default token permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Main branch protections and checks already present in the repo include:
 - CODEOWNERS on trunk paths in `.github/CODEOWNERS`
 - trunk guard workflow in `.github/workflows/trunk-guard.yml`
 - daily structural-fix workflow in `.github/workflows/permanent-structural-fix-daily.yml`
-- Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow and hosted-step receipt checks, main branch protection checks, open-PR check rollups, Node 24-ready checkout pinning, GitHub workflow frozen-install/audit/static-proof gate verification, least-privilege workflow token permission checks, incomplete-marker scanning, and bounded SDK/command-stub checks.
+- Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow and hosted-step receipt checks, main branch protection checks, repository Actions default permission checks, open-PR check rollups, Node 24-ready checkout pinning, GitHub workflow frozen-install/audit/static-proof gate verification, least-privilege workflow token permission checks, incomplete-marker scanning, and bounded SDK/command-stub checks.
 - Proof notes and current receipt in `docs/production-proof.md`
 
 If you are changing guarded architecture paths, expect extra review friction and explicit approval requirements.

--- a/docs/production-proof.md
+++ b/docs/production-proof.md
@@ -30,6 +30,8 @@ bun run proof:production
   and static production proof.
 - Main branch protection requires up-to-date `block-trunk-changes` and `verify`
   status checks, includes administrators, and blocks force pushes/deletions.
+- Repository Actions defaults grant read-only workflow tokens and forbid
+  workflow tokens from approving pull requests.
 - Current open PR check rollups have no red latest checks.
 - Workflow checkout actions stay pinned to Node 24-ready `actions/checkout@v5`.
 - GitHub `ci` and `permanent-structural-fix-daily` workflows keep
@@ -67,6 +69,7 @@ ci hosted steps verified
 permanent-structural-fix-daily hosted steps verified
 Main branch protection verified
 Workflow token permissions verified
+Repository Actions default workflow permissions verified
 PRODUCTION PROOF PASSED
 ```
 

--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -40,6 +40,11 @@ type BranchProtection = {
   allow_deletions?: { enabled: boolean }
 }
 
+type ActionsWorkflowPermissions = {
+  default_workflow_permissions: string
+  can_approve_pull_request_reviews: boolean
+}
+
 type PullRequestCheck = {
   name?: string
   status?: string
@@ -342,6 +347,33 @@ function proveMainBranchProtection(repoRoot: string): void {
       ', ',
     )}`,
   )
+}
+
+function proveActionsDefaultWorkflowPermissions(repoRoot: string): void {
+  const permissions = json<ActionsWorkflowPermissions>(
+    'gh',
+    ['api', `repos/${repoSlug(repoRoot)}/actions/permissions/workflow`],
+    repoRoot,
+  )
+  const failures: string[] = []
+
+  if (permissions.default_workflow_permissions !== 'read') {
+    failures.push(
+      `default workflow token permissions are ${permissions.default_workflow_permissions}, expected read`,
+    )
+  }
+
+  if (permissions.can_approve_pull_request_reviews !== false) {
+    failures.push('workflow token must not be able to approve pull requests')
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `Repository Actions workflow permissions are not production-ready:\n${failures.join('\n')}`,
+    )
+  }
+
+  console.log('Repository Actions default workflow permissions verified: read')
 }
 
 function proveOpenPrs(repoRoot: string): void {
@@ -743,6 +775,10 @@ function main(): void {
 
   step('main branch protection requires green checks', () => {
     proveMainBranchProtection(repoRoot)
+  })
+
+  step('repository Actions default permissions are read-only', () => {
+    proveActionsDefaultWorkflowPermissions(repoRoot)
   })
 
   step('open PR check rollups have no current red checks', () => {


### PR DESCRIPTION
## Summary
- make production proof assert repository Actions defaults keep workflow tokens read-only
- fail proof if workflow tokens are allowed to approve pull requests
- document the repo-level Actions permission receipt

## Verification
- PROOF_ALLOW_DIRTY=1 bun run proof:production
- bun run proof:production