### PR TITLE
ci: ignore known-breaking dependency majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       time: "10:00"
       timezone: "America/Toronto"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "eslint"
+        versions: [">=10"]
+      - dependency-name: "typescript"
+        versions: [">=6"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -17,3 +22,6 @@ updates:
       time: "10:30"
       timezone: "America/Toronto"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "actions/checkout"
+        versions: [">=6"]

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Main branch protections and checks already present in the repo include:
 - CODEOWNERS on trunk paths in `.github/CODEOWNERS`
 - trunk guard workflow in `.github/workflows/trunk-guard.yml`
 - daily structural-fix workflow in `.github/workflows/permanent-structural-fix-daily.yml`
-- Dependabot version updates in `.github/dependabot.yml` for Bun dependencies and GitHub Actions, with Dependabot security updates enabled at the repository level.
+- Dependabot version updates in `.github/dependabot.yml` for Bun dependencies and GitHub Actions, with known-breaking major lines ignored until they get deliberate upgrade work, and Dependabot security updates enabled at the repository level.
 - Local proof command: `cd "src 2" && bun run proof:production`. This runs frozen-lockfile install verification, supply-chain audit, the production pipeline, the full test suite, non-running-test modifier scanning, clean-worktree verification, GitHub main workflow and hosted-step receipt checks, main branch protection checks, repository Actions default permission checks, repository security setting checks, Dependabot update-policy checks, open-PR check rollups, Node 24-ready checkout pinning, GitHub workflow frozen-install/audit/static-proof gate verification, least-privilege workflow token permission checks, incomplete-marker scanning, and bounded SDK/command-stub checks.
 - Proof notes and current receipt in `docs/production-proof.md`
 

--- a/docs/production-proof.md
+++ b/docs/production-proof.md
@@ -35,7 +35,8 @@ bun run proof:production
 - Repository security settings keep Dependabot security updates, secret
   scanning, and secret scanning push protection enabled.
 - Dependabot version-update policy watches Bun dependencies under `src 2/` and
-  GitHub Actions weekly, with a bounded open-PR limit.
+  GitHub Actions weekly, with a bounded open-PR limit and known-breaking major
+  lines ignored until deliberate upgrade work lands.
 - Current open PR check rollups have no red latest checks.
 - Workflow checkout actions stay pinned to Node 24-ready `actions/checkout@v5`.
 - GitHub `ci` and `permanent-structural-fix-daily` workflows keep

--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -66,6 +66,10 @@ type DependabotUpdate = {
     timezone?: string
   }
   'open-pull-requests-limit'?: number
+  ignore?: Array<{
+    'dependency-name'?: string
+    versions?: string[]
+  }>
 }
 
 type DependabotConfig = {
@@ -146,11 +150,18 @@ const requiredDependabotUpdates = [
     ecosystem: 'bun',
     directory: '/src 2',
     time: '10:00',
+    ignoredVersions: [
+      { dependency: 'eslint', versions: ['>=10'] },
+      { dependency: 'typescript', versions: ['>=6'] },
+    ],
   },
   {
     ecosystem: 'github-actions',
     directory: '/',
     time: '10:30',
+    ignoredVersions: [
+      { dependency: 'actions/checkout', versions: ['>=6'] },
+    ],
   },
 ]
 
@@ -528,6 +539,26 @@ function proveDependabotPolicy(repoRoot: string): void {
       failures.push(
         `${required.ecosystem} updates must cap open PRs at 5`,
       )
+    }
+
+    for (const ignored of required.ignoredVersions) {
+      const ignoreRule = (update.ignore ?? []).find(
+        candidate => candidate['dependency-name'] === ignored.dependency,
+      )
+      if (!ignoreRule) {
+        failures.push(
+          `${required.ecosystem} updates must ignore known-breaking ${ignored.dependency} versions`,
+        )
+        continue
+      }
+
+      for (const version of ignored.versions) {
+        if (!(ignoreRule.versions ?? []).includes(version)) {
+          failures.push(
+            `${required.ecosystem} updates must ignore ${ignored.dependency} ${version}`,
+          )
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- ignore Dependabot major lines that immediately failed CI: actions/checkout >=6, eslint >=10, and typescript >=6
- make the production proof assert those ignores remain in the Dependabot policy
- update the production-proof docs to describe deliberate major-upgrade handling

## Verification
- bun run proof:static