### PR TITLE
ci: defer all ink major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       - dependency-name: "eslint"
         versions: [">=10"]
       - dependency-name: "ink"
-        versions: [">=7"]
+        versions: [">=6"]
       - dependency-name: "typescript"
         versions: [">=6"]
 

--- a/src 2/scripts/proveProductionReadiness.ts
+++ b/src 2/scripts/proveProductionReadiness.ts
@@ -152,7 +152,7 @@ const requiredDependabotUpdates = [
     time: '10:00',
     ignoredVersions: [
       { dependency: 'eslint', versions: ['>=10'] },
-      { dependency: 'ink', versions: ['>=7'] },
+      { dependency: 'ink', versions: ['>=6'] },
       { dependency: 'typescript', versions: ['>=6'] },
     ],
   },


### PR DESCRIPTION
## Summary
- change the Dependabot Ink ignore from >=7 to >=6
- make the production proof assert the full major-line deferral

## Why
- the project is on Ink 5.x, so any Ink 6+ update is a UI framework migration and should be deliberate

## Verification
- bun run proof:static