### PR TITLE
ci: defer ink major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     ignore:
       - dependency-name: "eslint"
         versions: [">=10"]
+      - dependency-name: "ink"
+        versions: [">=7"]
       - dependency-name: "typescript"
         versions: [">=6"]
 

--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -152,6 +152,7 @@ const requiredDependabotUpdates = [
     time: '10:00',
     ignoredVersions: [
       { dependency: 'eslint', versions: ['>=10'] },
+      { dependency: 'ink', versions: ['>=7'] },
       { dependency: 'typescript', versions: ['>=6'] },
     ],
   },


### PR DESCRIPTION
## Summary
- ignore Dependabot's Ink >=7 major line until it gets a deliberate UI migration
- make the production proof assert the ignore stays in place

## Why
- Dependabot's Ink v7 PR conflicted after other dependency updates landed
- Ink is a core CLI UI framework, so major upgrades should not be forced through as queue cleanup

## Verification
- bun run proof:static