### PR TITLE
fix: export missing isReplBridgeActive from bridge/replBridgeHandle

### DIFF
--- a/src 2/bridge/replBridgeHandle.test.ts
+++ b/src 2/bridge/replBridgeHandle.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  getReplBridgeHandle,
+  isReplBridgeActive,
+  setReplBridgeHandle,
+} from './replBridgeHandle.js'
+import type { ReplBridgeHandle } from './replBridge.js'
+
+afterEach(() => {
+  setReplBridgeHandle(null)
+})
+
+function makeHandle(): ReplBridgeHandle {
+  return {
+    bridgeSessionId: 'sess_test',
+    environmentId: 'env_test',
+    sessionIngressUrl: 'https://example.invalid/ingress',
+    writeMessages: () => {},
+    writeSdkMessages: () => {},
+    sendControlRequest: () => {},
+    sendControlResponse: () => {},
+    sendControlCancelRequest: () => {},
+    sendResult: () => {},
+    teardown: async () => {},
+  }
+}
+
+describe('replBridgeHandle', () => {
+  test('isReplBridgeActive() returns false when no handle is registered', () => {
+    setReplBridgeHandle(null)
+    expect(getReplBridgeHandle()).toBeNull()
+    expect(isReplBridgeActive()).toBe(false)
+  })
+
+  test('isReplBridgeActive() returns true after a handle is registered', () => {
+    setReplBridgeHandle(makeHandle())
+    expect(getReplBridgeHandle()).not.toBeNull()
+    expect(isReplBridgeActive()).toBe(true)
+  })
+
+  test('isReplBridgeActive() flips back to false on teardown', () => {
+    setReplBridgeHandle(makeHandle())
+    expect(isReplBridgeActive()).toBe(true)
+    setReplBridgeHandle(null)
+    expect(isReplBridgeActive()).toBe(false)
+  })
+
+  // Regression for the import-graph bug discovered by `bun test --coverage`.
+  // SendMessageTool.ts and ToolSearchTool/prompt.ts had been importing
+  // isReplBridgeActive from bootstrap/state.js, which never exported it.
+  // Plain bun test tolerated the unresolved name because the symbol was
+  // never accessed at runtime in the test suite; coverage instrumentation
+  // resolved it eagerly and threw `Export named 'isReplBridgeActive' not
+  // found in module .../bootstrap/state.ts`. This test pulls both call
+  // sites' modules into the import graph so that a regression (re-pointing
+  // the import at the wrong module, or removing the export) blocks plain
+  // `bun test` too — not just coverage runs.
+  test('regression: callers can resolve isReplBridgeActive from this module', async () => {
+    const sendMessageTool = await import(
+      '../tools/SendMessageTool/SendMessageTool.js'
+    )
+    expect(sendMessageTool).toBeDefined()
+    const toolSearchPrompt = await import('../tools/ToolSearchTool/prompt.js')
+    expect(toolSearchPrompt).toBeDefined()
+  })
+})

--- a/src 2/bridge/replBridgeHandle.ts
+++ b/src 2/bridge/replBridgeHandle.ts
@@ -27,6 +27,25 @@ export function getReplBridgeHandle(): ReplBridgeHandle | null {
 }
 
 /**
+ * True when a REPL bridge handle is registered. SendMessageTool and
+ * ToolSearchTool use this to gate inter-Claude messaging on a live bridge.
+ *
+ * Historically the two callers imported this name from bootstrap/state.js
+ * but the export never existed there, so plain `bun test` silently tolerated
+ * the unresolved name. Coverage instrumentation walks the import graph
+ * eagerly and surfaced the missing export as a SyntaxError. This is the
+ * canonical home for the function — the handle lives in this module, so
+ * keeping the predicate next to it removes a cross-module surprise.
+ *
+ * Outbound-only (CCR mirror) rejection is NOT enforced here yet; the comment
+ * at the call sites describes the intent, but ReplBridgeHandle does not
+ * currently expose the mode. Wiring that through is a follow-up.
+ */
+export function isReplBridgeActive(): boolean {
+  return handle !== null
+}
+
+/**
  * Our own bridge session ID in the session_* compat format the API returns
  * in /v1/sessions responses — or undefined if bridge isn't connected.
  */

--- a/src 2/tools/SendMessageTool/SendMessageTool.ts
+++ b/src 2/tools/SendMessageTool/SendMessageTool.ts
@@ -1,7 +1,9 @@
 import { feature } from 'bun:bundle'
 import { z } from 'zod/v4'
-import { isReplBridgeActive } from '../../bootstrap/state.js'
-import { getReplBridgeHandle } from '../../bridge/replBridgeHandle.js'
+import {
+  getReplBridgeHandle,
+  isReplBridgeActive,
+} from '../../bridge/replBridgeHandle.js'
 import type { Tool, ToolUseContext } from '../../Tool.js'
 import { buildTool, type ToolDef } from '../../Tool.js'
 import { findTeammateTaskByAgentId } from '../../tasks/InProcessTeammateTask/InProcessTeammateTask.js'

--- a/src 2/tools/ToolSearchTool/prompt.ts
+++ b/src 2/tools/ToolSearchTool/prompt.ts
@@ -1,5 +1,5 @@
 import { feature } from 'bun:bundle'
-import { isReplBridgeActive } from '../../bootstrap/state.js'
+import { isReplBridgeActive } from '../../bridge/replBridgeHandle.js'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../../services/analytics/growthbook.js'
 import type { Tool } from '../../Tool.js'
 import { AGENT_TOOL_NAME } from '../AgentTool/constants.js'


### PR DESCRIPTION
## Summary
- Adds `isReplBridgeActive()` to `bridge/replBridgeHandle.ts` (returns `handle !== null`); the function was imported from `bootstrap/state.js` but never exported there
- Re-points two callers (`SendMessageTool.ts`, `ToolSearchTool/prompt.ts`) at the new canonical location
- Adds `bridge/replBridgeHandle.test.ts` with 4 tests, including a regression that dynamically imports both former-broken-callers' modules

## Why this matters
Plain `bun test` tolerated the unresolved import (the symbol was never accessed at runtime by the test suite). `bun test --coverage` walks the import graph eagerly and surfaced the missing export as a `SyntaxError`, causing 11 test files to error out and forcing the coverage gate in companion PR `gagan114662/read-attachment` into `continue-on-error: true`.

## Verification

Before:
```
bun test --coverage  →  11 fails (SyntaxError: Export named 'isReplBridgeActive' not found)
```

After:
```
bun test --coverage  →  415 pass / 0 fail
grep -cE "SyntaxError|Export named" /tmp/cov-{stdout,stderr}.log  →  0  0
```

## Scope note
The CCR-mirror "outbound-only" rejection that the call-site comments describe is **not** wired here. `ReplBridgeHandle` does not currently expose that mode, and adding it would smuggle a behavior change into a bug fix. Tracked as a follow-up.

## Test plan
- [ ] `cd "src 2" && bun test ./bridge/replBridgeHandle.test.ts` → 4 pass
- [ ] `cd "src 2" && bun test --coverage 2>&1 | tail -5` → `<N> pass / 0 fail`
- [ ] After merge, on the companion gates branch: drop `continue-on-error: true` from coverage step in `.github/workflows/ci.yml` and the matching note in `docs/CI_CONFIDENCE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)